### PR TITLE
Add single quotes around password variables in ansible script

### DIFF
--- a/playbooks/roles/bench/tasks/setup_erpnext.yml
+++ b/playbooks/roles/bench/tasks/setup_erpnext.yml
@@ -15,7 +15,7 @@
     register: site_folder
 
   - name: Create a new site
-    command: "bench new-site {{ site }} --admin-password {{ admin_password }} --mariadb-root-password {{ mysql_root_password }}"
+    command: "bench new-site {{ site }} --admin-password '{{ admin_password }}' --mariadb-root-password '{{ mysql_root_password }}'"
     args:
       chdir: "{{ bench_path }}"
     when: not site_folder.stat.exists


### PR DESCRIPTION
As mentioned in #657 admin and mysql root password with white-spaces
aren't recognized properly by shell adding single quotes around them
fixes this issue.
