### PR TITLE
Bench py3 compatibility: Refactor `setup_env`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,4 @@ script:
   - sudo pip install -e ~/.bench
   # - sudo python -m unittest bench.tests.test_setup_production.TestSetupProduction.test_setup_production_v6
   - sudo python -m unittest -v bench.tests.test_setup_production
+  - sudo python -m unittest -v bench.tests.test_utils

--- a/bench/app.py
+++ b/bench/app.py
@@ -48,7 +48,7 @@ def write_appstxt(apps, bench_path='.'):
 	with open(os.path.join(bench_path, 'sites', 'apps.txt'), 'w') as f:
 		return f.write('\n'.join(apps))
 
-def get_app(git_url, branch=None, bench_path='.', build_asset_files=True, verbose=False):
+def get_app(git_url, branch=None, bench_path='.', build_asset_files=True, verbose=False, python_version='python2'):
 	#less verbose app install
 	if '/' not in git_url:
 		git_url = 'https://github.com/frappe/' + git_url
@@ -81,7 +81,7 @@ def get_app(git_url, branch=None, bench_path='.', build_asset_files=True, verbos
 	if conf.get('restart_supervisor_on_update'):
 		restart_supervisor_processes(bench_path=bench_path)
 
-def new_app(app, bench_path='.'):
+def new_app(app, bench_path='.', python_version='python2'):
 	# For backwards compatibility
 	app = app.lower().replace(" ", "_").replace("-", "_")
 	logger.info('creating new app {}'.format(app))
@@ -95,7 +95,7 @@ def new_app(app, bench_path='.'):
 		run_frappe_cmd('make-app', apps, app, bench_path=bench_path)
 	install_app(app, bench_path=bench_path)
 
-def install_app(app, bench_path='.', verbose=False, no_cache=False):
+def install_app(app, bench_path='.', verbose=False, no_cache=False, python_version='python2'):
 	logger.info('installing {}'.format(app))
 	# find_links = '--find-links={}'.format(conf.get('wheel_cache_dir')) if conf.get('wheel_cache_dir') else ''
 	find_links = ''
@@ -107,7 +107,7 @@ def install_app(app, bench_path='.', verbose=False, no_cache=False):
 				find_links=find_links))
 	add_to_appstxt(app, bench_path=bench_path)
 
-def remove_app(app, bench_path='.'):
+def remove_app(app, bench_path='.', python_version='python2'):
 	if not app in get_apps(bench_path):
 		print("No app named {0}".format(app))
 		sys.exit(1)

--- a/bench/commands/make.py
+++ b/bench/commands/make.py
@@ -10,49 +10,54 @@ import click
 @click.option('--no-backups',is_flag=True, help="Run migrations for all sites in the bench")
 @click.option('--no-auto-update',is_flag=True, help="Build JS and CSS artifacts for the bench")
 @click.option('--verbose',is_flag=True, help="Verbose output during install")
+@click.option('--python-version', default="python2", help="Python version to use ('python2 or python3')")
 def init(path, apps_path, frappe_path, frappe_branch, no_procfile, no_backups,
-		no_auto_update, clone_from, verbose):
+		no_auto_update, clone_from, verbose, python_version):
 	"Create a new bench"
 	from bench.utils import init
 	init(path, apps_path=apps_path, no_procfile=no_procfile, no_backups=no_backups,
 			no_auto_update=no_auto_update, frappe_path=frappe_path, frappe_branch=frappe_branch,
-			verbose=verbose, clone_from=clone_from)
+			verbose=verbose, clone_from=clone_from, python_version=python_version)
 	click.echo('Bench {} initialized'.format(path))
 
 
 @click.command('get-app')
 @click.argument('name', nargs=-1) # Dummy argument for backward compatibility
 @click.argument('git-url')
+@click.option('--python-version', default="python2", help="Python version to use ('python2 or python3')")
 @click.option('--branch', default=None, help="branch to checkout")
-def get_app(git_url, branch, name=None):
+def get_app(git_url, branch, python_version, name=None):
 	"clone an app from the internet and set it up in your bench"
 	from bench.app import get_app
-	get_app(git_url, branch=branch)
+	get_app(git_url, branch=branch, python_version=python_version)
 
 
 @click.command('new-app')
 @click.argument('app-name')
-def new_app(app_name):
+@click.option('--python-version', default="python2", help="Python version to use ('python2 or python3')")
+def new_app(app_name, python_version):
 	"start a new app"
 	from bench.app import new_app
