### PR TITLE
Added command to setup Let's Encrypt for site

### DIFF
--- a/bench/cli.py
+++ b/bench/cli.py
@@ -47,9 +47,10 @@ def check_uid():
 		sys.exit(1)
 
 def cmd_requires_root():
-	if len(sys.argv) > 2 and sys.argv[2] in ('production', 'sudoers'):
+	if len(sys.argv) > 2 and sys.argv[2] in ('production', 'sudoers', 'lets-encrypt'):
 	    return True
-	if len(sys.argv) > 2 and sys.argv[1] in ('patch',):
+	    #Changed > to >=, unsure if will cause the apolcaypse
+	if len(sys.argv) >= 2 and sys.argv[1] in ('patch', 'renew-lets-encrypt'):
 	    return True
 
 def change_dir():

--- a/bench/commands/__init__.py
+++ b/bench/commands/__init__.py
@@ -30,7 +30,7 @@ bench_command.add_command(switch_to_v5)
 
 
 from bench.commands.utils import (start, restart, set_nginx_port, set_ssl_certificate, set_ssl_certificate_key, set_url_root,
-	set_mariadb_host, set_default_site, download_translations, shell, backup_site, backup_all_sites, release)
+	set_mariadb_host, set_default_site, download_translations, shell, backup_site, backup_all_sites, release, renew_lets_encrypt)
 bench_command.add_command(start)
 bench_command.add_command(restart)
 bench_command.add_command(set_nginx_port)
@@ -44,7 +44,7 @@ bench_command.add_command(shell)
 bench_command.add_command(backup_site)
 bench_command.add_command(backup_all_sites)
 bench_command.add_command(release)
-
+bench_command.add_command(renew_lets_encrypt)
 
 from bench.commands.setup import setup
 bench_command.add_command(setup)

--- a/bench/commands/setup.py
+++ b/bench/commands/setup.py
@@ -63,6 +63,14 @@ def setup_env():
 	setup_env()
 
 
+@click.command('lets-encrypt')
+@click.argument('site')
+def setup_letsencrypt(site):
+	"Setup lets-encrypt for site"
+	from bench.config.lets_encrypt import setup_letsencrypt
+	setup_letsencrypt(site, bench_path='.')
+
+
 @click.command('procfile')
 def setup_procfile():
 	"Setup Procfile for bench start"
@@ -88,6 +96,7 @@ setup.add_command(setup_sudoers)
 setup.add_command(setup_nginx)
 setup.add_command(setup_supervisor)
 setup.add_command(setup_redis)
+setup.add_command(setup_letsencrypt)
 setup.add_command(setup_production)
 setup.add_command(setup_auto_update)
 setup.add_command(setup_backups)

--- a/bench/commands/utils.py
+++ b/bench/commands/utils.py
@@ -76,6 +76,11 @@ def download_translations():
 	from bench.utils import download_translations_p
 	download_translations_p()
 
+@click.command('renew-lets-encrypt')
+def renew_lets_encrypt():
+	"Renew Let's Encrypt certificate"
+	from bench.config.lets_encrypt import renew_certs
+	renew_certs()
 
 @click.command()
 def shell(bench='.'):

