### PR TITLE
Allow user to set single wildcard certificate for all domains

### DIFF
--- a/bench/config/nginx.py
+++ b/bench/config/nginx.py
@@ -228,7 +228,8 @@ def use_wildcard_certificate(bench_path, ret):
 	ssl_certificate = wildcard['ssl_certificate']
 	ssl_certificate_key = wildcard['ssl_certificate_key']
 
-	if domain.startswith('*.'):
+	# If domain is set as "*" all domains will be included
+	if domain.startswith('*'):
 		domain = domain[1:]
 	else:
 		domain = '.' + domain


### PR DESCRIPTION
This is for a scenario when you have a single wildcard certificate for multiple domains. By default the nginx generation logic will only set the certs for domains that match the one set as the wildcard domain. 

However, by doing this, when you just set the domain as "*", the domain variable in the next line is set as empty string, which then is used in an `endswith`, which will always resolve `True`.