### PR TITLE
Update pull_all_apps to use regex for check

### DIFF
--- a/bench/app.py
+++ b/bench/app.py
@@ -138,7 +138,7 @@ def pull_all_apps(bench_path='.', reset=False):
 		app_dir = get_repo_dir(app, bench_path=bench_path)
 		if os.path.exists(os.path.join(app_dir, '.git')):
 			out = subprocess.check_output(["git", "status"], cwd=app_dir)
-			if not 'nothing to commit, working directory clean' in out:
+			if not re.search(r'nothing to commit, working (directory|tree) clean', out):
 				print '''
 
 Cannot proceed with update: You have local changes in app "{0}" that are not committed.


### PR DESCRIPTION
pull_all_apps calls a "git status" and checks if the response contains "nothing to commit, working directory clean". However, it seems that at least some versions of git output the message "nothing to commit, working directory clean". This causes bench update to not work in systems where the output message uses "tree" instead of "directory". This update is to allow both strings to be used.