-	new_app(app_name)
+	new_app(app_name, python_version=python_version)
 
 
 @click.command('remove-app')
 @click.argument('app-name')
-def remove_app(app_name):
+@click.option('--python-version', default="python2", help="Python version to use ('python2 or python3')")
+def remove_app(app_name, python_version):
 	"completely remove app from bench"
 	from bench.app import remove_app
-	remove_app(app_name)
+	remove_app(app_name, python_version=python_version)
 
 
 @click.command('new-site')
-@click.option('--mariadb-root-password', help="MariaDB root password")
-@click.option('--admin-password', help="admin password to set for site")
+@click.option('--mariadb-root-password', default=None, help="MariaDB root password")
+@click.option('--admin-password', default=None, help="admin password to set for site")
+@click.option('--python-version', default="python2", help="Python version to use ('python2 or python3')")
 @click.argument('site')
-def new_site(site, mariadb_root_password=None, admin_password=None):
+def new_site(site, mariadb_root_password, admin_password, python_version):
 	"Create a new site in the bench"
 	from bench.utils import new_site
-	new_site(site, mariadb_root_password=mariadb_root_password, admin_password=admin_password)
+	new_site(site, mariadb_root_password=mariadb_root_password, admin_password=admin_password, python_version=python_version)
 
 

--- a/bench/tests/test_utils.py
+++ b/bench/tests/test_utils.py
@@ -1,0 +1,64 @@
+import os
+import shutil
+import unittest
+
+from bench.utils import is_valid_python_name, get_env_names, setup_env
+import six
+
+
+# adapted from: https://stackoverflow.com/a/2656405/806374 to be python 3
+# compatible
+def onerror(func, path, exc_info):
+	"""
+	Error handler for ``shutil.rmtree``.
+
+	If the error is due to an access error (read only file)
+	it attempts to add write permission and then retries.
+
+	If the error is for another reason it re-raises the error.
+
+	Usage : ``shutil.rmtree(path, onerror=onerror)``
+	"""
+	import stat
+	if not os.access(path, os.W_OK):
+		# Is the error an access error ?
+		os.chmod(path, stat.S_IWUSR)
+		func(path)
+	else:
+		six.reraise(exc_info)
+
+
+class TestUtils(unittest.TestCase):
+	def tearDown(self):
+		if os.path.exists('env'):
+			shutil.rmtree('env', onerror=onerror)
+		if os.path.exists('env3'):
+			shutil.rmtree('env3', onerror=onerror)
+
+	def test_is_valid_python_name(self):
+		self.assertEqual(is_valid_python_name('python2'), True)
+		self.assertEqual(is_valid_python_name('python3'), True)
+		self.assertEqual(is_valid_python_name(''), False)
+		self.assertEqual(is_valid_python_name(True), False)
+		self.assertEqual(is_valid_python_name(False), False)
+		self.assertEqual(is_valid_python_name('test_fail'), False)
+
+	def test_get_env_names(self):
+		if not os.path.exists('env'):
+			os.makedirs('env')
+		self.assertEqual(sorted(get_env_names()), ['env'])
+
+		if not os.path.exists('env3'):
+			os.makedirs('env3')
+		self.assertEqual(sorted(get_env_names()), ['env', 'env3'])
+
+	def test_setup_env(self):
+		with self.assertRaises(SystemExit) as test_case:
+			setup_env(python_version='test_to_fail')
+		self.assertEqual(test_case.exception.code, 1)
+
+		setup_env()
+		self.assertIn('env', get_env_names())
+
+		setup_env(python_version='python3')
+		self.assertIn('env3', get_env_names())

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -14,6 +14,11 @@ logger = logging.getLogger(__name__)
 
 folders_in_bench = ('apps', 'sites', 'config', 'logs', 'config/pids')
 
+
+def is_valid_python_name(py_version):
+	return py_version in ['python2', 'python3']
+
+
 def get_frappe(bench_path='.', python_version='python2'):
 	frappe = get_env_cmd('frappe', bench_path=bench_path)
 	if not os.path.exists(frappe):

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -14,19 +14,19 @@ logger = logging.getLogger(__name__)
 
 folders_in_bench = ('apps', 'sites', 'config', 'logs', 'config/pids')
 
-def get_frappe(bench_path='.'):
+def get_frappe(bench_path='.', python_version='python2'):
 	frappe = get_env_cmd('frappe', bench_path=bench_path)
 	if not os.path.exists(frappe):
 		print('frappe app is not installed. Run the following command to install frappe')
 		print('bench get-app https://github.com/frappe/frappe.git')
 	return frappe
 
