### PR TITLE
py_modules=['bench'] does not install the bench/ directory to lib/site-packages/bench/

### DIFF
--- a/bench/utils.py
+++ b/bench/utils.py
@@ -7,6 +7,7 @@ import logging
 import itertools
 import requests
 import json
+import platform
 import multiprocessing
 from distutils.spawn import find_executable
 import pwd, grp
@@ -167,7 +168,10 @@ def setup_backups(bench='.'):
 def add_to_crontab(line):
 	current_crontab = read_crontab()
 	if not line in current_crontab:
-		s = subprocess.Popen("crontab", stdin=subprocess.PIPE)
+		cmd = ["crontab"]
+		if platform.system() == 'FreeBSD':
+			cmd = ["crontab", "-"]
+		s = subprocess.Popen(cmd, stdin=subprocess.PIPE)
 		s.stdin.write(current_crontab)
 		s.stdin.write(line + '\n')
 		s.stdin.close()

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 setup(
 	name='bench',
 	version='0.1',
-	py_modules=find_packages(),
+	packages=find_packages(),
 	include_package_data=True,
 	url='https://github.com/frappe/bench',
 	author='Web Notes Technologies Pvt. Ltd.',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
 	name='bench',
-	version='0.1',
+	version='0.92',
 	packages=find_packages(),
 	include_package_data=True,
 	url='https://github.com/frappe/bench',


### PR DESCRIPTION
```
# pkg info | egrep 'python27|setuptools'
py27-setuptools27-5.5.1_1      Python packages installer
python27-2.7.9_1               Interpreted object-oriented programming language
```
py_modules=['bench']:
```
# make -dl install
(cd /usr/ports/www/py-bench/work/bench-7a9dc9a; /usr/bin/env XDG_DATA_HOME=/usr/ports/www/py-bench/work  XDG_CONFIG_HOME=/usr/ports/www/py-bench/work  HOME=/usr/ports/www/py-bench/work NO_PIE=yes SHELL=/bin/sh NO_LINT=YES LDSHARED="cc -shared" PYTHONDONTWRITEBYTECODE= PYTHONOPTIMIZE= PREFIX=/usr/local  LOCALBASE=/usr/local  LIBDIR="/usr/lib"  CC="cc" CFLAGS="-O2 -pipe  -fstack-protector -fno-strict-aliasing"  CPP="cpp" CPPFLAGS=""  LDFLAGS=" -fstack-protector" LIBS=""  CXX="c++" CXXFLAGS="-O2 -pipe -fstack-protector -fno-strict-aliasing "  MANPREFIX="/usr/local" BSD_INSTALL_PROGRAM="install  -s -m 555"  BSD_INSTALL_LIB="install  -s -m 444"  BSD_INSTALL_SCRIPT="install  -m 555"  BSD_INSTALL_DATA="install  -m 0644"  BSD_INSTALL_MAN="install  -m 444" /usr/local/bin/python2.7 -c  "import sys; import setuptools;  __file__='setup.py'; sys.argv[0]='setup.py';  exec(compile(open(__file__, 'rb').read().replace(b'\\r\\n', b'\\n'), __file__, 'exec'))" install --record /usr/ports/www/py-bench/work/.PLIST.pymodtmp  -c -O1 --prefix=/usr/local --single-version-externally-managed --root=/usr/ports/www/py-bench/work/stage)
running install
running build
running build_py
file bench.py (for module bench) not found
file bench.py (for module bench) not found
running egg_info
writing requirements to bench.egg-info/requires.txt
writing bench.egg-info/PKG-INFO
writing top-level names to bench.egg-info/top_level.txt
writing dependency_links to bench.egg-info/dependency_links.txt
writing entry points to bench.egg-info/entry_points.txt
file bench.py (for module bench) not found
reading manifest file 'bench.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'bench.egg-info/SOURCES.txt'
running install_lib
warning: install_lib: 'build/lib' does not exist -- no Python modules to install
running install_egg_info
Copying bench.egg-info to /usr/ports/www/py-bench/work/stage/usr/local/lib/python2.7/site-packages/bench-0.1-py2.7.egg-info
```

```
# find /usr/local/lib/python2.7/site-packages/ | grep -i bench
/usr/local/lib/python2.7/site-packages/bench-0.1-py2.7.egg-info
/usr/local/lib/python2.7/site-packages/bench-0.1-py2.7.egg-info/PKG-INFO
/usr/local/lib/python2.7/site-packages/bench-0.1-py2.7.egg-info/SOURCES.txt
/usr/local/lib/python2.7/site-packages/bench-0.1-py2.7.egg-info/dependency_links.txt
/usr/local/lib/python2.7/site-packages/bench-0.1-py2.7.egg-info/entry_points.txt
/usr/local/lib/python2.7/site-packages/bench-0.1-py2.7.egg-info/requires.txt
/usr/local/lib/python2.7/site-packages/bench-0.1-py2.7.egg-info/top_level.txt
```

packages=['bench']:

```
# make -dl install
(cd /usr/ports/www/py-bench/work/bench-7a9dc9a; /usr/bin/env XDG_DATA_HOME=/usr/ports/www/py-bench/work  XDG_CONFIG_HOME=/usr/ports/www/py-bench/work  HOME=/usr/ports/www/py-bench/work NO_PIE=yes SHELL=/bin/sh NO_LINT=YES LDSHARED="cc -shared" PYTHONDONTWRITEBYTECODE= PYTHONOPTIMIZE= PREFIX=/usr/local  LOCALBASE=/usr/local  LIBDIR="/usr/lib"  CC="cc" CFLAGS="-O2 -pipe  -fstack-protector -fno-strict-aliasing"  CPP="cpp" CPPFLAGS=""  LDFLAGS=" -fstack-protector" LIBS=""  CXX="c++" CXXFLAGS="-O2 -pipe -fstack-protector -fno-strict-aliasing "  MANPREFIX="/usr/local" BSD_INSTALL_PROGRAM="install  -s -m 555"  BSD_INSTALL_LIB="install  -s -m 444"  BSD_INSTALL_SCRIPT="install  -m 555"  BSD_INSTALL_DATA="install  -m 0644"  BSD_INSTALL_MAN="install  -m 444" /usr/local/bin/python2.7 -c  "import sys; import setuptools;  __file__='setup.py'; sys.argv[0]='setup.py';  exec(compile(open(__file__, 'rb').read().replace(b'\\r\\n', b'\\n'), __file__, 'exec'))" install --record /usr/ports/www/py-bench/work/.PLIST.pymodtmp  -c -O1 --prefix=/usr/local --single-version-externally-managed --root=/usr/ports/www/py-bench/work/stage)
running install
running build
running build_py
running egg_info
writing requirements to bench.egg-info/requires.txt
writing bench.egg-info/PKG-INFO
writing top-level names to bench.egg-info/top_level.txt
writing dependency_links to bench.egg-info/dependency_links.txt
writing entry points to bench.egg-info/entry_points.txt
reading manifest file 'bench.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'bench.egg-info/SOURCES.txt'
running install_lib
creating /usr/ports/www/py-bench/work/stage/usr/local/lib/python2.7
creating /usr/ports/www/py-bench/work/stage/usr/local/lib/python2.7/site-packages
creating /usr/ports/www/py-bench/work/stage/usr/local/lib/python2.7/site-packages/bench
copying build/lib/bench/__init__.py -> /usr/ports/www/py-bench/work/stage/usr/local/lib/python2.7/site-packages/bench
copying build/lib/bench/app.py -> /usr/ports/www/py-bench/work/stage/usr/local/lib/python2.7/site-packages/bench
copying build/lib/bench/cli.py -> /usr/ports/www/py-bench/work/stage/usr/local/lib/python2.7/site-packages/bench
copying build/lib/bench/config.py -> /usr/ports/www/py-bench/work/stage/usr/local/lib/python2.7/site-packages/bench
copying build/lib/bench/migrate3to4.py -> /usr/ports/www/py-bench/work/stage/usr/local/lib/python2.7/site-packages/bench
copying build/lib/bench/migrate_to_v5.py -> /usr/ports/www/py-bench/work/stage/usr/local/lib/python2.7/site-packages/bench
copying build/lib/bench/production_setup.py -> /usr/ports/www/py-bench/work/stage/usr/local/lib/python2.7/site-packages/bench
copying build/lib/bench/release.py -> /usr/ports/www/py-bench/work/stage/usr/local/lib/python2.7/site-packages/bench
copying build/lib/bench/utils.py -> /usr/ports/www/py-bench/work/stage/usr/local/lib/python2.7/site-packages/bench
creating /usr/ports/www/py-bench/work/stage/usr/local/lib/python2.7/site-packages/bench/templates
copying build/lib/bench/templates/nginx.conf -> /usr/ports/www/py-bench/work/stage/usr/local/lib/python2.7/site-packages/bench/templates
copying build/lib/bench/templates/nginx_default.conf -> /usr/ports/www/py-bench/work/stage/usr/local/lib/python2.7/site-packages/bench/templates
copying build/lib/bench/templates/redis.conf -> /usr/ports/www/py-bench/work/stage/usr/local/lib/python2.7/site-packages/bench/templates
copying build/lib/bench/templates/supervisor.conf -> /usr/ports/www/py-bench/work/stage/usr/local/lib/python2.7/site-packages/bench/templates
byte-compiling /usr/ports/www/py-bench/work/stage/usr/local/lib/python2.7/site-packages/bench/__init__.py to __init__.pyc
byte-compiling /usr/ports/www/py-bench/work/stage/usr/local/lib/python2.7/site-packages/bench/app.py to app.pyc
byte-compiling /usr/ports/www/py-bench/work/stage/usr/local/lib/python2.7/site-packages/bench/cli.py to cli.pyc
byte-compiling /usr/ports/www/py-bench/work/stage/usr/local/lib/python2.7/site-packages/bench/config.py to config.pyc
byte-compiling /usr/ports/www/py-bench/work/stage/usr/local/lib/python2.7/site-packages/bench/migrate3to4.py to migrate3to4.pyc
byte-compiling /usr/ports/www/py-bench/work/stage/usr/local/lib/python2.7/site-packages/bench/migrate_to_v5.py to migrate_to_v5.pyc
byte-compiling /usr/ports/www/py-bench/work/stage/usr/local/lib/python2.7/site-packages/bench/production_setup.py to production_setup.pyc
byte-compiling /usr/ports/www/py-bench/work/stage/usr/local/lib/python2.7/site-packages/bench/release.py to release.pyc
byte-compiling /usr/ports/www/py-bench/work/stage/usr/local/lib/python2.7/site-packages/bench/utils.py to utils.pyc
writing byte-compilation script '/tmp/tmplqgTZX.py'
/usr/local/bin/python2.7 -O /tmp/tmplqgTZX.py
removing /tmp/tmplqgTZX.py
running install_egg_info
Copying bench.egg-info to /usr/ports/www/py-bench/work/stage/usr/local/lib/python2.7/site-packages/bench-0.1-py2.7.egg-info
running install_scripts
Installing bench script to /usr/ports/www/py-bench/work/stage/usr/local/bin
writing list of installed files to '/usr/ports/www/py-bench/work/.PLIST.pymodtmp'
```
```
# find /usr/local/lib/python2.7/site-packages/ | grep -i bench
/usr/local/lib/python2.7/site-packages/bench-0.1-py2.7.egg-info
/usr/local/lib/python2.7/site-packages/bench-0.1-py2.7.egg-info/PKG-INFO
/usr/local/lib/python2.7/site-packages/bench-0.1-py2.7.egg-info/SOURCES.txt
/usr/local/lib/python2.7/site-packages/bench-0.1-py2.7.egg-info/dependency_links.txt
/usr/local/lib/python2.7/site-packages/bench-0.1-py2.7.egg-info/entry_points.txt
/usr/local/lib/python2.7/site-packages/bench-0.1-py2.7.egg-info/requires.txt
/usr/local/lib/python2.7/site-packages/bench-0.1-py2.7.egg-info/top_level.txt
/usr/local/lib/python2.7/site-packages/bench
/usr/local/lib/python2.7/site-packages/bench/__init__.py
/usr/local/lib/python2.7/site-packages/bench/__init__.pyc
/usr/local/lib/python2.7/site-packages/bench/__init__.pyo
/usr/local/lib/python2.7/site-packages/bench/app.py
/usr/local/lib/python2.7/site-packages/bench/app.pyc
/usr/local/lib/python2.7/site-packages/bench/app.pyo
/usr/local/lib/python2.7/site-packages/bench/cli.py
/usr/local/lib/python2.7/site-packages/bench/cli.pyc
/usr/local/lib/python2.7/site-packages/bench/cli.pyo
/usr/local/lib/python2.7/site-packages/bench/config.py
/usr/local/lib/python2.7/site-packages/bench/config.pyc
/usr/local/lib/python2.7/site-packages/bench/config.pyo
/usr/local/lib/python2.7/site-packages/bench/migrate3to4.py
/usr/local/lib/python2.7/site-packages/bench/migrate3to4.pyc
/usr/local/lib/python2.7/site-packages/bench/migrate3to4.pyo
/usr/local/lib/python2.7/site-packages/bench/migrate_to_v5.py
/usr/local/lib/python2.7/site-packages/bench/migrate_to_v5.pyc
/usr/local/lib/python2.7/site-packages/bench/migrate_to_v5.pyo
/usr/local/lib/python2.7/site-packages/bench/production_setup.py
/usr/local/lib/python2.7/site-packages/bench/production_setup.pyc
/usr/local/lib/python2.7/site-packages/bench/production_setup.pyo
/usr/local/lib/python2.7/site-packages/bench/release.py
/usr/local/lib/python2.7/site-packages/bench/release.pyc
/usr/local/lib/python2.7/site-packages/bench/release.pyo
/usr/local/lib/python2.7/site-packages/bench/templates
/usr/local/lib/python2.7/site-packages/bench/templates/nginx.conf
/usr/local/lib/python2.7/site-packages/bench/templates/nginx_default.conf
/usr/local/lib/python2.7/site-packages/bench/templates/redis.conf
/usr/local/lib/python2.7/site-packages/bench/templates/supervisor.conf
/usr/local/lib/python2.7/site-packages/bench/utils.py
/usr/local/lib/python2.7/site-packages/bench/utils.pyc
/usr/local/lib/python2.7/site-packages/bench/utils.py
```