### PR TITLE
Ignore set root pass error if root password is already set

### DIFF
--- a/playbooks/develop/includes/setup_mariadb.yml
+++ b/playbooks/develop/includes/setup_mariadb.yml
@@ -20,6 +20,8 @@
     become: yes
     become_user: root
     when: mysql_root_password is defined
+    # incase root password is already set
+    ignore_errors: yes
 
   - name: add launchagents folder mac
     file: path=~/Library/LaunchAgents state=directory


### PR DESCRIPTION
See https://github.com/frappe/bench/issues/285#issuecomment-239983969
Also disable exe bit on `setup_mariadb.yml`

Fixes #285 