--- a/bench/config/lets_encrypt.py
+++ b/bench/config/lets_encrypt.py
@@ -1,0 +1,95 @@
+import bench, os, click, errno, urllib
+from bench.utils import exec_cmd, update_site_config, CommandFailedError
+from bench.config.common_site_config import update_config as update_common_config
+from bench.config.nginx import make_nginx_conf
+from bench.config.production_setup import service
+from bench.config.common_site_config import get_config
+from crontab import CronTab
+
+def setup_letsencrypt(site, bench_path):
+
+	site_path = os.path.join(bench_path, "sites", site, "site_config.json")
+	if not os.path.exists(os.path.dirname(site_path)):
+		print "No site named "+site
+		return
+
+	click.confirm('Running this will stop the nginx service temporarily causing your sites to go offline\n'
+		'Do you want to continue?',
+		abort=True)
+
+	if not get_config(bench_path).get("dns_multitenant"):
+		print "You cannot setup SSL without DNS Multitenancy"
+		return
+
+	create_config(site)
+	run_certbot_and_setup_ssl(site, bench_path)	
+	setup_crontab()
+
+
+def create_config(site):
+	config = bench.env.get_template('letsencrypt.cfg').render(domain=site)
+	config_path = '/etc/letsencrypt/configs/{site}.cfg'.format(site=site)
+	create_dir_if_missing(config_path)
+
+	with open(config_path, 'w') as f:
+		f.write(config)
+
+
+def run_certbot_and_setup_ssl(site, bench_path):
+	service('nginx', 'stop')
+	get_certbot()
+	
+	try:
+		exec_cmd("{path} --config /etc/letsencrypt/configs/{site}.cfg certonly".format(path=get_certbot_path(), site=site))
+	except CommandFailedError:
+		service('nginx', 'start')
+		print "There was a problem trying to setup SSL for your site"
+		return
+
+	ssl_path = "/etc/letsencrypt/live/{site}/".format(site=site)
+
+	ssl_config = { "ssl_certificate": os.path.join(ssl_path, "fullchain.pem"), 
+					"ssl_certificate_key": os.path.join(ssl_path, "privkey.pem") }
+
+	update_site_config(site, ssl_config, bench=bench_path)
+	make_nginx_conf(bench_path)
+
+	service('nginx', 'start')
+
+
+def setup_crontab():
+	job_command = 'sudo service nginx stop && /opt/certbot-auto renew && sudo service nginx start'
+	user_crontab = CronTab(user=True)
+	if job_command not in str(user_crontab):
+		job  = user_crontab.new(command=job_command, comment="Renew lets-encrypt every month")
+		job.month.every(1)
+		job.enable()
+		user_crontab.write()
+
+
+def create_dir_if_missing(path):
+	if not os.path.exists(os.path.dirname(path)):
+		os.makedirs(os.path.dirname(path))
+
+
+def get_certbot():
+	certbot_path = get_certbot_path()
+	create_dir_if_missing(certbot_path)
+
+	if not os.path.isfile(certbot_path):
+		urllib.urlretrieve ("https://dl.eff.org/certbot-auto", certbot_path)	
+		os.chmod(certbot_path, 0744)
+
+
+def get_certbot_path():
+	return "/opt/certbot-auto"
+
+
+def renew_certs():
+	click.confirm('Running this will stop the nginx service temporarily causing your sites to go offline\n'
+		'Do you want to continue?',
+		abort=True)
+
+	service('nginx', 'start')
+	exec_cmd("{path} renew".format(path=get_certbot_path()))
+	service('nginx', 'stop')

--- a/bench/config/procfile.py
+++ b/bench/config/procfile.py
@@ -1,6 +1,6 @@
 import bench, os, click
-from bench.utils import find_executable
-from bench.app import use_rq
+from bench.utils import find_executable		
+from bench.app import use_rq		
 from bench.config.common_site_config import get_config
 
 def setup_procfile(bench_path, force=False):

--- a/bench/config/production_setup.py
+++ b/bench/config/production_setup.py
@@ -27,14 +27,14 @@ def setup_production(user, bench='.'):
 	if os.environ.get('NO_SERVICE_RESTART'):
 		return
 
-	restart_service('nginx')
+	service('nginx', 'restart')
 
 
-def restart_service(service):
+def service(service, option):
 	if os.path.basename(get_program(['systemctl']) or '') == 'systemctl' and is_running_systemd():
-		exec_cmd("{service_manager} restart {service}".format(service_manager='systemctl', service=service))
+		exec_cmd("{service_manager} {option} {service}".format(service_manager='systemctl', option=option, service=service))
 	elif os.path.basename(get_program(['service']) or '') == 'service':
-		exec_cmd("{service_manager} {service} restart ".format(service_manager='service', service=service))
+		exec_cmd("{service_manager} {service} {option} ".format(service_manager='service', service=service, option=option))
 	else:
 		# look for 'service_manager' and 'service_manager_command' in environment
 		service_manager = os.environ.get("BENCH_SERVICE_MANAGER")

--- a/bench/config/templates/letsencrypt.cfg
+++ b/bench/config/templates/letsencrypt.cfg
@@ -1,0 +1,20 @@
+# This is an example of the kind of things you can do in a configuration file.
+# All flags used by the client can be configured here. Run Certbot with
+# "--help" to learn more about the available options.
+
+# Use a 4096 bit RSA key instead of 2048
+rsa-key-size = 4096
+
+# Uncomment and update to register with the specified e-mail address
+#email = email@domain.com
+
+# Uncomment and update to generate certificates for the specified
+# domains.
+domains = {{ domain }}
+
+# Uncomment to use a text interface instead of ncurses
+text = True
+
+# Uncomment to use the standalone authenticator on port 443
+authenticator = standalone
+standalone-supported-challenges = tls-sni-01

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@ jinja2
 virtualenv
 requests
 honcho
+python-crontab
 semantic_version
 GitPython==0.3.2.rc1


### PR DESCRIPTION
**New Command**: `sudo bench setup lets-encrypt [site-name]`

TODO: 
- [x] Validate `dns_multitenant==True`
- [x] Renew cert using cron

Fix for : 

https://github.com/frappe/bench/issues/218