### PR TITLE
Added docker specific changes to bench

### DIFF
--- a/bench/commands/make.py
+++ b/bench/commands/make.py
@@ -11,12 +11,12 @@ import click
 @click.option('--no-auto-update',is_flag=True, help="Build JS and CSS artifacts for the bench")
 @click.option('--verbose',is_flag=True, help="Verbose output during install")
 def init(path, apps_path, frappe_path, frappe_branch, no_procfile, no_backups,
-		no_auto_update, clone_from, verbose):
+		no_auto_update, clone_from, verbose, skip_bench_mkdir):
 	"Create a new bench"
 	from bench.utils import init
 	init(path, apps_path=apps_path, no_procfile=no_procfile, no_backups=no_backups,
 			no_auto_update=no_auto_update, frappe_path=frappe_path, frappe_branch=frappe_branch,
-			verbose=verbose, clone_from=clone_from)
+			verbose=verbose, clone_from=clone_from, skip_bench_mkdir=skip_bench_mkdir)
 	click.echo('Bench {} initialized'.format(path))
 
 
@@ -54,5 +54,3 @@ def new_site(site, mariadb_root_password=None, admin_password=None):
 	"Create a new site in the bench"
 	from bench.utils import new_site
 	new_site(site, mariadb_root_password=mariadb_root_password, admin_password=admin_password)
-
-

--- a/bench/commands/make.py
+++ b/bench/commands/make.py
@@ -10,13 +10,15 @@ import click
 @click.option('--no-backups',is_flag=True, help="Run migrations for all sites in the bench")
 @click.option('--no-auto-update',is_flag=True, help="Build JS and CSS artifacts for the bench")
 @click.option('--verbose',is_flag=True, help="Verbose output during install")
+@click.option('--skip-bench-mkdir', is_flag=True, help="Skip mkdir frappe-bench")
+@click.option('--skip-redis-config-generation', is_flag=True, help="Skip redis config generation if already specifying the common-site-config file")
 def init(path, apps_path, frappe_path, frappe_branch, no_procfile, no_backups,
-		no_auto_update, clone_from, verbose, skip_bench_mkdir):
+		no_auto_update, clone_from, verbose, skip_bench_mkdir, skip_redis_config_generation):
 	"Create a new bench"
 	from bench.utils import init
 	init(path, apps_path=apps_path, no_procfile=no_procfile, no_backups=no_backups,
 			no_auto_update=no_auto_update, frappe_path=frappe_path, frappe_branch=frappe_branch,
-			verbose=verbose, clone_from=clone_from, skip_bench_mkdir=skip_bench_mkdir)
+			verbose=verbose, clone_from=clone_from, skip_bench_mkdir=skip_bench_mkdir, skip_redis_config_generation=skip_redis_config_generation)
 	click.echo('Bench {} initialized'.format(path))
 
 

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -26,19 +26,31 @@ def get_env_cmd(cmd, bench_path='.'):
 
 def init(path, apps_path=None, no_procfile=False, no_backups=False,
 		no_auto_update=False, frappe_path=None, frappe_branch=None, wheel_cache_dir=None,
-		verbose=False, clone_from=None):
+		verbose=False, clone_from=None, skip_bench_mkdir=False):
 	from .app import get_app, install_apps_from_path
 	from .config.common_site_config import make_config
 	from .config import redis
 	from .config.procfile import setup_procfile
 	from bench.patches import set_all_patches_executed
 
-	if os.path.exists(path):
-		print('Directory {} already exists!'.format(path))
-		raise Exception("Site directory already exists")
-		# sys.exit(1)
+	if(skip_bench_mkdir):
+		## Remove the files and subfolders inside frappe bench
+		folder = path
+		for the_file in os.listdir(folder):
+			file_path = os.path.join(folder, the_file)
+			try:
+				if os.path.isfile(file_path):
+					os.unlink(file_path)
+				elif os.path.isdir(file_path): shutil.rmtree(file_path)
+			except Exception as e:
+				print(e)
+	else:
+		if os.path.exists(path):
+			print('Directory {} already exists!'.format(path))
+			raise Exception("Site directory already exists")
+			# sys.exit(1)
+		os.makedirs(path)
 
-	os.makedirs(path)
 	for dirname in folders_in_bench:
 		os.mkdir(os.path.join(path, dirname))
 
