### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ python:
   - "2.7"
 
 install:
+  - sudo rm /etc/apt/sources.list.d/docker.list
+  - sudo pip install urllib3 pyOpenSSL ndg-httpsclient pyasn1
   - sudo apt-get purge -y mysql-common mysql-server mysql-client
   - sudo apt-get install --only-upgrade -y git
   - mkdir -p ~/.bench

--- a/bench/tests/test_init.py
+++ b/bench/tests/test_init.py
@@ -212,7 +212,7 @@ class TestBenchInit(unittest.TestCase):
 		self.assert_exists(python_path, "site-packages", "pip")
 
 		site_packages = os.listdir(os.path.join(python_path, "site-packages"))
-		self.assertTrue(any(package.startswith("mysqlclient-1.3.8") for package in site_packages))
+		self.assertTrue(any(package.startswith("mysqlclient-1.3.10") for package in site_packages))
 
 	def assert_config(self, bench_name):
 		for config, search_key in (

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -2,6 +2,7 @@ import os, sys, shutil, subprocess, logging, itertools, requests, json, platform
 from distutils.spawn import find_executable
 import bench
 from bench import env
+from six import iteritems
 
 class PatchError(Exception):
 	pass
@@ -410,7 +411,7 @@ def update_npm_packages(bench_path='.'):
 			with open(package_json_path, "r") as f:
 				app_package_json = json.loads(f.read())
 				# package.json is usually a dict in a dict
-				for key, value in app_package_json.iteritems():
+				for key, value in iteritems(app_package_json):
 					if not key in package_json:
 						package_json[key] = value
 					else:

--- a/playbooks/install.py
+++ b/playbooks/install.py
@@ -61,7 +61,7 @@ def install_bench(args):
 	# Restricting ansible version due to following bug in ansible 2.1
 	# https://github.com/ansible/ansible-modules-core/issues/3752
 	success = run_os_command({
-		'pip': "sudo pip install 'ansible==2.0.2.0'"
+		'pip': "sudo pip install ansible"
 	})
 
 	if not success:


### PR DESCRIPTION
After Travis changed its Trusy image, builds started failing. I traced it to the fact Travis `get_url` is making use of the system python interpreter (2.7.6). Python 2.7.6 does not support SNI thereby causing the download of `wkhtmltopdf` to fail.

- Upgrades ansible to 2.3.1
- Install urllib3, pyOpenSSL, ndg-httpsclient, pyasn1
- fix test case which was looking for mysqlclient-1.3.8 while our requirement in frappe/frappe is mysqlclient-1.3.10