### PR TITLE
Fix lets encrtypt fails with unsupported challenge

### DIFF
--- a/bench/config/templates/letsencrypt.cfg
+++ b/bench/config/templates/letsencrypt.cfg
@@ -17,4 +17,3 @@ text = True
 
 # Uncomment to use the standalone authenticator on port 443
 authenticator = standalone
-standalone-supported-challenges = tls-sni-01


### PR DESCRIPTION
Client with the currently selected authenticator does not support any combination of challenges that will satisfy the CA.

Log
```
frappe@ipxxxxxxxxx:~/frappe-bench$ sudo bench setup lets-encrypt test.example.com
Running this will stop the nginx service temporarily causing your sites to go offline
Do you want to continue? [y/N]: y
INFO:bench.utils:sudo systemctl stop nginx
INFO:bench.utils:/opt/certbot-auto --config /etc/letsencrypt/configs/test.example.com.cfg certonly
The standalone specific supported challenges flag is deprecated. Please use the --preferred-challenges flag instead.
Saving debug log to /var/log/letsencrypt/letsencrypt.log
Plugins selected: Authenticator standalone, Installer None
Obtaining a new certificate
Performing the following challenges:
Client with the currently selected authenticator does not support any combination of challenges that will satisfy the CA.
Client with the currently selected authenticator does not support any combination of challenges that will satisfy the CA.
INFO:bench.utils:sudo systemctl start nginx
There was a problem trying to setup SSL for your site
```