@@ -421,7 +433,7 @@ def update_npm_packages(bench_path='.'):
 							package_json[key].extend(value)
 						else:
 							package_json[key] = value
-	
+
 	if package_json is {}:
 		with open(os.path.join(os.path.dirname(__file__), 'package.json'), 'r') as f:
 			package_json = json.loads(f.read())
@@ -651,7 +663,7 @@ def update_translations(app, lang):
 				f.flush()
 
 	print('downloaded for', app, lang)
-	
+
 def download_chart_of_accounts():
 	charts_dir = os.path.join('apps', "erpnext", "erpnext", 'accounts', 'chart_of_accounts', "submitted")
 	csv_file = os.path.join(translations_dir, lang + '.csv')

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -85,7 +85,7 @@ def init(path, apps_path=None, no_procfile=False, no_backups=False,
 	set_all_patches_executed(bench_path=path)
 	build_assets(bench_path=path)
 
-	if(not skip_redis_config_generation):
+	if not skip_redis_config_generation:
 		redis.generate_config(path)
 
 	if not no_procfile:

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -4,6 +4,7 @@ import bench
 from bench import env
 from six import iteritems
 
+
 class PatchError(Exception):
 	pass
 
@@ -34,29 +35,16 @@ def init(path, apps_path=None, no_procfile=False, no_backups=False,
 	from bench.patches import set_all_patches_executed
 
 	if(skip_bench_mkdir):
-		## Remove the files and subfolders inside frappe bench
-		# folder = path
-		# for the_file in os.listdir(folder):
-		# 	file_path = os.path.join(folder, the_file)
-		# 	try:
-		# 		if os.path.isfile(file_path):
-		# 			os.unlink(file_path)
-		# 		elif os.path.isdir(file_path): shutil.rmtree(file_path)
-		# 	except Exception as e:
-		# 		print(e)
 		pass
 	else:
 		if os.path.exists(path):
 			print('Directory {} already exists!'.format(path))
 			raise Exception("Site directory already exists")
-			# sys.exit(1)
 		os.makedirs(path)
 
 	for dirname in folders_in_bench:
 		try:
-			print(dirname+'\n')
 			os.makedirs(os.path.join(path, dirname))
-			break
 		except OSError, e:
 			if e.errno != os.errno.EEXIST:
 				pass

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -54,6 +54,7 @@ def init(path, apps_path=None, no_procfile=False, no_backups=False,
 
 	for dirname in folders_in_bench:
 		try:
+			print(dirname+'\n')
 			os.makedirs(os.path.join(path, dirname))
 			break
 		except OSError, e:

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -27,7 +27,7 @@ def get_env_cmd(cmd, bench_path='.'):
 
 def init(path, apps_path=None, no_procfile=False, no_backups=False,
 		no_auto_update=False, frappe_path=None, frappe_branch=None, wheel_cache_dir=None,
-		verbose=False, clone_from=None, skip_bench_mkdir=False,skip_redis_config_generation=False):
+		verbose=False, clone_from=None, skip_bench_mkdir=False, skip_redis_config_generation=False):
 	from .app import get_app, install_apps_from_path
 	from .config.common_site_config import make_config
 	from .config import redis

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -53,12 +53,7 @@ def init(path, apps_path=None, no_procfile=False, no_backups=False,
 		os.makedirs(path)
 
 	for dirname in folders_in_bench:
-		try:
-			os.makedirs(os.path.join(path, dirname))
-			break
-		except OSError, e:
-			if e.errno != os.errno.EEXIST:
-				pass
+		os.mkdir(os.path.join(path, dirname))
 
 	setup_logging()
 

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -53,7 +53,12 @@ def init(path, apps_path=None, no_procfile=False, no_backups=False,
 		os.makedirs(path)
 
 	for dirname in folders_in_bench:
-		os.mkdir(os.path.join(path, dirname))
+		try:
+			os.makedirs(os.path.join(path, dirname))
+			break
+		except OSError, e:
+			if e.errno != os.errno.EEXIST:
+				pass
 
 	setup_logging()
 


### PR DESCRIPTION
- Added skip-bench-mkdir as a parameter to the bench init command which skips frappe_bench mkdir if it already exists. 
- Added skip-redis-config-generation as a click option to the bench init command to skip the redis.generate_config method
- Added a try catch block to catch and except file exists Error 17 exception [see lines 56-61 in utils.py]