### PR TITLE
Remove deprecated standalone-supported-challenges

### DIFF
--- a/bench/config/templates/letsencrypt.cfg
+++ b/bench/config/templates/letsencrypt.cfg
@@ -17,4 +17,3 @@ text = True
 
 # Uncomment to use the standalone authenticator on port 443
 authenticator = standalone
-standalone-supported-challenges = tls-sni-01


### PR DESCRIPTION
With this modification I can now use bench setup lets-encrypt without any error.