### PR TITLE
Issues with Mac development bench installer

### DIFF
--- a/playbooks/develop/create_user.yml
+++ b/playbooks/develop/create_user.yml
@@ -20,3 +20,4 @@
 
     - name: Set /tmp/.bench folder perms
       command: 'chown -R {{ frappe_user }}:{{ frappe_user }} /tmp/.bench'
+      when: ansible_distribution == 'Ubuntu' or ansible_distribution == 'CentOS'


### PR DESCRIPTION
- Setuptools to be installed using bootstrap script instead of `pip`
- Do not get passwords while running script to setup development environment
- Added option to mention `repo-url` along with the branch
- `extra_vars.json` file moved to `/tmp` directory instead of user home directory
- create user ansible script needs to perform `chown` only in case of Linux.