### PR TITLE
Add openldap-devel prerequisite for CentOS 7

### DIFF
--- a/playbooks/install.py
+++ b/playbooks/install.py
@@ -18,7 +18,7 @@ def install_bench(args):
 		],
 		'yum': [
 			'sudo yum groupinstall -y "Development tools"',
-			'sudo yum install -y epel-release redhat-lsb-core git python-setuptools python-devel openssl-devel libffi-devel'
+			'sudo yum install -y epel-release redhat-lsb-core git python-setuptools python-devel openssl-devel openldap-devel libffi-devel'
 		],
 		# epel-release is required to install redis, so installing it before the playbook-run.
 		# redhat-lsb-core is required, so that ansible can set ansible_lsb variable


### PR DESCRIPTION
Hi, please add openldap-devel as a pre requisite for CentOS 7, python-ldap requires this package to install properly vía pip.

bench init frappe-bench
[...]
Running setup.py install for python-ldap ... error
    Modules/errors.h:8:18: fatal error: lber.h: No such file or directory
     #include "lber.h"
                      ^
    compilation terminated.
    error: command 'gcc' failed with exit status 1
    
    ----------------------------------------
Command "/bin/python -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-Nxeni8/python-ldap/setup.py';exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" install --record /tmp/pip-eRo_3D-record/install-record.txt --single-version-externally-managed --compile" failed with error code 1 in /tmp/pip-build-Nxeni8/python-ldap/

References:

 - http://stackoverflow.com/questions/4768446/i-cant-install-python-ldap

Signed-off-by: William Moreno Reyes <williamjmorenor@gmail.com>