### PR TITLE
Automate swap partition setup for centos / ubuntu / debian servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Supported for CentOS 6, CentOS 7, Debian 7 and Ubuntu 12.04+
 Open your Terminal and enter:
 
 ```
-wget https://raw.githubusercontent.com/frappe/bench/master/install_scripts/setup_frappe.sh
+rm -fr setup_frappe.sh; wget https://raw.githubusercontent.com/frappe/bench/master/install_scripts/setup_frappe.sh
 sudo bash setup_frappe.sh --setup-production
 ```
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ This script should install the pre-requisites, install bench and setup an ERPNex
 
 If you want to develop ERPNext or any Frappe App, you can omit the "--setup-production" part from the command.
 
+For advanced users, `setup_frappe.sh` script offers following options:
+```
+sudo bash setup_frappe.sh --setup-swap --setup-production
+```
+This will check if your system does require swap partition, if required it will create new one, otherwise it will skip the swap setup part and continue with rest of the setup instructions.
+
+
 
 Manual Install
 --------------
@@ -45,7 +52,7 @@ mysql.server start
 mysqladmin -uroot password ROOTPASSWORD
 ```
 
-	
+
 Install bench as a *non root* user,
 
 		git clone https://github.com/frappe/bench bench-repo
@@ -100,7 +107,7 @@ Basic Usage
 		bench start
 
 	To login to Frappe / ERPNext, open your browser and go to `localhost:8000`
-	
+
 	The default user name is "Administrator" and password is what you set when you created the new site.
 
 
@@ -205,7 +212,7 @@ then copy/link this file to the supervisor config directory and reload it for it
 take effect.
 
 eg,
-	
+
 ```
 bench setup supervisor
 sudo ln -s `pwd`/config/supervisor.conf /etc/supervisor/conf.d/frappe.conf
@@ -213,7 +220,7 @@ sudo ln -s `pwd`/config/supervisor.conf /etc/supervisor/conf.d/frappe.conf
 
 Note: For CentOS 7, the extension should be `ini`, thus the command becomes
 ```
-bench setup supervisor 
+bench setup supervisor
 sudo ln -s `pwd`/config/supervisor.conf /etc/supervisor/conf.d/frappe.ini #for CentOS 7 only
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Supported for CentOS 6, CentOS 7, Debian 7 and Ubuntu 12.04+
 Open your Terminal and enter:
 
 ```
