### PR TITLE
Fix on install_wkhtmltopdf_centos

### DIFF
--- a/install_scripts/setup_frappe.sh
+++ b/install_scripts/setup_frappe.sh
@@ -194,7 +194,7 @@ install_packages() {
 
 install_wkhtmltopdf_centos () {
 
-	if [[ $OS == "centos" && $OS_VER == "7" && $T_ARCH="i386" ]]; then
+	if [[ $OS == "centos" && $OS_VER == "7" && $T_ARCH == "i386" ]]; then
 		echo "Cannot install wkhtmltodpdf. Skipping..."
 		return 0
 	fi


### PR DESCRIPTION
Typo error on if [[ $OS == "centos" && $OS_VER == "7" && $T_ARCH="i386" ]]; then
