### PR TITLE
Don't need $query_string

### DIFF
--- a/bench/config/templates/nginx.conf
+++ b/bench/config/templates/nginx.conf
@@ -128,7 +128,7 @@ server {
 			{% endfor -%}
 			;
 
-	    return 301 https://$host$request_uri?$query_string;
+	    return 301 https://$host$request_uri;
 	}
 
 {% endif %}


### PR DESCRIPTION
nginx http to https redirect,  it don't need $query_string.