### PR TITLE
use certbot with -n option

### DIFF
--- a/bench/config/lets_encrypt.py
+++ b/bench/config/lets_encrypt.py
@@ -56,7 +56,7 @@ def run_certbot_and_setup_ssl(site, custom_domain, bench_path):
 	get_certbot()
 
 	try:
-		exec_cmd("{path} --config /etc/letsencrypt/configs/{site}.cfg certonly".format(path=get_certbot_path(), site=custom_domain or site))
+		exec_cmd("{path} -n --config /etc/letsencrypt/configs/{site}.cfg certonly".format(path=get_certbot_path(), site=custom_domain or site))
 	except CommandFailedError:
 		service('nginx', 'start')
 		print("There was a problem trying to setup SSL for your site")


### PR DESCRIPTION
allows us to use yes | bench setup lets-encrypt {clientsite}

it gets rid of certbot prompt

Cert not yet due for renewal

You have an existing certificate that has exactly the same domains or certificate name you requested and isn't close to expiry.

What would you like to do?
-------------------------------------------------------------------------------
1: Keep the existing certificate for now
2: Renew & replace the cert (limit ~5 per 7 days)
-------------------------------------------------------------------------------

automatically chooses option 1

By Default, most users would want to choose option 1 as let's encrypt lets a weekly limitation as to the number of certs you can get issued+renew. Cant really think of a usecase in which you want to replace the cert unless your cert is compromised.