### PR TITLE
Use downloads.wkhtmltopdf.org instead of gna.org

### DIFF
--- a/playbooks/develop/includes/wkhtmltopdf.yml
+++ b/playbooks/develop/includes/wkhtmltopdf.yml
@@ -1,6 +1,6 @@
 ---
   - name: download wkthmltox linux
-    get_url: url=http://download.gna.org/wkhtmltopdf/0.12/0.12.3/wkhtmltox-0.12.3_linux-generic-{{ "amd64" if ansible_architecture == "x86_64" else "i386"}}.tar.xz dest=/tmp/wkhtmltox.tar.xz
+    get_url: url=http://downloads.wkhtmltopdf.org/0.12/0.12.3/wkhtmltox-0.12.3_linux-generic-{{ "amd64" if ansible_architecture == "x86_64" else "i386"}}.tar.xz dest=/tmp/wkhtmltox.tar.xz
 
   - name: Creates directory
     file: path=/tmp/wkhtmltox state=directory


### PR DESCRIPTION
gna.org is supposedly shutting down, and was unavailable for most of
today.