### PR TITLE
mariadb repo check

### DIFF
--- a/install_scripts/setup_frappe.sh
+++ b/install_scripts/setup_frappe.sh
@@ -134,11 +134,12 @@ add_debian_mariadb_repo() {
 		echo Unsupported Debian Version
 		exit 1
 	fi
-
 	run_cmd sudo apt-get update
 	run_cmd sudo apt-get install -y software-properties-common python-software-properties
 	run_cmd sudo apt-key adv --recv-keys --keyserver keyserver.ubuntu.com 0xcbcb082a1bb943db
-	run_cmd sudo add-apt-repository "deb http://ams2.mirrors.digitalocean.com/mariadb/repo/10.0/debian $CODENAME main"
+	if [ -z $(apt-cache search --names-only 'mariadb-server') ]; then
+		run_cmd sudo add-apt-repository "deb http://ams2.mirrors.digitalocean.com/mariadb/repo/10.0/debian $CODENAME main"
+	fi
 }
 
 add_ius_repo() {


### PR DESCRIPTION
Without mariadb repo check, setup script will fail for jessie 8.5 or any debian distro that has existing mariadb