### PR TITLE
Decode redis version_string

### DIFF
--- a/bench/config/redis.py
+++ b/bench/config/redis.py
@@ -59,7 +59,7 @@ def get_redis_version():
 	version_string = subprocess.check_output('redis-server --version', shell=True).strip()
 
 	# extract version number from string
-	version = re.findall("\d+\.\d+", version_string)
+	version = re.findall("\d+\.\d+", version_string.decode("utf-8"))
 	if not version:
 		return None
 


### PR DESCRIPTION
Bench port

Trying to install frappe with Python 3 after applying [Frappe PR 3848](https://github.com/frappe/frappe/pull/3848) yields following error traceback

```
Traceback (most recent call last):
  File "/home/frappe/aditya/485e242e/3/bin/bench", line 11, in <module>
    load_entry_point('bench', 'console_scripts', 'bench')()
  File "/home/frappe/aditya/485e242e/bench-repo/bench/cli.py", line 40, in cli
    bench_command()
  File "/home/frappe/aditya/485e242e/3/lib/python3.5/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/home/frappe/aditya/485e242e/3/lib/python3.5/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/home/frappe/aditya/485e242e/3/lib/python3.5/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/aditya/485e242e/3/lib/python3.5/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/frappe/aditya/485e242e/3/lib/python3.5/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/home/frappe/aditya/485e242e/bench-repo/bench/commands/make.py", line 19, in init
    verbose=verbose, clone_from=clone_from)
  File "/home/frappe/aditya/485e242e/bench-repo/bench/utils.py", line 69, in init
    redis.generate_config(path)
  File "/home/frappe/aditya/485e242e/bench-repo/bench/config/redis.py", line 39, in generate_config
    "redis_version": get_redis_version(),
  File "/home/frappe/aditya/485e242e/bench-repo/bench/config/redis.py", line 62, in get_redis_version
    version = re.findall("\d+\.\d+", version_string)
  File "/home/frappe/aditya/485e242e/3/lib/python3.5/re.py", line 213, in findall
    return _compile(pattern, flags).findall(string)
TypeError: cannot use a string pattern on a bytes-like object
```
Fixed it by decoding `version_string`

In Python 2 you could use the `str` type for both text and binary data.

Python 3.0 uses the concepts of text and (binary) data instead of Unicode strings and 8-bit strings. All text is Unicode; however encoded Unicode is represented as binary data. The type used to hold text is `str`, the type used to hold data is bytes. The biggest difference with the 2.x situation is that any attempt to mix text and data in Python 3.0 raises `TypeError`,

As the `str` and `bytes` types cannot be mixed, you must always explicitly convert between them. Use `str.encode()` to go from `str` to `bytes`, and `bytes.decode()` to go from `bytes` to `str`.