### PR TITLE
Use subprocess.check_output instead of Popen

### DIFF
--- a/bench/utils.py
+++ b/bench/utils.py
@@ -241,10 +241,10 @@ def add_to_crontab(line):
 		s.stdin.close()
 
 def read_crontab():
-	s = subprocess.Popen(["crontab", "-l"], stdin=subprocess.PIPE, stdout=subprocess.PIPE)
-	out = s.stdout.read()
-	s.stdout.close()
-	return out
+	try:
+		return subprocess.check_output(["crontab", "-l"]).decode()
+	except subprocess.CalledProcessError:
+		return b""
 
 def update_bench():
 	logger.info('updating bench')
@@ -696,10 +696,10 @@ def log_line(data, stream):
 	return sys.stdout.write(data)
 
 def get_output(*cmd):
-	s = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
-	out = s.stdout.read()
-	s.stdout.close()
-	return out
+	try:
+		return subprocess.check_output(cmd).decode()
+	except subprocess.CalledProcessError:
+		return b""
 
 def before_update(bench_path, requirements):
 	validate_pillow_dependencies(bench_path, requirements)


### PR DESCRIPTION
Bench port

Trying to install frappe with Python 3 after applying #467 yields following error traceback

```
Traceback (most recent call last):
  File "/home/frappe/aditya/b4e5700f/3/bin/bench", line 11, in <module>
    load_entry_point('bench', 'console_scripts', 'bench')()
  File "/home/frappe/aditya/b4e5700f/bench-repo/bench/cli.py", line 40, in cli
    bench_command()
  File "/home/frappe/aditya/b4e5700f/3/lib/python3.5/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/home/frappe/aditya/b4e5700f/3/lib/python3.5/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/home/frappe/aditya/b4e5700f/3/lib/python3.5/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/aditya/b4e5700f/3/lib/python3.5/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/frappe/aditya/b4e5700f/3/lib/python3.5/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/home/frappe/aditya/b4e5700f/bench-repo/bench/commands/make.py", line 21, in init
    verbose=verbose, clone_from=clone_from, skip_bench_mkdir=skip_bench_mkdir, skip_redis_config_generation=skip_redis_config_generation)
  File "/home/frappe/aditya/b4e5700f/bench-repo/bench/utils.py", line 83, in init
    setup_backups(bench_path=path)
  File "/home/frappe/aditya/b4e5700f/bench-repo/bench/utils.py", line 230, in setup_backups
    logfile=os.path.join(get_bench_dir(bench_path=bench_path), 'logs', 'backup.log')))
  File "/home/frappe/aditya/b4e5700f/bench-repo/bench/utils.py", line 234, in add_to_crontab
    if not line in current_crontab:
TypeError: a bytes-like object is required, not 'str'
```

We traced the root to `read_crontab()` which uses `subprocess.Popen()` and `subprocess.Popen.stdout.read` returning `bytes` instead of `str` and fixed it by using `subprocess.check_output()` and explicitly decoding its result

In Python 2 you could use the `str` type for both text and binary data.

Python 3.0 uses the concepts of text and (binary) data instead of Unicode strings and 8-bit strings. All text is Unicode; however encoded Unicode is represented as binary data. The type used to hold text is `str`, the type used to hold data is bytes. The biggest difference with the 2.x situation is that any attempt to mix text and data in Python 3.0 raises `TypeError`,

As the `str` and `bytes` types cannot be mixed, you must always explicitly convert between them. Use `str.encode()` to go from `str` to `bytes`, and `bytes.decode()` to go from `bytes` to `str`.