### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,10 @@ Manual Install
 
 Install pre-requisites,
 
-* Python 2.7
-* MariaDB
-* Redis
+* [Python 2.7](https://www.python.org/download/releases/2.7/)
+* [MariaDB](https://mariadb.org/)
+* [Redis](http://redis.io/topics/quickstart)
 * [wkhtmltopdf](http://wkhtmltopdf.org/downloads.html) (optional, required for pdf generation)
-* Memcached
 
 For installing MaraiDB on OSX, use:
 ```


### PR DESCRIPTION
As far as I understand Memcached is not necessary anymore.
Added links to the dependencies, maybe OSX Setup should be explained in more detail with Homebrew for Python and MariaDB.