### PR TITLE
Decode byte string returned by subprocess.check_output

### DIFF
--- a/bench/app.py
+++ b/bench/app.py
@@ -119,7 +119,7 @@ def remove_app(app, bench_path='.'):
 	for site in os.listdir(site_path):
 		req_file = os.path.join(site_path, site, 'site_config.json')
 		if os.path.exists(req_file):
-			out = subprocess.check_output(["bench", "--site", site, "list-apps"], cwd=bench_path)
+			out = subprocess.check_output(["bench", "--site", site, "list-apps"], cwd=bench_path).decode()
 			if re.search(r'\b' + app + r'\b', out):
 				print("Cannot remove, app is installed on site: {0}".format(site))
 				sys.exit(1)
@@ -141,7 +141,7 @@ def pull_all_apps(bench_path='.', reset=False):
 		for app in get_apps(bench_path=bench_path):
 			app_dir = get_repo_dir(app, bench_path=bench_path)
 			if os.path.exists(os.path.join(app_dir, '.git')):
-				out = subprocess.check_output(["git", "status"], cwd=app_dir)
+				out = subprocess.check_output(["git", "status"], cwd=app_dir).decode()
 				if not re.search(r'nothing to commit, working (directory|tree) clean', out):
 					print('''
 
@@ -203,7 +203,7 @@ def get_current_branch(app, bench_path='.'):
 def get_remote(app, bench_path='.'):
 	repo_dir = get_repo_dir(app, bench_path=bench_path)
 	contents = subprocess.check_output(['git', 'remote', '-v'], cwd=repo_dir,
-									   stderr=subprocess.STDOUT)
+									   stderr=subprocess.STDOUT).decode()
 	if re.findall('upstream[\s]+', contents):
 		remote = 'upstream'
 	else:
@@ -237,7 +237,7 @@ def get_upstream_version(app, branch=None, bench_path='.'):
 	if not branch:
 		branch = get_current_branch(app, bench_path=bench_path)
 	try:
-		contents = subprocess.check_output(['git', 'show', 'upstream/{branch}:{app}/__init__.py'.format(branch=branch, app=app)], cwd=repo_dir, stderr=subprocess.STDOUT)
+		contents = subprocess.check_output(['git', 'show', 'upstream/{branch}:{app}/__init__.py'.format(branch=branch, app=app)], cwd=repo_dir, stderr=subprocess.STDOUT).decode()
 	except subprocess.CalledProcessError as e:
 		if "Invalid object" in e.output:
 			return None
@@ -247,7 +247,7 @@ def get_upstream_version(app, branch=None, bench_path='.'):
 
 def get_upstream_url(app, bench_path='.'):
 	repo_dir = get_repo_dir(app, bench_path=bench_path)
-	return subprocess.check_output(['git', 'config', '--get', 'remote.upstream.url'], cwd=repo_dir).strip()
+	return subprocess.check_output(['git', 'config', '--get', 'remote.upstream.url'], cwd=repo_dir).decode().strip()
 
 def get_repo_dir(app, bench_path='.'):
 	return os.path.join(bench_path, 'apps', app)

--- a/bench/commands/git.py
+++ b/bench/commands/git.py
@@ -28,6 +28,6 @@ def remote_urls():
 
 		if os.path.exists(os.path.join(repo_dir, '.git')):
 			remote = get_remote(app)
-			remote_url = subprocess.check_output(['git', 'config', '--get', 'remote.{}.url'.format(remote)], cwd=repo_dir).strip()
+			remote_url = subprocess.check_output(['git', 'config', '--get', 'remote.{}.url'.format(remote)], cwd=repo_dir).decode().strip()
 			print("{app}	{remote_url}".format(app=app, remote_url=remote_url))
 

--- a/bench/config/redis.py
+++ b/bench/config/redis.py
@@ -56,7 +56,7 @@ def write_redis_config(template_name, context, bench_path):
 		f.write(template.render(**context))
 
 def get_redis_version():
-	version_string = subprocess.check_output('redis-server --version', shell=True).strip()
+	version_string = subprocess.check_output('redis-server --version', shell=True).decode().strip()
 
 	# extract version number from string
 	version = re.findall("\d+\.\d+", version_string)

--- a/bench/patches/v4/update_node.py
+++ b/bench/patches/v4/update_node.py
@@ -8,7 +8,7 @@ def execute(bench_path):
 
 
 	if node_exec:
-		result = subprocess.check_output([node_exec, '-v'])
+		result = subprocess.check_output([node_exec, '-v']).decode()
 	else:
 		click.echo('''
 		No node executable was found on your machine.

--- a/bench/tests/test_init.py
+++ b/bench/tests/test_init.py
@@ -115,7 +115,7 @@ class TestBenchInit(unittest.TestCase):
 		# install it to site
 		subprocess.check_output(["bench", "--site", site_name, "install-app", "erpnext"], cwd=bench_path)
 
-		out = subprocess.check_output(["bench", "--site", site_name, "list-apps"], cwd=bench_path)
+		out = subprocess.check_output(["bench", "--site", site_name, "list-apps"], cwd=bench_path).decode()
 		self.assertTrue("erpnext" in out)
 
 
@@ -142,12 +142,12 @@ class TestBenchInit(unittest.TestCase):
 		app_path = os.path.join(bench_path, "apps", "frappe")
 
 		bench.app.switch_branch(branch="master", apps=["frappe"], bench_path=bench_path, check_upgrade=False)
-		out = subprocess.check_output(['git', 'status'], cwd=app_path)
+		out = subprocess.check_output(['git', 'status'], cwd=app_path).decode()
 		self.assertTrue("master" in out)
 
 		# bring it back to develop!
 		bench.app.switch_branch(branch="develop", apps=["frappe"], bench_path=bench_path, check_upgrade=False)
-		out = subprocess.check_output(['git', 'status'], cwd=app_path)
+		out = subprocess.check_output(['git', 'status'], cwd=app_path).decode()
 		self.assertTrue("develop" in out)
 
 	def init_bench(self, bench_name, **kwargs):

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -101,12 +101,12 @@ def clone_apps_from(bench_path, clone_from):
 			# remove .egg-ino
 			subprocess.check_output(['rm', '-rf', app + '.egg-info'], cwd=app_path)
 
-			remotes = subprocess.check_output(['git', 'remote'], cwd=app_path).strip().split()
+			remotes = subprocess.check_output(['git', 'remote'], cwd=app_path).decode().strip().split()
 			if 'upstream' in remotes:
 				remote = 'upstream'
 			else:
 				remote = remotes[0]
-			branch = subprocess.check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD'], cwd=app_path).strip()
+			branch = subprocess.check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD'], cwd=app_path).decode().strip()
 			subprocess.check_output(['git', 'reset', '--hard'], cwd=app_path)
 			subprocess.check_output(['git', 'pull', '--rebase', remote, branch], cwd=app_path)
 
@@ -351,7 +351,7 @@ def check_git_for_shallow_clone():
 
 def get_cmd_output(cmd, cwd='.'):
 	try:
-		return subprocess.check_output(cmd, cwd=cwd, shell=True, stderr=open(os.devnull, 'wb')).strip()
+		return subprocess.check_output(cmd, cwd=cwd, shell=True, stderr=open(os.devnull, 'wb')).decode().strip()
 	except subprocess.CalledProcessError as e:
 		if e.output:
 			print(e.output)
@@ -367,7 +367,7 @@ def restart_supervisor_processes(bench_path='.', web_workers=False):
 		exec_cmd(cmd, cwd=bench_path)
 
 	else:
-		supervisor_status = subprocess.check_output(['sudo', 'supervisorctl', 'status'], cwd=bench_path)
+		supervisor_status = subprocess.check_output(['sudo', 'supervisorctl', 'status'], cwd=bench_path).decode()
 
 		if web_workers and '{bench_name}-web:'.format(bench_name=bench_name) in supervisor_status:
 			group = '{bench_name}-web:	'.format(bench_name=bench_name)
@@ -571,7 +571,7 @@ def get_frappe_cmd_output(*args, **kwargs):
 	bench_path = kwargs.get('bench_path', '.')
 	f = get_env_cmd('python', bench_path=bench_path)
 	sites_dir = os.path.join(bench_path, 'sites')
-	return subprocess.check_output((f, '-m', 'frappe.utils.bench_helper', 'frappe') + args, cwd=sites_dir)
+	return subprocess.check_output((f, '-m', 'frappe.utils.bench_helper', 'frappe') + args, cwd=sites_dir).decode()
 
 def validate_upgrade(from_ver, to_ver, bench_path='.'):
 	if to_ver >= 6:

--- a/vm/build.py
+++ b/vm/build.py
@@ -30,7 +30,7 @@ def update_latest():
 		json.dump(get_latest(), f)
 
 def get_latest():
-	md5 = subprocess.check_output("md5sum {}".format(get_filepath()), shell=True).split()[0]
+	md5 = subprocess.check_output("md5sum {}".format(get_filepath()), shell=True).decode().split()[0]
 	return {
 		"filename": get_filename(),
 		"md5": md5


### PR DESCRIPTION
Bench port

Trying to install frappe with Python 3 after applying #466 yields following error traceback

```
Traceback (most recent call last):
  File "/home/frappe/aditya/0a4b2ec7/3/bin/bench", line 11, in <module>
    load_entry_point('bench', 'console_scripts', 'bench')()
  File "/home/frappe/aditya/0a4b2ec7/bench-repo/bench/cli.py", line 40, in cli
    bench_command()
  File "/home/frappe/aditya/0a4b2ec7/3/lib/python3.5/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/home/frappe/aditya/0a4b2ec7/3/lib/python3.5/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/home/frappe/aditya/0a4b2ec7/3/lib/python3.5/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/aditya/0a4b2ec7/3/lib/python3.5/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/frappe/aditya/0a4b2ec7/3/lib/python3.5/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/home/frappe/aditya/0a4b2ec7/bench-repo/bench/commands/make.py", line 21, in init
    verbose=verbose, clone_from=clone_from, skip_bench_mkdir=skip_bench_mkdir, skip_redis_config_generation=skip_redis_config_generation)
  File "/home/frappe/aditya/0a4b2ec7/bench-repo/bench/utils.py", line 64, in init
    get_app(frappe_path, branch=frappe_branch, bench_path=path, build_asset_files=False, verbose=verbose)
  File "/home/frappe/aditya/0a4b2ec7/bench-repo/bench/app.py", line 58, in get_app
    shallow_clone = '--depth 1' if check_git_for_shallow_clone() else ''
  File "/home/frappe/aditya/0a4b2ec7/bench-repo/bench/utils.py", line 347, in check_git_for_shallow_clone
    git_version = get_git_version()
  File "/home/frappe/aditya/0a4b2ec7/bench-repo/bench/utils.py", line 334, in get_git_version
    version = '.'.join(version.split('.')[0:2])
TypeError: a bytes-like object is required, not 'str'

```

We traced the root to `get_cmd_output()` which calls `subprocess.check_output()` returning `bytes` instead of `str` and fixed it by explicitly decoding result of `subprocess.check_output()`

In Python 2 you could use the `str` type for both text and binary data.

Python 3.0 uses the concepts of text and (binary) data instead of Unicode strings and 8-bit strings. All text is Unicode; however encoded Unicode is represented as binary data. The type used to hold text is `str`, the type used to hold data is bytes. The biggest difference with the 2.x situation is that any attempt to mix text and data in Python 3.0 raises `TypeError`,

As the `str` and `bytes` types cannot be mixed, you must always explicitly convert between them. Use `str.encode()` to go from `str` to `bytes`, and `bytes.decode()` to go from `bytes` to `str`.