### PR TITLE
Autocomplete for zsh and bash

### DIFF
--- a/completion.sh
+++ b/completion.sh
@@ -1,30 +1,11 @@
 _setup_bench_tab_completion () {
 	if [ -n "$BASH" ] ; then
-        _bench () {
-			local cur=${COMP_WORDS[COMP_CWORD]}
-			local prev=${COMP_WORDS[COMP_CWORD-1]}
-			if [[ $prev == "--site" ]]; then
-				COMPREPLY=( $(compgen -W "`_site_dirs`" -- $cur) )
-			fi
-			}
-			complete -F _bench bench
+		eval "$(_BENCH_COMPLETE=source bench)"
 	elif [ -n "$ZSH_VERSION" ]; then
-		 _bench () {
-			 local a
-			 local prev
-			 read -l a
-			 prev=`echo $a| awk '{ print $NF }'`
-			 if [[ $prev == "--site" ]]; then
-				 reply=($(_site_dirs))
-			 fi
-         }
-		 compctl -K _bench bench
+		autoload bashcompinit
+		bashcompinit
+		eval "$(_BENCH_COMPLETE=source bench)"
 	fi
 }
-
-_site_dirs() {
-	ls -d sites/*/ | sed "s/sites\///g" | sed "s/\/$//g" | xargs echo
-}
-
 
 _setup_bench_tab_completion


### PR DESCRIPTION
Doesn't yet provide auto-completion for frappe commands

Run `source completion.sh` to enable auto-completion on zsh and bash