### PR TITLE
Fix installation error - Mac

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 nose 
 tornado
+matplotlib
 Click
 jinja2
 virtualenv

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+nose 
+tornado
 Click
 jinja2
 virtualenv


### PR DESCRIPTION
Fix : 
matplotlib 1.3.1 requires nose, which is not installed.
matplotlib 1.3.1 requires tornado, which is not installed
<img width="1260" alt="screen shot 2018-04-17 at 5 23 13 pm" src="https://user-images.githubusercontent.com/1805372/38875868-068ac2c6-4264-11e8-9e02-c778c38e5994.png">

After editing requirements.txt, the error has been resolved 
<img width="1285" alt="screen shot 2018-04-17 at 5 23 36 pm" src="https://user-images.githubusercontent.com/1805372/38875890-15ab6b34-4264-11e8-8257-59f099c2f0d0.png">