### PR TITLE
Added command to setup firewall

### DIFF
--- a/bench/cli.py
+++ b/bench/cli.py
@@ -47,7 +47,7 @@ def check_uid():
 		sys.exit(1)
 
 def cmd_requires_root():
-	if len(sys.argv) > 2 and sys.argv[2] in ('production', 'sudoers', 'lets-encrypt', 'fonts', 'reload-nginx'):
+	if len(sys.argv) > 2 and sys.argv[2] in ('production', 'sudoers', 'lets-encrypt', 'fonts', 'reload-nginx', 'firewall'):
 	    return True
 	if len(sys.argv) >= 2 and sys.argv[1] in ('patch', 'renew-lets-encrypt', 'disable-production'):
 	    return True

--- a/bench/commands/setup.py
+++ b/bench/commands/setup.py
@@ -75,6 +75,14 @@ def setup_env():
 	from bench.utils import setup_env
 	setup_env()
 
+@click.command('firewall')
+def setup_firewall():
+	"Setup firewall"
+	from bench.utils import run_playbook
+	click.confirm('Setting up the firewall will block all ports except 80, 443 and 22\n'
+		'Do you want to continue?',
+		abort=True)
+	run_playbook('production/setup_firewall.yml')
 
 @click.command('lets-encrypt')
 @click.argument('site')
@@ -170,3 +178,4 @@ setup.add_command(setup_fonts)
 setup.add_command(add_domain)
 setup.add_command(remove_domain)
 setup.add_command(sync_domains)
+setup.add_command(setup_firewall)

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -685,3 +685,7 @@ def set_git_remote_url(git_url, bench_path='.'):
 	app_dir = bench.app.get_repo_dir(app, bench_path=bench_path)
 	if os.path.exists(os.path.join(app_dir, '.git')):
 		exec_cmd("git remote set-url upstream {}".format(git_url), cwd=app_dir)
+
+def run_playbook(playbook_name):
+	args = ['ansible-playbook', '-c', 'local', playbook_name]
+	subprocess.check_call(args, cwd=os.path.join(os.path.dirname(bench.__path__[0]), 'playbooks'))

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -687,5 +687,8 @@ def set_git_remote_url(git_url, bench_path='.'):
 		exec_cmd("git remote set-url upstream {}".format(git_url), cwd=app_dir)
 
 def run_playbook(playbook_name):
+	if not find_executable('ansible'):
+		print "Ansible is needed to run this command, please install it using 'pip install ansible'"
+		sys.exit(1)
 	args = ['ansible-playbook', '-c', 'local', playbook_name]
 	subprocess.check_call(args, cwd=os.path.join(os.path.dirname(bench.__path__[0]), 'playbooks'))

--- a/playbooks/production/setup_firewall.yml
+++ b/playbooks/production/setup_firewall.yml
@@ -3,16 +3,14 @@
   hosts: localhost
 
   tasks:
+      # For CentOS
     - name: Install firewalld
       yum: name=firewalld state=present
       when: ansible_distribution == 'CentOS'
 
-    - name: Install firewalld
-      apt: name=firewalld state=present
-      when: ansible_distribution == 'Ubuntu' or ansible_distribution == 'Debian'
-
     - name: Enable Firewall
       service: name=firewalld state=started enabled=yes
+      when: ansible_distribution == 'CentOS'
 
     - name: Add firewall rules
       firewalld: port={{ item }}/tcp permanent=true state=enabled
@@ -20,7 +18,26 @@
         - 80
         - 443
         - 22
+      when: ansible_distribution == 'CentOS'
 
     - name: Restart Firewall
       service: name=firewalld state=restarted enabled=yes
+      when: ansible_distribution == 'CentOS'
+
+      # For Ubuntu / Debian
+    - name: Install ufw
+      apt: name=ufw state=present
+      when: ansible_distribution == 'Ubuntu' or ansible_distribution == 'Debian'
+
+    - name: Enable Firewall
+      ufw: state=enabled policy=deny
+      when: ansible_distribution == 'Ubuntu' or ansible_distribution == 'Debian'
+
+    - name: Add firewall rules
+      ufw: rule=allow proto=tcp port={{ item }}
+      with_items:
+        - 80
+        - 443
+        - 22
+      when: ansible_distribution == 'Ubuntu' or ansible_distribution == 'Debian'
 

--- a/playbooks/production/setup_firewall.yml
+++ b/playbooks/production/setup_firewall.yml
@@ -1,0 +1,26 @@
+- name: Setup Firewall
+  user: root
+  hosts: localhost
+
+  tasks:
+    - name: Install firewalld
+      yum: name=firewalld state=present
+      when: ansible_distribution == 'CentOS'
+
+    - name: Install firewalld
+      apt: name=firewalld state=present
+      when: ansible_distribution == 'Ubuntu' or ansible_distribution == 'Debian'
+
+    - name: Enable Firewall
+      service: name=firewalld state=started enabled=yes
+
+    - name: Add firewall rules
+      firewalld: port={{ item }}/tcp permanent=true state=enabled
+      with_items:
+        - 80
+        - 443
+        - 22
+
+    - name: Restart Firewall
+      service: name=firewalld state=restarted enabled=yes
+


### PR DESCRIPTION
## `bench setup firewall`
Added `run_playbook` method to utils.py. Method exists in install.py, however, would have to make too many workarounds to re-use it. Currently dropped setup_firewall.yml inside `playbooks/production`, not sure of the best place. Command also checks if Ansible is installed.

### Note : firewalld doesn't work on Ubuntu 16.04 (with ansible) and UFW doesn't work on CentOS 7 😠 . Therefore the playbook now installs firewalld on CentOS and UFW on Ubuntu / Debian. Sure, it looks ugly, but it won't break. 🙈 

- [x] Testing: 
  - [x] Ubuntu
  - [x] Debian
  - [x] CentOS
- [x] Check if Ansible is installed, and promt to install if not
