### PR TITLE
fix no procfile found

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,4 +4,4 @@ recursive-include bench *.conf
 recursive-include bench *.py
 recursive-include bench *.txt
 recursive-include bench *.json
-recursive-include bench/templates *
+recursive-include bench/config/templates *


### PR DESCRIPTION
While `bench init`ing, `jinja2.exceptions.TemplateNotFound: Procfile` happens. This PR fixes it