### PR TITLE
Update setup_frappe.sh

### DIFF
--- a/install_scripts/setup_frappe.sh
+++ b/install_scripts/setup_frappe.sh
@@ -134,11 +134,12 @@ add_debian_mariadb_repo() {
 		echo Unsupported Debian Version
 		exit 1
 	fi
-
 	run_cmd sudo apt-get update
 	run_cmd sudo apt-get install -y software-properties-common python-software-properties
 	run_cmd sudo apt-key adv --recv-keys --keyserver keyserver.ubuntu.com 0xcbcb082a1bb943db
-	run_cmd sudo add-apt-repository "deb http://ams2.mirrors.digitalocean.com/mariadb/repo/10.0/debian $CODENAME main"
+	if [ -z $(apt-cache search --names-only 'mariadb-server') ]; then
+		run_cmd sudo add-apt-repository "deb http://ams2.mirrors.digitalocean.com/mariadb/repo/10.0/debian $CODENAME main"
+	fi
 }
 
 add_ius_repo() {


### PR DESCRIPTION
Check for mariadb in existing repo

Without this check, existing setup script will fail in jessie 8.5