### PR TITLE
Added command to give git status for all apps in bench

### DIFF
--- a/bench/commands/__init__.py
+++ b/bench/commands/__init__.py
@@ -38,7 +38,7 @@ bench_command.add_command(switch_to_develop)
 
 from bench.commands.utils import (start, restart, set_nginx_port, set_ssl_certificate, set_ssl_certificate_key, set_url_root,
 	set_mariadb_host, set_default_site, download_translations, shell, backup_site, backup_all_sites, release, renew_lets_encrypt,
-	disable_production, bench_src)
+	disable_production, bench_src, apps_status)
 bench_command.add_command(start)
 bench_command.add_command(restart)
 bench_command.add_command(set_nginx_port)
@@ -55,6 +55,7 @@ bench_command.add_command(release)
 bench_command.add_command(renew_lets_encrypt)
 bench_command.add_command(disable_production)
 bench_command.add_command(bench_src)
+bench_command.add_command(apps_status)
 
 from bench.commands.setup import setup
 bench_command.add_command(setup)

--- a/bench/commands/utils.py
+++ b/bench/commands/utils.py
@@ -143,3 +143,9 @@ def bench_src():
 	"""Prints bench source folder path, which can be used as: cd `bench src` """
 	import bench
 	print(os.path.dirname(bench.__path__[0]))
+
+@click.command('status')
+def apps_status():
+	""" Give git status for every app """ 
+	from bench.utils import check_apps_status
+	check_apps_status()

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -759,3 +759,11 @@ def run_playbook(playbook_name, extra_vars=None):
 	if extra_vars:
 		args.extend(['-e', json.dumps(extra_vars)])
 	subprocess.check_call(args, cwd=os.path.join(os.path.dirname(bench.__path__[0]), 'playbooks'))
+
+
+def check_apps_status():
+	for app in os.listdir('./apps'):
+		if os.path.isdir(os.path.join('./apps', app)):
+			print app.upper()
+			exec_cmd('git status', os.path.join('apps', app))
+			print "\n"


### PR DESCRIPTION
Current command : `bench status`


Example Output : 

```
FRAPPE
INFO:bench.utils:git status -sb
## customv7...upstream/customv7
 M frappe/utils/oauth.py


ERPNEXT
INFO:bench.utils:git status -sb
## customv7...upstream/customv7
```
