### PR TITLE
added npm, missing deb/ubuntu dependency

### DIFF
--- a/install_scripts/setup_frappe.sh
+++ b/install_scripts/setup_frappe.sh
@@ -209,7 +209,7 @@ install_packages() {
 		run_cmd sudo apt-get install -y python-dev python-setuptools build-essential python-mysqldb git \
 			ntp vim screen htop mariadb-server mariadb-common libmariadbclient-dev \
 			libxslt1.1 libxslt1-dev redis-server libssl-dev libcrypto++-dev postfix nginx \
-			supervisor python-pip fontconfig libxrender1 libxext6 xfonts-75dpi xfonts-base nodejs
+			supervisor python-pip fontconfig libxrender1 libxext6 xfonts-75dpi xfonts-base nodejs npm
 
 		if [ $OS_VER == "precise" ]; then
 			run_cmd sudo apt-get install -y libtiff4-dev libjpeg8-dev zlib1g-dev libfreetype6-dev liblcms2-dev libwebp-dev tcl8.5-dev tk8.5-dev python-tk

--- a/install_scripts/setup_frappe.sh
+++ b/install_scripts/setup_frappe.sh
@@ -209,14 +209,17 @@ install_packages() {
 		run_cmd sudo apt-get install -y python-dev python-setuptools build-essential python-mysqldb git \
 			ntp vim screen htop mariadb-server mariadb-common libmariadbclient-dev \
 			libxslt1.1 libxslt1-dev redis-server libssl-dev libcrypto++-dev postfix nginx \
-			supervisor python-pip fontconfig libxrender1 libxext6 xfonts-75dpi xfonts-base nodejs npm
+			supervisor python-pip fontconfig libxrender1 libxext6 xfonts-75dpi xfonts-base nodejs
 
 		if [ $OS_VER == "precise" ]; then
-			run_cmd sudo apt-get install -y libtiff4-dev libjpeg8-dev zlib1g-dev libfreetype6-dev liblcms2-dev libwebp-dev tcl8.5-dev tk8.5-dev python-tk
+			run_cmd sudo apt-get install -y libtiff4-dev libjpeg8-dev zlib1g-dev libfreetype6-dev \
+				liblcms2-dev libwebp-dev tcl8.5-dev tk8.5-dev python-tk
 		elif [ $OS_VER == "8" ]; then
-                        run_cmd sudo apt-get install -y libtiff5-dev libjpeg62-turbo-dev zlib1g-dev libfreetype6-dev liblcms2-dev libwebp-dev tcl8.5-dev tk8.5-dev python-tk
+			run_cmd sudo apt-get install -y libtiff5-dev libjpeg62-turbo-dev zlib1g-dev libfreetype6-dev \
+				liblcms2-dev libwebp-dev tcl8.5-dev tk8.5-dev python-tk npm
 		else
-			run_cmd sudo apt-get install -y libtiff5-dev libjpeg8-dev zlib1g-dev libfreetype6-dev liblcms2-dev libwebp-dev tcl8.6-dev tk8.6-dev python-tk
+			run_cmd sudo apt-get install -y libtiff5-dev libjpeg8-dev zlib1g-dev libfreetype6-dev \
+				liblcms2-dev libwebp-dev tcl8.6-dev tk8.6-dev python-tk
 		fi
 
 		echo "Installing wkhtmltopdf"


### PR DESCRIPTION
Running Frappe setup script on a clean Debian installation caused following error.

```bash
admin@erpnext6:~$ admin@erpnext6:~$ sudo bash setup_frappe.sh --setup-production
admin@erpnext6:~$ sudo bash setup_frappe.sh --setup-production
Installing for debian 8 amd64
In case you encounter an error, you can post on https://discuss.frappe.io

Adding debian mariadb repo
Installing packages for debian. This might take time...
Installing wkhtmltopdf
Adding frappe user
Installing frappe-bench
Already using interpreter /usr/bin/python
INFO:bench.app:getting app frappe
Cloning into 'frappe'...
INFO:bench.app:installing frappe
INFO:urllib3.connectionpool:Starting new HTTPS connection (1): raw.githubusercontent.com
DEBUG:urllib3.connectionpool:"GET /frappe/bench/master/install_scripts/erpnext-apps-master.json HTTP/1.1" 200 101
INFO:bench.app:getting app erpnext
Cloning into 'erpnext'...
Checking out files: 100% (3482/3482), done.
INFO:bench.app:installing erpnext
/bin/sh: 1: npm: not found
installing frappe
installing erpnext
Traceback (most recent call last):
  File "/usr/local/bin/bench", line 9, in <module>
    load_entry_point('bench==3.0.0', 'console_scripts', 'bench')()
  File "/home/admin/bench-repo/bench/cli.py", line 40, in cli
    bench_command()
  File "/usr/local/lib/python2.7/dist-packages/click/core.py", line 716, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/click/core.py", line 696, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python2.7/dist-packages/click/core.py", line 1060, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python2.7/dist-packages/click/core.py", line 889, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python2.7/dist-packages/click/core.py", line 534, in invoke
    return callback(*args, **kwargs)
  File "/home/admin/bench-repo/bench/commands/make.py", line 17, in init
    no_auto_update=no_auto_update, frappe_path=frappe_path, frappe_branch=frappe_branch, verbose=verbose)
  File "/home/admin/bench-repo/bench/utils.py", line 70, in init
    setup_socketio(bench=path)
  File "/home/admin/bench-repo/bench/utils.py", line 110, in setup_socketio
    exec_cmd("npm install socket.io redis express superagent cookie", cwd=bench)
  File "/home/admin/bench-repo/bench/utils.py", line 100, in exec_cmd
    raise CommandFailedError(cmd)
bench.utils.CommandFailedError: npm install socket.io redis express superagent cookie
```