### PR TITLE
removed psutil as a requirement

### DIFF
--- a/bench/config/nginx.py
+++ b/bench/config/nginx.py
@@ -215,7 +215,6 @@ def get_error_pages():
 
 def get_limit_conn_shared_memory():
 	"""Allocate 2 percent of total virtual memory as shared memory for nginx limit_conn_zone"""
-	import psutil
-	total_vm = (psutil.virtual_memory().total) / (1024 * 1024) # in MB
+	total_vm = (os.sysconf('SC_PAGE_SIZE') * os.sysconf('SC_PHYS_PAGES')) / (1024 * 1024) # in MB
 
 	return int(0.02 * total_vm)

--- a/bench/config/redis.py
+++ b/bench/config/redis.py
@@ -67,9 +67,7 @@ def get_redis_version():
 	return float('{major}.{minor}'.format(major=version.major, minor=version.minor))
 
 def get_max_redis_memory():
-	import psutil
-	
-	total_virtual_mem = psutil.virtual_memory().total/(pow(1024, 2))
+	total_virtual_mem = os.sysconf('SC_PAGE_SIZE') * os.sysconf('SC_PHYS_PAGES')/(pow(1024, 2))
 	max_memory = int(total_virtual_mem * 0.05) # Max memory for redis is 5% of virtual memory
 
 	if max_memory < 50:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ jinja2
 virtualenv
 requests
 honcho
-psutil
 python-crontab
 semantic_version
 GitPython==0.3.2.1


### PR DESCRIPTION
Works on linux. I need someone to test the following piece of code on MacOS and check if it correctly returns the total physical memory (RAM) in MBs in python.

```python
import os
(os.sysconf('SC_PAGE_SIZE') * os.sysconf('SC_PHYS_PAGES')) / (1024 * 1024)
``` 

Platform to test before merge
- [x] MacOS High Sierra >= 10.13 with python >= 3.6.4

