### PR TITLE
Stop and start mysql instead of restart

### DIFF
--- a/playbooks/roles/mariadb/handlers/main.yml
+++ b/playbooks/roles/mariadb/handlers/main.yml
@@ -1,4 +1,5 @@
 ---
 - name: restart mysql
-  service: name=mysql state=restarted
+  service:service: name=mysql state=stopped
+  service: name=mysql state=started
 ...


### PR DESCRIPTION
Stop and start `mysql` instead of restart since restart fails on some machines after `mariadb` installation (and halt `install.py` at `RUNNING HANDLER [mariadb : restart mysql]`):
```
$ sudo systemctl restart mysql.service
Job for mysql.service failed because the control process exited with error code. See "systemctl status mysql.service" and "journalctl -xe" for details.
```