### PR TITLE
Start services for deb/ubuntu

### DIFF
--- a/install_scripts/setup_frappe.sh
+++ b/install_scripts/setup_frappe.sh
@@ -291,8 +291,8 @@ start_services_centos7() {
 start_services_debian_ubuntu() {
 	run_cmd service nginx start
 	run_cmd service mysql start
-	run_cmd service redis start
-	run_cmd service supervisord start
+	run_cmd service redis-server start
+	run_cmd service supervisor start
 	run_cmd service memcached start
 }
 


### PR DESCRIPTION
Environment: Ubuntu 14.04 inside of docker (Docker version 1.3.1, build 4e9bbfa, on LinuxMint).
O.S.: Debian or Ubuntu.
- Was added a package to be installed as prerequisite of wkhtmltopdf.
- As docker environment don't automatically initialize all of its services, was necessary start all of then before install bench, as it was made for CentOs.
  ![result_after_installed_bench](https://cloud.githubusercontent.com/assets/2197380/5048090/2b22bbf2-6c02-11e4-8a8d-612214a0ebda.png)