-def get_env_cmd(cmd, bench_path='.'):
+def get_env_cmd(cmd, bench_path='.', python_version='python2'):
 	return os.path.abspath(os.path.join(bench_path, 'env', 'bin', cmd))
 
 def init(path, apps_path=None, no_procfile=False, no_backups=False,
 		no_auto_update=False, frappe_path=None, frappe_branch=None, wheel_cache_dir=None,
-		verbose=False, clone_from=None):
+		verbose=False, clone_from=None, python_version='python2'):
 	from .app import get_app, install_apps_from_path
 	from .config.common_site_config import make_config
 	from .config import redis
@@ -130,7 +130,7 @@ def exec_cmd(cmd, cwd='.'):
 	if return_code > 0:
 		raise CommandFailedError(cmd)
 
-def setup_env(bench_path='.'):
+def setup_env(bench_path='.', python_version='python2'):
 	exec_cmd('virtualenv -q {} -p {}'.format('env', sys.executable), cwd=bench_path)
 	exec_cmd('./env/bin/pip -q install --upgrade pip', cwd=bench_path)
 	exec_cmd('./env/bin/pip -q install wheel', cwd=bench_path)
@@ -141,7 +141,7 @@ def setup_socketio(bench_path='.'):
 	exec_cmd("npm install socket.io redis express superagent cookie", cwd=bench_path)
 
 
-def new_site(site, mariadb_root_password=None, admin_password=None, bench_path='.'):
+def new_site(site, mariadb_root_password=None, admin_password=None, bench_path='.', python_version='python2'):
 	"""
 	Creates a new site in the specified bench, default is current bench
 	"""

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -21,6 +21,11 @@ def is_valid_python_name(py_version):
 	return py_version in ['python2', 'python3']
 
 
+def get_env_names(bench_path='.'):
+	env_names = [dir_name for dir_name in os.listdir(bench_path) if dir_name in ['env', 'env3']]
+	return env_names
+
+
 def get_frappe(bench_path='.', python_version='python2'):
 	frappe = get_env_cmd('frappe', bench_path=bench_path)
 	if not os.path.exists(frappe):

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -169,8 +169,15 @@ def setup_env(bench_path='.', python_version='python2'):
 	# check if env is already created
 	env_names = get_env_names()
 	if env in env_names:
-		logger.info('Virtualenv {} has already been set up'.format(env))
+		logger.info('Virtualenv {} has already been set up.'.format(env))
 		return
+
+	# check if specified `python_version` interpreter is available
+	python_path = os.popen('which {}'.format(python_version)).read()
+	if not python_path:
+		logger.info("There's no {} on your computer.".format(python_version))
+		sys.exit(1)
+	logger.info("using ", python_path)
 
 	exec_cmd('virtualenv -q {} -p {}'.format('env', sys.executable), cwd=bench_path)
 	exec_cmd('./env/bin/pip -q install --upgrade pip', cwd=bench_path)

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -14,6 +14,8 @@ logger = logging.getLogger(__name__)
 
 folders_in_bench = ('apps', 'sites', 'config', 'logs', 'config/pids')
 
