### PR TITLE
Add default ERPNext installation to Easy Install script (develop)

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ For production:
 - Install all the pre-requisites
 - Install the command line `bench`
 - Create a new bench (a folder that will contain your entire frappe/erpnext setup)
-- Create a new site on the bench
+- Create a new ERPNext site on the bench 
 
 #### How do I start ERPNext
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Note: Please do not remove the bench directory the above commands will create
 - You may also have to install build-essential and python-setuptools by running `apt-get install build-essential python-setuptools`
 - This script will install the pre-requisites, install bench and setup an ERPNext site
 - Passwords for Frappe Administrator and MariaDB (root) will be asked
+- MariaDB (root) password may be `password` on a fresh server
 - You can then login as **Administrator** with the Administrator password
 - If you find any problems, post them on the forum: [https://discuss.erpnext.com](https://discuss.erpnext.com)
 

--- a/playbooks/develop/centos.yml
+++ b/playbooks/develop/centos.yml
@@ -85,5 +85,5 @@
   - include: includes/setup_dev_env.yml
     when: not run_travis and not production
   
-  # setup an erpnext site called site1.default
+  # setup an erpnext site called site1.local
   - include: includes/setup_erpnext.yml

--- a/playbooks/develop/centos.yml
+++ b/playbooks/develop/centos.yml
@@ -87,3 +87,4 @@
   
   # setup an erpnext site called site1.local
   - include: includes/setup_erpnext.yml
+    when: not production and not run_travis

--- a/playbooks/develop/centos.yml
+++ b/playbooks/develop/centos.yml
@@ -84,3 +84,6 @@
   # setup development environment
   - include: includes/setup_dev_env.yml
     when: not run_travis and not production
+  
+  # setup an erpnext site called site1.default
+  - include: includes/setup_erpnext.yml

--- a/playbooks/develop/centos.yml
+++ b/playbooks/develop/centos.yml
@@ -84,7 +84,4 @@
   # setup development environment
   - include: includes/setup_dev_env.yml
     when: not run_travis and not production
-  
-  # setup an erpnext site called site1.local
-  - include: includes/setup_erpnext.yml
-    when: not production and not run_travis
+    

--- a/playbooks/develop/centos.yml
+++ b/playbooks/develop/centos.yml
@@ -13,7 +13,7 @@
     become: yes
     become_user: root
 
-  - name: install prequisites
+  - name: install prerequisites
     yum: pkg={{ item }} state=present
     with_items:
       # basic installs

--- a/playbooks/develop/debian.yml
+++ b/playbooks/develop/debian.yml
@@ -127,3 +127,4 @@
   
   # setup an erpnext site called site1.local
   - include: includes/setup_erpnext.yml
+    when: not production and not run_travis

--- a/playbooks/develop/debian.yml
+++ b/playbooks/develop/debian.yml
@@ -125,5 +125,5 @@
   - include: includes/setup_dev_env.yml
     when: not production and not run_travis
   
-  # setup an erpnext site called site1.default
+  # setup an erpnext site called site1.local
   - include: includes/setup_erpnext.yml

--- a/playbooks/develop/debian.yml
+++ b/playbooks/develop/debian.yml
@@ -124,7 +124,4 @@
   # setup development environment
   - include: includes/setup_dev_env.yml
     when: not production and not run_travis
-  
-  # setup an erpnext site called site1.local
-  - include: includes/setup_erpnext.yml
-    when: not production and not run_travis
+

--- a/playbooks/develop/debian.yml
+++ b/playbooks/develop/debian.yml
@@ -124,3 +124,6 @@
   # setup development environment
   - include: includes/setup_dev_env.yml
     when: not production and not run_travis
+  
+  # setup an erpnext site called site1.default
+  - include: includes/setup_erpnext.yml

--- a/playbooks/develop/includes/setup_dev_env.yml
+++ b/playbooks/develop/includes/setup_dev_env.yml
@@ -14,3 +14,7 @@
    args:
      creates: "{{ bench_path }}/config/redis_socketio.conf"
      chdir: "{{ bench_path }}"
+
+
+ # Setup an ERPNext site called site1.local
+ - include: includes/setup_erpnext.yml

--- a/playbooks/develop/includes/setup_erpnext.yml
+++ b/playbooks/develop/includes/setup_erpnext.yml
@@ -1,14 +1,24 @@
 ---
+  - name: Check whether a site called site1.local exists
+    stat: path="{{ bench_path }}/sites/site1.local"
+    register: site_folder
+
   - name: create a new default site 
     command: bench new-site site1.local --admin-password {{ admin_password }} --mariadb-root-password {{ mysql_root_password }}
     args:
       chdir: "{{ bench_path }}"
+    when: not site_folder.stat.exists
+  
+  - name: Check if ERPNext App exists
+    stat: path="{{ bench_path }}/apps/erpnext"
+    register: app
 
   - name: get erpnext
-    command: bench get-app erpnext https://github.com/frappe/erpnext
+    command: bench get-app erpnext https://github.com/frappe/erpnext --branch {{ branch }}
     args:
       creates: "{{ bench_path }}/apps/erpnext"
       chdir: "{{ bench_path }}"
+    when: not app.stat.exists
 
   - name: install erpnext to default site
     command: bench --site site1.local install-app erpnext

--- a/playbooks/develop/includes/setup_erpnext.yml
+++ b/playbooks/develop/includes/setup_erpnext.yml
@@ -1,14 +1,4 @@
 ---
-  - name: Check whether a site called site1.local exists
-    stat: path="{{ bench_path }}/sites/site1.local"
-    register: site_folder
-
-  - name: create a new default site 
-    command: bench new-site site1.local --admin-password {{ admin_password }} --mariadb-root-password {{ mysql_root_password }}
-    args:
-      chdir: "{{ bench_path }}"
-    when: not site_folder.stat.exists
-  
   - name: Check if ERPNext App exists
     stat: path="{{ bench_path }}/apps/erpnext"
     register: app
@@ -19,6 +9,16 @@
       creates: "{{ bench_path }}/apps/erpnext"
       chdir: "{{ bench_path }}"
     when: not app.stat.exists
+
+  - name: Check whether a site called site1.local exists
+    stat: path="{{ bench_path }}/sites/site1.local"
+    register: site_folder
+
+  - name: create a new default site 
+    command: bench new-site site1.local --admin-password {{ admin_password }} --mariadb-root-password {{ mysql_root_password }}
+    args:
+      chdir: "{{ bench_path }}"
+    when: not site_folder.stat.exists
 
   - name: install erpnext to default site
     command: bench --site site1.local install-app erpnext

--- a/playbooks/develop/includes/setup_erpnext.yml
+++ b/playbooks/develop/includes/setup_erpnext.yml
@@ -1,0 +1,20 @@
+---
+  - name: create a new default site 
+    command: bench new-site site1.default
+    args:
+      chdir: "{{ bench_path }}"
+
+  - name: get erpnext
+    command: bench get-app erpnext https://github.com/frappe/erpnext
+    args:
+      creates: "{{ bench_path }}/apps/erpnext"
+      chdir: "{{ bench_path }}"
+
+  - name: install erpnext to default site
+    command: bench --site site1.local install-app erpnext
+    args:
+      chdir: "{{ bench_path }}"
+
+# bench new-site site1.local
+# bench get-app erpnext https://github.com/frappe/erpnext
+# bench --site site1.local install-app erpnext

--- a/playbooks/develop/includes/setup_erpnext.yml
+++ b/playbooks/develop/includes/setup_erpnext.yml
@@ -1,17 +1,17 @@
 ---
-  - name: create a new default site 
-    command: bench new-site site1.default
-    args:
-      chdir: "{{ bench_path }}"
+  # - name: create a new default site 
+  #   command: bench new-site site1.default
+  #   args:
+  #     chdir: "{{ bench_path }}"
 
-  - name: get erpnext
-    command: bench get-app erpnext https://github.com/frappe/erpnext
-    args:
-      creates: "{{ bench_path }}/apps/erpnext"
-      chdir: "{{ bench_path }}"
+  # - name: get erpnext
+  #   command: bench get-app erpnext https://github.com/frappe/erpnext
+  #   args:
+  #     creates: "{{ bench_path }}/apps/erpnext"
+  #     chdir: "{{ bench_path }}"
 
   - name: install erpnext to default site
-    command: bench --site site1.local install-app erpnext
+    command: bench --site site1.default install-app erpnext
     args:
       chdir: "{{ bench_path }}"
 

--- a/playbooks/develop/includes/setup_erpnext.yml
+++ b/playbooks/develop/includes/setup_erpnext.yml
@@ -1,20 +1,17 @@
 ---
-  # - name: create a new default site 
-  #   command: bench new-site site1.default
-  #   args:
-  #     chdir: "{{ bench_path }}"
+  - name: create a new default site 
+    command: bench new-site site1.default
+    args:
+      chdir: "{{ bench_path }}"
 
-  # - name: get erpnext
-  #   command: bench get-app erpnext https://github.com/frappe/erpnext
-  #   args:
-  #     creates: "{{ bench_path }}/apps/erpnext"
-  #     chdir: "{{ bench_path }}"
+  - name: get erpnext
+    command: bench get-app erpnext https://github.com/frappe/erpnext
+    args:
+      creates: "{{ bench_path }}/apps/erpnext"
+      chdir: "{{ bench_path }}"
 
   - name: install erpnext to default site
     command: bench --site site1.default install-app erpnext
     args:
       chdir: "{{ bench_path }}"
 
-# bench new-site site1.local
-# bench get-app erpnext https://github.com/frappe/erpnext
-# bench --site site1.local install-app erpnext

--- a/playbooks/develop/includes/setup_erpnext.yml
+++ b/playbooks/develop/includes/setup_erpnext.yml
@@ -1,6 +1,6 @@
 ---
   - name: create a new default site 
-    command: bench new-site site1.default
+    command: bench new-site site1.default --admin-password {{ admin_password }} --mariadb-root-password {{ mysql_root_password }}
     args:
       chdir: "{{ bench_path }}"
 

--- a/playbooks/develop/includes/setup_erpnext.yml
+++ b/playbooks/develop/includes/setup_erpnext.yml
@@ -1,6 +1,6 @@
 ---
   - name: create a new default site 
-    command: bench new-site site1.default --admin-password {{ admin_password }} --mariadb-root-password {{ mysql_root_password }}
+    command: bench new-site site1.local --admin-password {{ admin_password }} --mariadb-root-password {{ mysql_root_password }}
     args:
       chdir: "{{ bench_path }}"
 
@@ -11,7 +11,7 @@
       chdir: "{{ bench_path }}"
 
   - name: install erpnext to default site
-    command: bench --site site1.default install-app erpnext
+    command: bench --site site1.local install-app erpnext
     args:
       chdir: "{{ bench_path }}"
 

--- a/playbooks/develop/macosx.yml
+++ b/playbooks/develop/macosx.yml
@@ -32,7 +32,4 @@
   # setup development environment
   - include: includes/setup_dev_env.yml
     when: not production
-
-  # setup an erpnext site called site1.local
-  - include: includes/setup_erpnext.yml
-    when: not production and not run_travis
+  

--- a/playbooks/develop/macosx.yml
+++ b/playbooks/develop/macosx.yml
@@ -32,3 +32,6 @@
   # setup development environment
   - include: includes/setup_dev_env.yml
     when: not production
+
+  # setup an erpnext site called site1.default
+  - include: includes/setup_erpnext.yml

--- a/playbooks/develop/macosx.yml
+++ b/playbooks/develop/macosx.yml
@@ -33,5 +33,5 @@
   - include: includes/setup_dev_env.yml
     when: not production
 
-  # setup an erpnext site called site1.default
+  # setup an erpnext site called site1.local
   - include: includes/setup_erpnext.yml

--- a/playbooks/develop/macosx.yml
+++ b/playbooks/develop/macosx.yml
@@ -35,3 +35,4 @@
 
   # setup an erpnext site called site1.local
   - include: includes/setup_erpnext.yml
+    when: not production and not run_travis

--- a/playbooks/develop/ubuntu.yml
+++ b/playbooks/develop/ubuntu.yml
@@ -107,3 +107,5 @@
   # setup development environment
   - include: includes/setup_dev_env.yml
     when: not production and not run_travis and not without_bench_setup
+
+  - include: includes/setup_erpnext.yml

--- a/playbooks/develop/ubuntu.yml
+++ b/playbooks/develop/ubuntu.yml
@@ -88,24 +88,25 @@
     become: yes
     become_user: root
 
-  # # install MariaDB
-  # - include: includes/mariadb_ubuntu.yml
+  # install MariaDB
+  - include: includes/mariadb_ubuntu.yml
 
-  # # install WKHTMLtoPDF
-  # - include: includes/wkhtmltopdf.yml
+  # install WKHTMLtoPDF
+  - include: includes/wkhtmltopdf.yml
 
-  # # setup MariaDB
-  # - include: includes/setup_mariadb.yml
+  # setup MariaDB
+  - include: includes/setup_mariadb.yml
 
-  # - debug:
-  #     var: run_travis
+  - debug:
+      var: run_travis
 
-  # # setup frappe-bench
-  # - include: includes/setup_bench.yml
-  #   when: not without_bench_setup and not run_travis
+  # setup frappe-bench
+  - include: includes/setup_bench.yml
+    when: not without_bench_setup and not run_travis
 
-  # # setup development environment
-  # - include: includes/setup_dev_env.yml
-  #   when: not production and not run_travis and not without_bench_setup
+  # setup development environment
+  - include: includes/setup_dev_env.yml
+    when: not production and not run_travis and not without_bench_setup
 
+  # setup an erpnext site called site1.default
   - include: includes/setup_erpnext.yml

--- a/playbooks/develop/ubuntu.yml
+++ b/playbooks/develop/ubuntu.yml
@@ -108,5 +108,5 @@
   - include: includes/setup_dev_env.yml
     when: not production and not run_travis and not without_bench_setup
 
-  # setup an erpnext site called site1.default
+  # setup an erpnext site called site1.local
   - include: includes/setup_erpnext.yml

--- a/playbooks/develop/ubuntu.yml
+++ b/playbooks/develop/ubuntu.yml
@@ -88,24 +88,24 @@
     become: yes
     become_user: root
 
-  # install MariaDB
-  - include: includes/mariadb_ubuntu.yml
+  # # install MariaDB
+  # - include: includes/mariadb_ubuntu.yml
 
-  # install WKHTMLtoPDF
-  - include: includes/wkhtmltopdf.yml
+  # # install WKHTMLtoPDF
+  # - include: includes/wkhtmltopdf.yml
 
-  # setup MariaDB
-  - include: includes/setup_mariadb.yml
+  # # setup MariaDB
+  # - include: includes/setup_mariadb.yml
 
-  - debug:
-      var: run_travis
+  # - debug:
+  #     var: run_travis
 
-  # setup frappe-bench
-  - include: includes/setup_bench.yml
-    when: not without_bench_setup and not run_travis
+  # # setup frappe-bench
+  # - include: includes/setup_bench.yml
+  #   when: not without_bench_setup and not run_travis
 
-  # setup development environment
-  - include: includes/setup_dev_env.yml
-    when: not production and not run_travis and not without_bench_setup
+  # # setup development environment
+  # - include: includes/setup_dev_env.yml
+  #   when: not production and not run_travis and not without_bench_setup
 
   - include: includes/setup_erpnext.yml

--- a/playbooks/develop/ubuntu.yml
+++ b/playbooks/develop/ubuntu.yml
@@ -107,7 +107,4 @@
   # setup development environment
   - include: includes/setup_dev_env.yml
     when: not production and not run_travis and not without_bench_setup
-
-  # setup an erpnext site called site1.local
-  - include: includes/setup_erpnext.yml
-    when: not production and not run_travis
+    

--- a/playbooks/develop/ubuntu.yml
+++ b/playbooks/develop/ubuntu.yml
@@ -110,3 +110,4 @@
 
   # setup an erpnext site called site1.local
   - include: includes/setup_erpnext.yml
+    when: not production and not run_travis


### PR DESCRIPTION
@rmehta, I'm creating a site called **site1.default** for default ERPNext installation. Is this approach okay or should we name the site in another way?

Works great on Ubuntu 16.04, I will now test on all other OSes.

- [ ] Test on OS X
- [x] Test on Debian 7.1
- [x] Test on Centos 7.3
- [x] Test on Ubuntu 16.04
- [x] Fix incomplete README.md
 