### PR TITLE
Encode strings before passing to stdin.write

### DIFF
--- a/bench/utils.py
+++ b/bench/utils.py
@@ -236,8 +236,8 @@ def add_to_crontab(line):
 		if platform.system() == 'FreeBSD':
 			cmd = ["crontab", "-"]
 		s = subprocess.Popen(cmd, stdin=subprocess.PIPE)
-		s.stdin.write(current_crontab)
-		s.stdin.write(line + '\n')
+		s.stdin.write(current_crontab.encode())
+		s.stdin.write((line + '\n').encode())
 		s.stdin.close()
 
 def read_crontab():


### PR DESCRIPTION
Bench port

Trying to install frappe with Python 3 after applying #468 yields following error traceback

```
Traceback (most recent call last):
  File "/home/frappe/aditya/4ab5ee90/3/bin/bench", line 11, in <module>
    load_entry_point('bench', 'console_scripts', 'bench')()
  File "/home/frappe/aditya/4ab5ee90/bench-repo/bench/cli.py", line 40, in cli
    bench_command()
  File "/home/frappe/aditya/4ab5ee90/3/lib/python3.5/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/home/frappe/aditya/4ab5ee90/3/lib/python3.5/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/home/frappe/aditya/4ab5ee90/3/lib/python3.5/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/aditya/4ab5ee90/3/lib/python3.5/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/frappe/aditya/4ab5ee90/3/lib/python3.5/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/home/frappe/aditya/4ab5ee90/bench-repo/bench/commands/make.py", line 21, in init
    verbose=verbose, clone_from=clone_from, skip_bench_mkdir=skip_bench_mkdir, skip_redis_config_generation=skip_redis_config_generation)
  File "/home/frappe/aditya/4ab5ee90/bench-repo/bench/utils.py", line 83, in init
    setup_backups(bench_path=path)
  File "/home/frappe/aditya/4ab5ee90/bench-repo/bench/utils.py", line 230, in setup_backups
    logfile=os.path.join(get_bench_dir(bench_path=bench_path), 'logs', 'backup.log')))
  File "/home/frappe/aditya/4ab5ee90/bench-repo/bench/utils.py", line 239, in add_to_crontab
    s.stdin.write(current_crontab)
TypeError: a bytes-like object is required, not 'str'
```

Fixed it by explicitly encoding arguments to `subprocess.Popen.stdin.write()`