### PR TITLE
increased max_allowed_packet in mysql to 256M

### DIFF
--- a/playbooks/roles/mariadb/files/debian_mariadb_config.cnf
+++ b/playbooks/roles/mariadb/files/debian_mariadb_config.cnf
@@ -5,7 +5,7 @@ innodb-large-prefix=1
 character-set-client-handshake = FALSE
 character-set-server = utf8mb4
 collation-server = utf8mb4_unicode_ci
-max_allowed_packet=64M
+max_allowed_packet=256M
 
 [mysql]
 default-character-set = utf8mb4

--- a/playbooks/roles/mariadb/files/mariadb_config.cnf
+++ b/playbooks/roles/mariadb/files/mariadb_config.cnf
@@ -11,7 +11,7 @@ key-buffer-size                = 32M
 myisam-recover                 = FORCE,BACKUP
 
 # SAFETY #
-max-allowed-packet             = 64M
+max-allowed-packet             = 256M
 max-connect-errors             = 1000000
 innodb                         = FORCE
 
@@ -49,7 +49,7 @@ innodb-large-prefix            = 1
 collation-server               = utf8mb4_unicode_ci
 character-set-server           = utf8mb4
 character-set-client-handshake = FALSE
-max_allowed_packet             = 64M
+max_allowed_packet             = 256M
 
 # LOGGING #
 log-error                      = /var/lib/mysql/mysql-error.log


### PR DESCRIPTION
Change made to prevent backup failure due to large packet size

fixes #601 