### PR TITLE
Update Link for wkhtml

### DIFF
--- a/install_scripts/setup_frappe.sh
+++ b/install_scripts/setup_frappe.sh
@@ -240,7 +240,7 @@ install_wkhtmltopdf_centos () {
 		return 0
 	fi
 	RPM="wkhtmltox-0.12.2.1_linux-$OS$OS_VER-$WK_ARCH.rpm"
-	run_cmd wget http://download.gna.org/wkhtmltopdf/0.12/0.12.2.1/$RPM
+	run_cmd wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.2.1/$RPM
 	rpm --quiet -q wkhtmltox || run_cmd rpm -Uvh $RPM
 }
 
@@ -257,7 +257,7 @@ install_wkhtmltopdf_deb () {
 		WK_VER="jessie"
 	fi
 
-	run_cmd wget http://download.gna.org/wkhtmltopdf/0.12/0.12.2.1/wkhtmltox-0.12.2.1_linux-$WK_VER-$WK_ARCH.deb
+	run_cmd wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.2.1/wkhtmltox-0.12.2.1_linux-$WK_VER-$WK_ARCH.deb
 	run_cmd dpkg -i wkhtmltox-0.12.2.1_linux-$WK_VER-$WK_ARCH.deb
 }
 


### PR DESCRIPTION
to https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.2.1

Hi,

Was trying to build this using docker from **cloudhsiao/erpnext**. Failed for unreachable wkhtmltopdf domain link: http://download.gna.org/wkhtmltopdf/0.12/0.12.2.1/wkhtmltox-0.12.2.1_linux-trusty-amd64.deb

Have updated in the PR. If you can please update this.

Nice work on the project !