### PR TITLE
[Minor] Added command to archive-bench

### DIFF
--- a/bench/commands/__init__.py
+++ b/bench/commands/__init__.py
@@ -29,7 +29,8 @@ bench_command.add_command(switch_to_v5)
 
 
 from bench.commands.utils import (start, restart, set_nginx_port, set_ssl_certificate, set_ssl_certificate_key, set_url_root,
-	set_mariadb_host, set_default_site, download_translations, shell, backup_site, backup_all_sites, release, renew_lets_encrypt)
+	set_mariadb_host, set_default_site, download_translations, shell, backup_site, backup_all_sites, release, renew_lets_encrypt,
+	archive_bench)
 bench_command.add_command(start)
 bench_command.add_command(restart)
 bench_command.add_command(set_nginx_port)
@@ -44,6 +45,8 @@ bench_command.add_command(backup_site)
 bench_command.add_command(backup_all_sites)
 bench_command.add_command(release)
 bench_command.add_command(renew_lets_encrypt)
+bench_command.add_command(archive_bench)
+
 
 from bench.commands.setup import setup
 bench_command.add_command(setup)

--- a/bench/commands/utils.py
+++ b/bench/commands/utils.py
@@ -128,3 +128,12 @@ def release(app, bump_type, develop, master, owner, repo_name, remote):
 	from bench.release import release
 	release(bench_path='.', app=app, bump_type=bump_type, develop=develop, master=master,
 		remote=remote, owner=owner, repo_name=repo_name)
+
+@click.command('archive-bench')
+@click.argument('bench-path')
+@click.option('--archive-benches-path', default=None)
+@click.option('--force', default=False, is_flag=True, help='Force archiving of bench with sites')
+def archive_bench(bench_path, archive_benches_path, force):
+	"""Archives bench, only if it contains no sites"""
+	from bench.utils import archive_bench
+	archive_bench(bench_path, archive_benches_path, force)


### PR DESCRIPTION
- [x] New command to archive bench `bench archive-bench {bench_path}`.
- [x] Delete symlinks from nginx and supervisor configs before archiving the bench in case of production.
- [x] Archived bench can be moved to default path or custom path provided by the user `--archived-benches-path`
- [x] Force archival in case site exists on the bench using `--force`.
- [x] Restarting and reloading `nginx` and `supervisorctl` after deleting symlinks.