-rm -fr setup_frappe.sh; wget https://raw.githubusercontent.com/frappe/bench/master/install_scripts/setup_frappe.sh
+wget https://raw.githubusercontent.com/frappe/bench/master/install_scripts/setup_frappe.sh
 sudo bash setup_frappe.sh --setup-production
 ```
 

--- a/install_scripts/setup_frappe.sh
+++ b/install_scripts/setup_frappe.sh
@@ -414,9 +414,6 @@ install_packages() {
 			run_cmd bash -c "curl -sL https://deb.nodesource.com/setup_0.12 | bash -"
 		fi
 		run_cmd sudo apt-get update
-=======
-		run_cmd sudo apt-get update
->>>>>>> parent of 394ca9b... Helps fix issues with outdated system packages
 		run_cmd sudo apt-get install -y python-dev python-setuptools build-essential python-mysqldb git ntp vim screen htop mariadb-server mariadb-common libmariadbclient-dev  libxslt1.1 libxslt1-dev redis-server libssl-dev libcrypto++-dev postfix nginx supervisor python-pip fontconfig libxrender1 libxext6 xfonts-75dpi xfonts-base nodejs npm
 
 		echo "Installing wkhtmltopdf"

--- a/install_scripts/setup_frappe.sh
+++ b/install_scripts/setup_frappe.sh
@@ -145,47 +145,47 @@ setup_swap() {
       then
         if [ "$swap_count" -ge 8000 ]
         then
-          echo "Your swap is already enough. Do not need to add swap. Returing to frappe installation.\n"
+          echo "Your swap is already enough. Do not need to add swap. Returing to frappe installation."
           run_cmd sudo rm -rf $LOCKfile
           return 1
         elif [ "$swap_count" -ne 0 ]
         then
-          echo "Your swap is not enough, need to add swap.\n"
+          echo "Your swap is not enough, need to add swap."
           remove_old_swap
           create_swap 8192
         else
-          echo "Your swap is not enough, need to add swap.\n"
+          echo "Your swap is not enough, need to add swap."
           create_swap 8192
         fi
       elif [ "$mem_count" -ge 3900 ] && [ "$mem_count" -lt 15000 ]
       then
         if [ "$swap_count" -ge 3900 ]
         then
-          echo "Your swap is already enough. Do not need to add swap. Returing to frappe installation.\n"
+          echo "Your swap is already enough. Do not need to add swap. Returing to frappe installation."
           run_cmd sudo rm -rf $LOCKfile
           return 1
         elif [ "$swap_count" -ne 0 ]
         then
-          echo "Your swap is not enough, need to add swap.\n"
+          echo "Your swap is not enough, need to add swap."
           remove_old_swap
           create_swap 4096
         else
-          echo "Your swap is not enough, need to add swap.\n"
+          echo "Your swap is not enough, need to add swap."
           create_swap 4096
         fi
       else
         if [ "$swap_count" -ge 2000 ]
         then
-          echo "Your swap is already enough. Do not need to add swap. Returing to frappe installation.\n"
+          echo "Your swap is already enough. Do not need to add swap. Returing to frappe installation."
           run_cmd sudo rm -rf $LOCKfile
           return 1
         elif [ "$swap_count" -ne 0 ]
         then
-          echo "Your swap is not enough, need to add swap.\n"
+          echo "Your swap is not enough, need to add swap."
           remove_old_swap
           create_swap 2048
         else
-          echo "Your swap is not enough, need to add swap.\n"
+          echo "Your swap is not enough, need to add swap."
           create_swap 2048
         fi
       fi
@@ -196,7 +196,7 @@ setup_swap() {
       root_disk_size=$(df -m|grep -w "/"|awk '{print $4}')
       if [ "$1" -gt "$((root_disk_size-1024))" ]
       then
-        echo "The root disk partition has no space for $1M swap file. Returing to frappe installation.\n"
+        echo "The root disk partition has no space for $1M swap file. Returing to frappe installation."
         run_cmd sudo rm -rf $LOCKfile
         return 1
       fi
@@ -211,9 +211,9 @@ setup_swap() {
         run_cmd sudo mkswap $swapfile
         run_cmd sudo swapon $swapfile
         run_cmd sudo swapon -s
-        echo "Step 3. Add swap partition successful.\n"
+        echo "Step 3. Add swap partition successful."
       else
-        echo "The /swapfile already exists. Returing to frappe installation.\n"
+        echo "The /swapfile already exists. Returing to frappe installation."
         run_cmd sudo rm -rf $LOCKfile
         return 1
       fi
@@ -242,11 +242,11 @@ setup_swap() {
     {
       if ! grep $swapfile $fstab >/dev/null 2>&1
       then
-        echo "Begin to modify $fstab.\n"
+        echo "Begin to modify $fstab."
         echo "$swapfile	 swap	 swap defaults 0 0" >>$fstab
 				adjust_swappiness
       else
-        echo "/etc/fstab is already configured. Returing to frappe installation.\n"
+        echo "/etc/fstab is already configured. Returing to frappe installation."
         run_cmd sudo rm -rf $LOCKfile
         return 1
       fi
@@ -256,11 +256,11 @@ setup_swap() {
     {
       if ! grep $swapfile $fstab >/dev/null 2>&1
       then
-        echo "Begin to modify $fstab.\n"
+        echo "Begin to modify $fstab."
         echo "$swapfile	 none	 swap sw 0 0" >>$fstab
 				adjust_swappiness
       else
-        echo "/etc/fstab is already configured. Returing to frappe installation.\n"
+        echo "/etc/fstab is already configured. Returing to frappe installation."
         run_cmd sudo rm -rf $LOCKfile
         return 1
       fi
@@ -271,17 +271,17 @@ setup_swap() {
     LOCKfile=/tmp/.setup-swap-lock-frappe
     if [ -f "$LOCKfile" ]
     then
-      echo "The script is already exist, please delete file from $LOCKfile next time to run this script.\n"
+      echo "The script is already exist, please delete file from $LOCKfile next time to run this script."
       exit
     else
-      echo "Step 1. No lock file, begin to create lock file and continue.\n"
+      echo "Step 1. No lock file, begin to create lock file and continue."
       run_cmd sudo touch $LOCKfile
     fi
 
     #check user
     if [ $(id -u) != "0" ]
     then
-      echo "Error: You must be root to run this script, please use root to setup the swap partition.\n"
+      echo "Error: You must be root to run this script, please use root to setup the swap partition."
       run_cmd sudo rm -rf $LOCKfile
       return 1
     fi
@@ -289,21 +289,21 @@ setup_swap() {
     os_release=$(check_os_release)
     if [ "X$os_release" == "X" ]
     then
-      echo "The OS does not identify, So the swap setup is skipped.\n"
+      echo "The OS does not identify, So the swap setup is skipped."
       run_cmd sudo rm -rf $LOCKfile
       return 0
     else
-      echo "Step 2. Check this OS type.\n"
-      echo "This OS is $os_release.\n"
+      echo "Step 2. Check this OS type."
+      echo "This OS is $os_release."
     fi
 
     swapfile=/swapfile
     fstab=/etc/fstab
 
-    echo "Step 3. Check the memory and swap.\n"
+    echo "Step 3. Check the memory and swap."
     check_memory_and_swap
 
-    echo "Step 4. Begin to modify $fstab.\n"
+    echo "Step 4. Begin to modify $fstab."
     case "$os_release" in
     redhat|centos)
       config_rhel_fstab
@@ -314,7 +314,7 @@ setup_swap() {
     esac
 
     free -m
-    echo "All the swap setup related operations were completed. Returing to frappe installation.\n"
+    echo "All the swap setup related operations were completed. Returing to frappe installation."
     run_cmd sudo rm -rf $LOCKfile
 }
 

--- a/install_scripts/setup_frappe.sh
+++ b/install_scripts/setup_frappe.sh
@@ -193,7 +193,7 @@ setup_swap() {
 
     create_swap()
     {
-      root_disk_size=$(df -m|grep -w "/"|awk '{print $4}')
+      root_disk_size=$(df -m|grep -w "/"|awk '{print $4}'|head -1)
       if [ "$1" -gt "$((root_disk_size-1024))" ]
       then
         echo "The root disk partition has no space for $1M swap file. Returing to frappe installation."

--- a/install_scripts/setup_frappe.sh
+++ b/install_scripts/setup_frappe.sh
@@ -410,7 +410,7 @@ install_packages() {
 	elif [ $OS == "debian" ] || [ $OS == "Ubuntu" ]; then
 		export DEBIAN_FRONTEND=noninteractive
 		setup_debconf
-		run_cmd sudo apt-get update
+		run_cmd sudo apt-get update && apt-get upgrade -y
 		run_cmd sudo apt-get install -y python-dev python-setuptools build-essential python-mysqldb git ntp vim screen htop mariadb-server mariadb-common libmariadbclient-dev  libxslt1.1 libxslt1-dev redis-server libssl-dev libcrypto++-dev postfix nginx supervisor python-pip fontconfig libxrender1 libxext6 xfonts-75dpi xfonts-base nodejs npm
 
 		echo "Installing wkhtmltopdf"

--- a/install_scripts/setup_frappe.sh
+++ b/install_scripts/setup_frappe.sh
@@ -211,7 +211,7 @@ setup_swap() {
         run_cmd sudo mkswap $swapfile
         run_cmd sudo swapon $swapfile
         run_cmd sudo swapon -s
-        echo "Step 3. Add swap partition successful."
+        echo "Step 3. The swap partition setup successful."
       else
         echo "The /swapfile already exists. Returing to frappe installation."
         run_cmd sudo rm -rf $LOCKfile
@@ -225,10 +225,10 @@ setup_swap() {
       run_cmd sudo swapoff $old_swap_file
       run_cmd sudo cp -f $fstab ${fstab}_bak
       run_cmd sudo sed -i '/swap/d' $fstab
-			old_swapiness_setting=$(grep swap $fstab|grep -v "#"|awk '{print $1}')
     }
+
 		adjust_swappiness() {
-			echo "Begin to adjust swappiness & vfs_cache_pressure"
+			echo "Step 5. Begin to adjust swappiness & vfs_cache_pressure"
 			run_cmd sudo sed '/vm\.swappiness/d' -ibak /etc/sysctl.conf
 			echo "vm.swappiness = 10" >> /etc/sysctl.conf
 			run_cmd sudo sysctl vm.swappiness=10

--- a/install_scripts/setup_frappe.sh
+++ b/install_scripts/setup_frappe.sh
@@ -129,8 +129,7 @@ setup_swap() {
 		if [ "$1" -gt "$((root_disk_size-1024))" ]
 			then
 			echo "The root disk partition has no space for $1M swap file. Returing to frappe installation."
-
-			return 1
+			return 0
 		fi
 		if [ ! -e $swapfile ]
 			then
@@ -138,12 +137,10 @@ setup_swap() {
 			run_cmd sudo chmod 600 $swapfile
 			run_cmd sudo mkswap $swapfile
 			run_cmd sudo swapon $swapfile
-			run_cmd sudo swapon -s
 			echo "The swap partition setup successful."
 		else
 			echo "The /swapfile already exists. Returing to frappe installation."
-
-			return 1
+			return 0
 		fi
 	}
 
@@ -173,8 +170,7 @@ setup_swap() {
 			adjust_swappiness
 		else
 			echo "/etc/fstab is already configured. Returing to frappe installation."
-
-			return 1
+			return 0
 		fi
 	}
 
@@ -186,8 +182,7 @@ setup_swap() {
 			adjust_swappiness
 		else
 			echo "/etc/fstab is already configured. Returing to frappe installation."
-
-			return 1
+			return 0
 		fi
 	}
 
@@ -199,7 +194,6 @@ echo "Check the memory and swap."
 check_memory_and_swap
 
 echo "Making swap partition persistant by adding it to $fstab."
-
 case "$OS" in
 	centos)
 	config_centos_fstab
@@ -209,7 +203,7 @@ case "$OS" in
 	;;
 	*)
 	echo "Unable to identify OS, ignoring swap setup instructions."
-	return 1
+	return 0
 	;;
 esac
 # free -m

--- a/install_scripts/setup_frappe.sh
+++ b/install_scripts/setup_frappe.sh
@@ -108,53 +108,19 @@ setup_swap() {
 	check_memory_and_swap() {
 		mem_count=$(free -m|grep Mem|awk '{print $2}')
 		swap_count=$(free -m|grep Swap|awk '{print $2}')
-		if [ "$mem_count" -ge 15000 ]  && [ "$mem_count" -le 32768 ]
+		if  [ "$mem_count" -le 2048 ]
 			then
-			if [ "$swap_count" -ge 8000 ]
+			if [ "$swap_count" -ne 0 ]
 				then
-				echo "Your swap is already enough. Do not need to add swap. Returing to frappe installation."
-
-				return 1
-			elif [ "$swap_count" -ne 0 ]
-				then
-				echo "Your swap is not enough, creating swap partition."
 				remove_old_swap
-				create_swap 8192
-			else
-				echo "Your swap is not enough, creating swap partition."
-				create_swap 8192
 			fi
-		elif [ "$mem_count" -ge 3900 ] && [ "$mem_count" -lt 15000 ]
-			then
-			if [ "$swap_count" -ge 3900 ]
-				then
-				echo "Your swap is already enough. Do not need to add swap. Returing to frappe installation."
-
-				return 1
-			elif [ "$swap_count" -ne 0 ]
-				then
-				echo "Your swap is not enough, creating swap partition."
-				remove_old_swap
-				create_swap 4096
-			else
-				echo "Your swap is not enough, creating swap partition."
-				create_swap 4096
-			fi
+				create_swap $((mem_count*3))
 		else
-			if [ "$swap_count" -ge 2000 ]
+			if [ "$swap_count" -ne 0 ]
 				then
-				echo "Your swap is already enough. Do not need to add swap. Returing to frappe installation."
-
-				return 1
-			elif [ "$swap_count" -ne 0 ]
-				then
-				echo "Your swap is not enough, creating swap partition."
 				remove_old_swap
-				create_swap 2048
-			else
-				echo "Your swap is not enough, creating swap partition."
-				create_swap 2048
 			fi
+			create_swap $((mem_count+2048))
 		fi
 	}
 

--- a/install_scripts/setup_frappe.sh
+++ b/install_scripts/setup_frappe.sh
@@ -107,35 +107,34 @@ run_cmd() {
 setup_swap() {
     check_os_release()
     {
-      # while true
-      # do
-      #   if cat /proc/version | grep redhat >/dev/null 2>&1
-      #   then
-      #     os_release=redhat
-      #     echo "$os_release"
-      #     break
-      #   fi
-      #   if cat /proc/version | grep centos >/dev/null 2>&1
-      #   then
-      #     os_release=centos
-      #     echo "$os_release"
-      #     break
-      #   fi
-      #   if cat /proc/version | grep ubuntu >/dev/null 2>&1
-      #   then
-      #     os_release=ubuntu
-      #     echo "$os_release"
-      #     break
-      #   fi
-      #   if cat /proc/version | grep -i debian >/dev/null 2>&1
-      #   then
-      #     os_release=debian
-      #     echo "$os_release"
-      #     break
-      #   fi
-      #   break
-      #   done
-			os_release=$OS
+      while true
+      do
+        if cat /proc/version | grep redhat >/dev/null 2>&1
+        then
+          os_release=redhat
+          echo "$os_release"
+          break
+        fi
+        if cat /proc/version | grep centos >/dev/null 2>&1
+        then
+          os_release=centos
+          echo "$os_release"
+          break
+        fi
+        if cat /proc/version | grep ubuntu >/dev/null 2>&1
+        then
+          os_release=ubuntu
+          echo "$os_release"
+          break
+        fi
+        if cat /proc/version | grep -i debian >/dev/null 2>&1
+        then
+          os_release=debian
+          echo "$os_release"
+          break
+        fi
+        break
+      done
     }
 
     check_memory_and_swap()

--- a/install_scripts/setup_frappe.sh
+++ b/install_scripts/setup_frappe.sh
@@ -117,11 +117,11 @@ setup_swap() {
 				return 1
 			elif [ "$swap_count" -ne 0 ]
 				then
-				echo "Your swap is not enough, need to add swap."
+				echo "Your swap is not enough, creating swap partition."
 				remove_old_swap
 				create_swap 8192
 			else
-				echo "Your swap is not enough, need to add swap."
+				echo "Your swap is not enough, creating swap partition."
 				create_swap 8192
 			fi
 		elif [ "$mem_count" -ge 3900 ] && [ "$mem_count" -lt 15000 ]
@@ -133,11 +133,11 @@ setup_swap() {
 				return 1
 			elif [ "$swap_count" -ne 0 ]
 				then
-				echo "Your swap is not enough, need to add swap."
+				echo "Your swap is not enough, creating swap partition."
 				remove_old_swap
 				create_swap 4096
 			else
-				echo "Your swap is not enough, need to add swap."
+				echo "Your swap is not enough, creating swap partition."
 				create_swap 4096
 			fi
 		else
@@ -148,11 +148,11 @@ setup_swap() {
 				return 1
 			elif [ "$swap_count" -ne 0 ]
 				then
-				echo "Your swap is not enough, need to add swap."
+				echo "Your swap is not enough, creating swap partition."
 				remove_old_swap
 				create_swap 2048
 			else
-				echo "Your swap is not enough, need to add swap."
+				echo "Your swap is not enough, creating swap partition."
 				create_swap 2048
 			fi
 		fi
@@ -189,7 +189,7 @@ setup_swap() {
 	}
 
 	adjust_swappiness() {
-		echo "Step 5. Begin to adjust swappiness & vfs_cache_pressure"
+		echo "Adjusting swappiness & vfs_cache_pressure"
 		run_cmd sudo sed '/vm\.swappiness/d' -ibak /etc/sysctl.conf
 		echo "vm.swappiness = 10" >> /etc/sysctl.conf
 		run_cmd sudo sysctl vm.swappiness=10

--- a/install_scripts/setup_frappe.sh
+++ b/install_scripts/setup_frappe.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 set -e
-set -x
 
 
 ## Utils

--- a/install_scripts/setup_frappe.sh
+++ b/install_scripts/setup_frappe.sh
@@ -410,14 +410,13 @@ install_packages() {
 	elif [ $OS == "debian" ] || [ $OS == "Ubuntu" ]; then
 		export DEBIAN_FRONTEND=noninteractive
 		setup_debconf
-<<<<<<< HEAD
-		run_cmd sudo apt-get update && apt-get upgrade -y
-=======
 		if [ $OS == "debian" ]; then
 			run_cmd bash -c "curl -sL https://deb.nodesource.com/setup_0.12 | bash -"
 		fi
 		run_cmd sudo apt-get update
->>>>>>> frappe/master
+=======
+		run_cmd sudo apt-get update
+>>>>>>> parent of 394ca9b... Helps fix issues with outdated system packages
 		run_cmd sudo apt-get install -y python-dev python-setuptools build-essential python-mysqldb git ntp vim screen htop mariadb-server mariadb-common libmariadbclient-dev  libxslt1.1 libxslt1-dev redis-server libssl-dev libcrypto++-dev postfix nginx supervisor python-pip fontconfig libxrender1 libxext6 xfonts-75dpi xfonts-base nodejs npm
 
 		echo "Installing wkhtmltopdf"

--- a/install_scripts/setup_frappe.sh
+++ b/install_scripts/setup_frappe.sh
@@ -181,11 +181,11 @@ setup_swap() {
           return 1
         elif [ "$swap_count" -ne 0 ]
         then
-          echo "Your swap is not enough,need to add swap.\n"
+          echo "Your swap is not enough, need to add swap.\n"
           remove_old_swap
           create_swap 2048
         else
-          echo "Your swap is not enough,need to add swap.\n"
+          echo "Your swap is not enough, need to add swap.\n"
           create_swap 2048
         fi
       fi
@@ -205,7 +205,7 @@ setup_swap() {
         #if ! [ -x "$(fallocate -h)" ]; then
 				#run_cmd dd if=/dev/zero of=$swapfile bs=1M count=$1
 				#else
-				run_cmd sudo fallocate -l $1 $swapfile
+				run_cmd sudo fallocate -l ${1}M $swapfile
 				#fi
 				run_cmd sudo chmod 600 $swapfile
         run_cmd sudo mkswap $swapfile

--- a/install_scripts/setup_frappe.sh
+++ b/install_scripts/setup_frappe.sh
@@ -205,12 +205,12 @@ setup_swap() {
         #if ! [ -x "$(fallocate -h)" ]; then
 				#run_cmd dd if=/dev/zero of=$swapfile bs=1M count=$1
 				#else
-				run_cmd sudo fallocate -l $1 /$swapfile
+				run_cmd sudo fallocate -l $1 $swapfile
 				#fi
-				run_cmd sudo /sbin/chmod 600 /$swapfile
-        run_cmd sudo /sbin/mkswap $swapfile
-        run_cmd sudo /sbin/swapon $swapfile
-        run_cmd sudo /sbin/swapon -s
+				run_cmd sudo chmod 600 $swapfile
+        run_cmd sudo mkswap $swapfile
+        run_cmd sudo swapon $swapfile
+        run_cmd sudo swapon -s
         echo "Step 3. Add swap partition successful.\n"
       else
         echo "The /swapfile already exists. Returing to frappe installation.\n"


### PR DESCRIPTION
I observed on many low memory VMs setup_frappe.sh fails because of no swap partition, on the same system if swap is available MariaDB and rest of setup insturctions executes without fail.