### PR TITLE
Replaced Py2 'except' syntax with Py3 syntax

### DIFF
--- a/bench/utils.py
+++ b/bench/utils.py
@@ -45,7 +45,7 @@ def init(path, apps_path=None, no_procfile=False, no_backups=False,
 	for dirname in folders_in_bench:
 		try:
 			os.makedirs(os.path.join(path, dirname))
-		except OSError, e:
+		except OSError as e:
 			if e.errno != os.errno.EEXIST:
 				pass
 


### PR DESCRIPTION
Bench port

Trying to install frappe with Python 3 yields following error traceback

```
Traceback (most recent call last):
  File "/home/frappe/aditya/c6345ee5/3/bin/bench", line 11, in <module>
    load_entry_point('bench', 'console_scripts', 'bench')()
  File "/home/frappe/aditya/c6345ee5/3/lib/python3.5/site-packages/pkg_resources/__init__.py", line 564, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/home/frappe/aditya/c6345ee5/3/lib/python3.5/site-packages/pkg_resources/__init__.py", line 2662, in load_entry_point
    return ep.load()
  File "/home/frappe/aditya/c6345ee5/3/lib/python3.5/site-packages/pkg_resources/__init__.py", line 2316, in load
    return self.resolve()
  File "/home/frappe/aditya/c6345ee5/3/lib/python3.5/site-packages/pkg_resources/__init__.py", line 2322, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/home/frappe/aditya/c6345ee5/bench-repo/bench/cli.py", line 3, in <module>
    from bench.utils import is_root, PatchError, drop_privileges, get_env_cmd, get_cmd_output, get_frappe
  File "/home/frappe/aditya/c6345ee5/bench-repo/bench/utils.py", line 48
    except OSError, e:
                  ^
SyntaxError: invalid syntax
```

Fixed it by replacing  `except Exception, e:` with `except Exception as e:`

Python 3 [PEP 3110](https://www.python.org/dev/peps/pep-3110/) introduced changed syntax for `except` clause