+version_map = {'python2': 'env', 'python3': 'env3'}
+
 
 def is_valid_python_name(py_version):
 	return py_version in ['python2', 'python3']

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -73,7 +73,7 @@ def init(path, apps_path=None, no_procfile=False, no_backups=False,
 
 	setup_logging()
 
-	setup_env(bench_path=path)
+	setup_env(bench_path=path, python_version=python_version)
 
 	make_config(path)
 
@@ -160,6 +160,12 @@ def exec_cmd(cmd, cwd='.'):
 		raise CommandFailedError(cmd)
 
 def setup_env(bench_path='.', python_version='python2'):
+	if is_valid_python_name(python_version):
+		env = version_map.get(python_version)
+	else:
+		logger.info('{} is not valid. Use either "python2" or "python3"'.format(python_version))
+		sys.exit(1)
+
 	exec_cmd('virtualenv -q {} -p {}'.format('env', sys.executable), cwd=bench_path)
 	exec_cmd('./env/bin/pip -q install --upgrade pip', cwd=bench_path)
 	exec_cmd('./env/bin/pip -q install wheel', cwd=bench_path)

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -26,6 +26,23 @@ def get_env_names(bench_path='.'):
 	return env_names
 
 
+def add_env(env_name, python_version, bench_path='.'):
+	if is_valid_python_name(python_version):
+		exec_cmd('virtualenv -q {0} -p `which {1}`'.format(env_name, python_version), cwd=bench_path)
+		exec_cmd('./{0}/bin/python ./{0}/bin/pip -q install --upgrade pip'.format(env_name),
+				 cwd=bench_path)
+		exec_cmd('./{0}/bin/python ./{0}/bin/pip -q install wheel'.format(env_name), cwd=bench_path)
+		# exec_cmd('./env/bin/pip -q install https://github.com/frappe/MySQLdb1/archive/MySQLdb-1.2.5-patched.tar.gz', cwd=bench_path)
+		exec_cmd(
+			'./{0}/bin/python ./{0}/bin/pip -q install -e git+https://github.com/frappe/python-pdfkit.git#egg=pdfkit'.format(
+				env_name),
+			cwd=bench_path
+		)
+	else:
+		logger.info("Operation failed. Python version should be either 'python2' or 'python3'")
+		sys.exit(1)
+
+
 def get_frappe(bench_path='.', python_version='python2'):
 	frappe = get_env_cmd('frappe', bench_path=bench_path)
 	if not os.path.exists(frappe):

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -178,7 +178,6 @@ def setup_env(bench_path='.', python_version='python2'):
 	if not python_path:
 		logger.info("There's no {} on your computer.".format(python_version))
 		sys.exit(1)
-	logger.info("using ", python_path)
 
 	add_env(env, python_version=python_version, bench_path=bench_path)
 

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -2,6 +2,7 @@ import os, sys, shutil, subprocess, logging, itertools, requests, json, platform
 from distutils.spawn import find_executable
 import bench
 from bench import env
+from six import iteritems
 
 class PatchError(Exception):
 	pass
@@ -410,7 +411,7 @@ def update_npm_packages(bench_path='.'):
 			with open(package_json_path, "r") as f:
 				app_package_json = json.loads(f.read())
 				# package.json is usually a dict in a dict
-				for key, value in app_package_json.iteritems():
+				for key, value in iteritems(app_package_json):
 					if not key in package_json:
 						package_json[key] = value
 					else:

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -166,6 +166,12 @@ def setup_env(bench_path='.', python_version='python2'):
 		logger.info('{} is not valid. Use either "python2" or "python3"'.format(python_version))
 		sys.exit(1)
 
+	# check if env is already created
+	env_names = get_env_names()
+	if env in env_names:
+		logger.info('Virtualenv {} has already been set up'.format(env))
+		return
+
 	exec_cmd('virtualenv -q {} -p {}'.format('env', sys.executable), cwd=bench_path)
 	exec_cmd('./env/bin/pip -q install --upgrade pip', cwd=bench_path)
 	exec_cmd('./env/bin/pip -q install wheel', cwd=bench_path)

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -159,6 +159,7 @@ def exec_cmd(cmd, cwd='.'):
 	if return_code > 0:
 		raise CommandFailedError(cmd)
 
+
 def setup_env(bench_path='.', python_version='python2'):
 	if is_valid_python_name(python_version):
 		env = version_map.get(python_version)
@@ -179,11 +180,8 @@ def setup_env(bench_path='.', python_version='python2'):
 		sys.exit(1)
 	logger.info("using ", python_path)
 
-	exec_cmd('virtualenv -q {} -p {}'.format('env', sys.executable), cwd=bench_path)
-	exec_cmd('./env/bin/pip -q install --upgrade pip', cwd=bench_path)
-	exec_cmd('./env/bin/pip -q install wheel', cwd=bench_path)
-	# exec_cmd('./env/bin/pip -q install https://github.com/frappe/MySQLdb1/archive/MySQLdb-1.2.5-patched.tar.gz', cwd=bench_path)
-	exec_cmd('./env/bin/pip -q install -e git+https://github.com/frappe/python-pdfkit.git#egg=pdfkit', cwd=bench_path)
+	add_env(env, python_version=python_version, bench_path=bench_path)
+
 
 def setup_socketio(bench_path='.'):
 	exec_cmd("npm install socket.io redis express superagent cookie", cwd=bench_path)


### PR DESCRIPTION
This is the first of the series of commit towards the goal of python 3 compatibility and the ability to run bench commands using python 2 and 3 in parallel.

The PR is a refactor of `setup_env`. A few of others to be refactored are:
- `install_app`
- `get_frappe`
- `run_frappe_cmd`
- etc