### PR TITLE
Installation fails for PDFKit - no module named six

### DIFF
--- a/bench/utils.py
+++ b/bench/utils.py
@@ -134,6 +134,7 @@ def setup_env(bench_path='.'):
 	exec_cmd('./env/bin/pip -q install --upgrade pip', cwd=bench_path)
 	exec_cmd('./env/bin/pip -q install wheel', cwd=bench_path)
 	# exec_cmd('./env/bin/pip -q install https://github.com/frappe/MySQLdb1/archive/MySQLdb-1.2.5-patched.tar.gz', cwd=bench_path)
+	exec_cmd('./env/bin/pip -q install six', cwd=bench_path)
 	exec_cmd('./env/bin/pip -q install -e git+https://github.com/frappe/python-pdfkit.git#egg=pdfkit', cwd=bench_path)
 
 def setup_socketio(bench_path='.'):


### PR DESCRIPTION
Get the following error when installing:

`./env/bin/pip install -e git+https://github.com/frappe/python-pdfkit.git#egg=pdfkit
Obtaining pdfkit from git+https://github.com/frappe/python-pdfkit.git#egg=pdfkit
  Updating ./env/src/pdfkit clone
Installing collected packages: pdfkit
  Running setup.py develop for pdfkit
    Complete output from command /home/strella/frappe-bench/env/bin/python -c "import setuptools, tokenize;__file__='/home/strella/frappe-bench/env/src/pdfkit/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" develop --no-deps:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/home/strella/frappe-bench/env/src/pdfkit/setup.py", line 51, in <module>
        'Topic :: Utilities'
      File "/usr/lib/python2.7/distutils/core.py", line 137, in setup
        ok = dist.parse_command_line()
      File "/home/strella/frappe-bench/env/local/lib/python2.7/site-packages/setuptools/dist.py", line 363, in parse_command_line
        result = _Distribution.parse_command_line(self)
      File "/usr/lib/python2.7/distutils/dist.py", line 467, in parse_command_line
        args = self._parse_command_opts(parser, args)
      File "/home/strella/frappe-bench/env/local/lib/python2.7/site-packages/setuptools/dist.py", line 674, in _parse_command_opts
        nargs = _Distribution._parse_command_opts(self, parser, args)
      File "/usr/lib/python2.7/distutils/dist.py", line 523, in _parse_command_opts
        cmd_class = self.get_command_class(command)
      File "/home/strella/frappe-bench/env/local/lib/python2.7/site-packages/setuptools/dist.py", line 495, in get_command_class
        self.cmdclass[command] = cmdclass = ep.load()
      File "/home/strella/frappe-bench/env/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2303, in load
        return self.resolve()
      File "/home/strella/frappe-bench/env/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2309, in resolve
        module = __import__(self.module_name, fromlist=['__name__'], level=0)
      File "/home/strella/frappe-bench/env/local/lib/python2.7/site-packages/setuptools/command/develop.py", line 11, in <module>
        from setuptools.command.easy_install import easy_install
      File "/home/strella/frappe-bench/env/local/lib/python2.7/site-packages/setuptools/command/easy_install.py", line 49, in <module>
        from setuptools.py27compat import rmtree_safe
      File "/home/strella/frappe-bench/env/local/lib/python2.7/site-packages/setuptools/py27compat.py", line 7, in <module>
        import six
    ImportError: No module named six`