### PR TITLE
Fix determine current branch

### DIFF
--- a/bench/app.py
+++ b/bench/app.py
@@ -174,7 +174,7 @@ def get_current_frappe_version(bench_path='.'):
 
 def get_current_branch(app, bench_path='.'):
 	repo_dir = get_repo_dir(app, bench_path=bench_path)
-	return get_cmd_output("basename $(git symbolic-ref -q HEAD)", cwd=repo_dir)
+	return get_cmd_output("git branch | grep \* | cut -d ' ' -f2", cwd=repo_dir)
 
 def get_remote(app, bench_path='.'):
 	repo_dir = get_repo_dir(app, bench_path=bench_path)


### PR DESCRIPTION
This fix to handle branches with slashes, when using gitflow for example, you will have branches with names hotfix/branch-name. The bench commands fails with these branches names because it ignores anything before the slash. This fix would fix this issue to get the full name of the branch name