### PR TITLE
[refactor] nginx config now supports wildcard ssl and custom domains

### DIFF
--- a/bench/__init__.py
+++ b/bench/__init__.py
@@ -2,7 +2,7 @@ from jinja2 import Environment, PackageLoader
 
 __version__ = "4.0.0-beta"
 
-env = Environment(loader=PackageLoader('bench.config'), trim_blocks=True)
+env = Environment(loader=PackageLoader('bench.config'))
 
 FRAPPE_VERSION = None
 

--- a/bench/config/templates/nginx.conf
+++ b/bench/config/templates/nginx.conf
@@ -1,7 +1,16 @@
-{% macro server_block(bench_name, port, server_names, sites_path, ssl_certificate, ssl_certificate_key) %}
+{%- macro nginx_map(from_variable, to_variable, values, default) %}
+map {{ from_variable }} {{ to_variable }} {
+	{% for (from, to) in values.items() -%}
+		{{ from }} {{ to }};
+	{% endfor %}
 
-{%- set site_name = server_names[0] if (server_names|length)==1 else "$host" -%}
+	{%- if default -%}
+		default {{ default }};
+	{% endif %}
+}
+{%- endmacro %}
 
+{%- macro server_block(bench_name, port, server_names, site_name, sites_path, ssl_certificate, ssl_certificate_key) %}
 server {
 	listen {{ port }};
 	server_name
@@ -94,18 +103,22 @@ server {
 		# text/html is always compressed by HttpGzipModule
 }
 
-{% if ssl_certificate and ssl_certificate_key %}
-	# http to https redirect for {{ server_names[0] }}
+{% if ssl_certificate and ssl_certificate_key -%}
+	# http to https redirect
 	server {
 	    listen 80;
-		server_name {{ server_names[0] }};
+		server_name
+			{% for name in server_names -%}
+			{{ name }}
+			{% endfor -%}
+			;
+
 	    return 301 https://$host$request_uri?$query_string;
 	}
 
 {% endif %}
 
-{# keep the empty line above for a pleasant rendering #}
-{% endmacro %}
+{%- endmacro -%}
 
 upstream {{ bench_name }}-frappe {
     server 127.0.0.1:{{ webserver_port or 8000 }} fail_timeout=0;
@@ -115,16 +128,36 @@ upstream {{ bench_name}}-socketio-server {
     server 127.0.0.1:{{ socketio_port or 3000 }} fail_timeout=0;
 }
 
+# setup maps
+{%- set site_name_variable="$host" %}
+{% if sites.domain_map -%}
+	{# we append these variables with a random string as there could be multiple benches #}
+	{%- set site_name_variable="$site_name_{0}".format(random_string) -%}
+	{{ nginx_map(from_variable="$host", to_variable=site_name_variable, values=sites.domain_map, default="$host") }}
+{%- endif %}
+
+# server blocks
 {% if sites.that_use_dns -%}
 
-	{{ server_block(bench_name, 80, sites.that_use_dns, sites_path) }}
+	{{ server_block(bench_name, port=80, server_names=sites.that_use_dns, site_name=site_name_variable, sites_path=sites_path) }}
+
+{%- endif %}
+
+{% if sites.that_use_wildcard_ssl -%}
+
+	{{ server_block(bench_name, port=443, server_names=sites.that_use_wildcard_ssl,
+		site_name=site_name_variable, sites_path=sites_path,
+		ssl_certificate=sites.wildcard_ssl_certificate,
+		ssl_certificate_key=sites.wildcard_ssl_certificate_key) }}
 
 {%- endif %}
 
 {%- if sites.that_use_ssl -%}
 	{% for site in sites.that_use_ssl -%}
 
-		{{ server_block(bench_name, 443, [site.name], sites_path, site.ssl_certificate, site.ssl_certificate_key) }}
+		{{ server_block(bench_name, port=443, server_names=[site.domain or site.name],
+				site_name=site_name_variable, sites_path=sites_path,
+				ssl_certificate=site.ssl_certificate, ssl_certificate_key=site.ssl_certificate_key) }}
 
 	{% endfor %}
 {%- endif %}
@@ -132,7 +165,7 @@ upstream {{ bench_name}}-socketio-server {
 {% if sites.that_use_port -%}
 	{%- for site in sites.that_use_port -%}
 
-		{{ server_block(bench_name, site.port, [site.name], sites_path) }}
+		{{ server_block(bench_name, port=site.port, server_names=[site.name], site_name=site.name, sites_path=sites_path) }}
 
 	{%- endfor %}
 {% endif %}


### PR DESCRIPTION
- Wildcard SSL

In common_site_config.json:
```
"wildcard": {
    "domain": "*.example.com",
    "ssl_certificate": "/path/to/example.com.crt",
    "ssl_certificate_key": "/path/to/example.com.key"
}
```

- Custom Domains

In site_config.json:
```
"domains": [
    "other-example.com",
    {"domain": "another-example.com", "ssl_certificate": "...", "ssl_certificate_key": "..."}
]
```

