### PR TITLE
Encode 'site' before hashing with hashlib.sha1

### DIFF
--- a/bench/utils.py
+++ b/bench/utils.py
@@ -170,7 +170,7 @@ def new_site(site, mariadb_root_password=None, admin_password=None, bench_path='
 	exec_cmd("{frappe} {site} --install {db_name} {mysql_root_password_fragment} {admin_password_fragment}".format(
 				frappe=get_frappe(bench_path=bench_path),
 				site=site,
-				db_name=hashlib.sha1(site).hexdigest()[:10],
+				db_name=hashlib.sha1(site.encode()).hexdigest()[:10],
 				mysql_root_password_fragment=mysql_root_password_fragment,
 				admin_password_fragment=admin_password_fragment
 			), cwd=os.path.join(bench_path, 'sites'))


### PR DESCRIPTION
Bench port

Trying to install frappe with Python 3 after applying #469 yields following error traceback

```
Traceback (most recent call last):
  File "/home/frappe/aditya/973b4a1c/3/bin/bench", line 11, in <module>
    load_entry_point('bench', 'console_scripts', 'bench')()
  File "/home/frappe/aditya/973b4a1c/bench-repo/bench/cli.py", line 40, in cli
    bench_command()
  File "/home/frappe/aditya/973b4a1c/3/lib/python3.5/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/home/frappe/aditya/973b4a1c/3/lib/python3.5/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/home/frappe/aditya/973b4a1c/3/lib/python3.5/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/aditya/973b4a1c/3/lib/python3.5/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/frappe/aditya/973b4a1c/3/lib/python3.5/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/home/frappe/aditya/973b4a1c/bench-repo/bench/commands/make.py", line 58, in new_site
    new_site(site, mariadb_root_password=mariadb_root_password, admin_password=admin_password)
  File "/home/frappe/aditya/973b4a1c/bench-repo/bench/utils.py", line 173, in new_site
    db_name=hashlib.sha1(site).hexdigest()[:10],
TypeError: Unicode-objects must be encoded before hashing
```

Fixed it by explicitly encoding arguments to `hashlib.sha1()`