### PR TITLE
[install] update frappe,erpnext docs apps to be installed

### DIFF
--- a/bench/app.py
+++ b/bench/app.py
@@ -75,7 +75,7 @@ def add_to_excluded_apps_txt(app, bench_path='.'):
 	if app == 'frappe':
 		raise ValueError('Frappe app cannot be excludeed from update')
 	if app not in os.listdir('apps'):
-		raise ValueError('The app {} does not exist'.format(app)) 
+		raise ValueError('The app {} does not exist'.format(app))
 	apps = get_excluded_apps(bench_path=bench_path)
 	if app not in apps:
 		apps.append(app)
@@ -129,6 +129,22 @@ def get_app(git_url, branch=None, bench_path='.', build_asset_files=True, verbos
 		if repo_name != app_name:
 			apps_path = os.path.join(os.path.abspath(bench_path), 'apps')
 			os.rename(os.path.join(apps_path, repo_name), os.path.join(apps_path, app_name))
+
+	docs_app = ''
+	docs_app_url = ''
+	app_docs_map = {
+		'frappe': 'frappe/frappe_io',
+		'erpnext': 'erpnext/foundation'
+	}
+	if repo_name in app_docs_map.keys():
+		docs_app = app_docs_map[repo_name]
+		docs_app_url = 'https://github.com/{docs_app}'.format(docs_app=docs_app)
+		print('Getting docs app for ' + app_name + '' + docs_app)
+		exec_cmd("git clone {git_url} {branch} {shallow_clone} --origin upstream".format(
+				git_url=docs_app_url,
+				shallow_clone=shallow_clone,
+				branch=branch),
+			cwd=os.path.join(bench_path, 'apps'))
 
 	print('installing', app_name)
 	install_app(app=app_name, bench_path=bench_path, verbose=verbose)


### PR DESCRIPTION
So this involves special handling for the `frappe` and `erpnext` docs apps: `frappe/frappe_io` and `erpnext/foundation`.
`get-app` only _clones_ the specified docs_app as well. Doesn't install

Issues:
- [ ] Applied only for new users who `get-app`. Those who already have the app must also get the docs_app cloned on migration

- [ ] Assets (images and things) in the built docs will have to be present in the site's `assets` folder, so will not work unless app is installed; still seems too heavy to install the whole app only for docs. Is it the only way?

------------------------------

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [x] Have you lint your code locally prior to submission?
- [x] Have you successfully run tests with your changes locally?
- [x] Does your commit message have an explanation for your changes and why you'd like us to include them?
- [ ] Docs have been added / updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Did you modify the existing test cases? If yes, why?

---

What type of a PR is this? 

- [x] Changes to Existing Features
- [ ] New Feature Submissions
- [ ] Bug Fix
- [ ] Breaking Change

--- 

- Motivation and Context (What existing problem does the pull request solve):
- Related Issue: 
- Screenshots (if applicable, remember, a picture tells a thousand words): 

**Please don't be intimidated by the long list of options you've fill. Try to fill out as much as you can. Remember, the more the information the easier it is for us to test and get your pull request merged** :grin: 

