### PR TITLE
Install debian 9 support

### DIFF
--- a/playbooks/install.py
+++ b/playbooks/install.py
@@ -115,7 +115,7 @@ def install_bench(args):
 		shutil.rmtree(tmp_bench_repo)
 
 def check_distribution_compatibility():
-	supported_dists = {'ubuntu': [14, 15, 16], 'debian': [7, 8],
+	supported_dists = {'ubuntu': [14, 15, 16], 'debian': [7, 8, 9],
 		'centos': [7], 'macos': [10.9, 10.10, 10.11, 10.12]}
 
 	dist_name, dist_version = get_distribution_info()

--- a/playbooks/install.py
+++ b/playbooks/install.py
@@ -58,10 +58,8 @@ def install_bench(args):
 				'pip': 'sudo pip install --upgrade pip setuptools',
 			})
 
-	# Restricting ansible version due to following bug in ansible 2.1
-	# https://github.com/ansible/ansible-modules-core/issues/3752
 	success = run_os_command({
-		'pip': "sudo pip install ansible==2.3.1"
+		'pip': "sudo pip install ansible==2.4.1"
 	})
 
 	if not success:

--- a/playbooks/install.py
+++ b/playbooks/install.py
@@ -59,7 +59,7 @@ def install_bench(args):
 			})
 
 	success = run_os_command({
-		'pip': "sudo pip install ansible==2.4.1"
+		'pip': "sudo pip install ansible==2.3.1"
 	})
 
 	if not success:


### PR DESCRIPTION
All of the *.yml Ansible files already have support for Debian 9. The only thing missing is an update to Ansible 2.4.1 and then changing the test up front. This has been tested on a out of box install on Debian 9.2.1.