### PR TITLE
Update main.yml

### DIFF
--- a/playbooks/roles/nodejs/tasks/main.yml
+++ b/playbooks/roles/nodejs/tasks/main.yml
@@ -25,7 +25,7 @@
 
 - name: Add repo
   apt_repository:
-    repo: "deb [arch=amd64,i386] https://deb.nodesource.com/node_6.x {{ ansible_distribution_release }} main"
+    repo: "deb [arch=amd64,i386,armhf,arm64] https://deb.nodesource.com/node_6.x {{ ansible_distribution_release }} main"
     state: present
   register: node_repo
   when: ansible_os_family == 'Debian' or ansible_distribution == 'Ubuntu'


### PR DESCRIPTION
Add support for Raspberry Pi and other ARM boards. I've been [failing](https://github.com/frappe/bench/issues/610) to install `bench` and subsequently, ERPNext for the sole reason of `node 6.x` not being downloaded and installed because the `apt` sources list only mentioned `amd64` and `i386` archs.