### PR TITLE
Add git utility commands

### DIFF
--- a/bench/app.py
+++ b/bench/app.py
@@ -134,15 +134,7 @@ def pull_all_apps(bench_path='.'):
 	for app in get_apps(bench_path=bench_path):
 		app_dir = get_repo_dir(app, bench_path=bench_path)
 		if os.path.exists(os.path.join(app_dir, '.git')):
-			contents = subprocess.check_output(['git', 'remote', '-v'], cwd=app_dir,
-				stderr=subprocess.STDOUT)
-
-			if re.findall('upstream[\s]+', contents):
-				remote = 'upstream'
-			else:
-				# get the first remote
-				remote = contents.splitlines()[0].split()[0]
-
+			remote = get_remote(app)
 			logger.info('pulling {0}'.format(app))
 			exec_cmd("git pull {rebase} {remote} {branch}".format(rebase=rebase,
 				remote=remote, branch=get_current_branch(app, bench_path=bench_path)), cwd=app_dir)
@@ -177,6 +169,18 @@ def get_current_frappe_version(bench_path='.'):
 def get_current_branch(app, bench_path='.'):
 	repo_dir = get_repo_dir(app, bench_path=bench_path)
 	return get_cmd_output("basename $(git symbolic-ref -q HEAD)", cwd=repo_dir)
+
+def get_remote(app, bench_path='.'):
+	repo_dir = get_repo_dir(app, bench_path=bench_path)
+	contents = subprocess.check_output(['git', 'remote', '-v'], cwd=repo_dir,
+									   stderr=subprocess.STDOUT)
+	if re.findall('upstream[\s]+', contents):
+		remote = 'upstream'
+	else:
+		# get the first remote
+		remote = contents.splitlines()[0].split()[0]
+
+	return remote
 
 def use_rq(bench_path):
 	bench_path = os.path.abspath(bench_path)

--- a/bench/commands/__init__.py
+++ b/bench/commands/__init__.py
@@ -65,3 +65,8 @@ bench_command.add_command(setup)
 
 from bench.commands.config import config
 bench_command.add_command(config)
+
+from bench.commands.git import remote_set_url, remote_reset_url, remote_urls
+bench_command.add_command(remote_set_url)
+bench_command.add_command(remote_reset_url)
+bench_command.add_command(remote_urls)

--- a/bench/commands/git.py
+++ b/bench/commands/git.py
@@ -1,0 +1,33 @@
+import click
+import os, subprocess, re
+
+from bench.app import get_repo_dir, get_apps, get_remote
+from bench.utils import set_git_remote_url
+
+
+@click.command('remote-set-url')
+@click.argument('git-url')
+def remote_set_url(git_url):
+	"Set app remote url"
+	set_git_remote_url(git_url)
+
+
+@click.command('remote-reset-url')
+@click.argument('app')
+def remote_reset_url(app):
+	"Reset app remote url to frappe official"
+	git_url = "https://github.com/frappe/{}.git".format(app)
+	set_git_remote_url(git_url)
+
+
+@click.command('remote-urls')
+def remote_urls():
+	"Show apps remote url"
+	for app in get_apps():
+		repo_dir = get_repo_dir(app)
+
+		if os.path.exists(os.path.join(repo_dir, '.git')):
+			remote = get_remote(app)
+			remote_url = subprocess.check_output(['git', 'config', '--get', 'remote.{}.url'.format(remote)], cwd=repo_dir).strip()
+			print "{app}	{remote_url}".format(app=app, remote_url=remote_url)
+

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -675,3 +675,15 @@ def setup_fonts():
 	os.rename(os.path.join(fonts_path, 'usr_share_fonts'), '/usr/share/fonts')
 	shutil.rmtree(fonts_path)
 	exec_cmd("fc-cache -fv")
+
+def set_git_remote_url(git_url, bench_path='.'):
+	"Set app remote git url"
+	app = git_url.rsplit('/', 1)[1].rsplit('.', 1)[0]
+
+	if app not in bench.app.get_apps(bench_path):
+		print "No app named {0}".format(app)
+		sys.exit(1)
+
+	app_dir = bench.app.get_repo_dir(app, bench_path=bench_path)
+	if os.path.exists(os.path.join(app_dir, '.git')):
+		exec_cmd("git remote set-url upstream {}".format(git_url), cwd=app_dir)


### PR DESCRIPTION
New commands added:

1. bench remote-set-url `git_url`: Set upstream remote url for app
2. bench remote-reset-url:  Reset upstream remote url to frappe official
3. bench remote-urls: List apps remote url