### PR TITLE
[fix] reload(): use importlib for python3

### DIFF
--- a/bench/app.py
+++ b/bench/app.py
@@ -387,6 +387,8 @@ def switch_branch(branch, apps=None, bench_path='.', upgrade=False, check_upgrad
 		print("Successfully switched branches for:\n" + "\n".join(switched_apps))
 
 	if version_upgrade[0] and upgrade:
+		if sys.version_info >= (3, 4):
+			from importlib import reload
 		update_requirements()
 		update_node_packages()
 		pre_upgrade(version_upgrade[1], version_upgrade[2])

--- a/bench/commands/update.py
+++ b/bench/commands/update.py
@@ -77,6 +77,8 @@ def _update(pull=False, patch=False, build=False, update_bench=False, auto=False
 		update_node_packages(bench_path=bench_path)
 
 	if version_upgrade[0] or (not version_upgrade[0] and force):
+		if sys.version_info >= (3, 4):
+			from importlib import reload
 		pre_upgrade(version_upgrade[1], version_upgrade[2], bench_path=bench_path)
 		import bench.utils, bench.app
 		print('Reloading bench...')


### PR DESCRIPTION

`reload()` is an inbuilt function in python2 but has been moved to `importlib` since python3.4.

source: https://docs.python.org/3/library/importlib.html#importlib.reload

`Signed-off-by: Chinmay Pai <chinmaydpai@gmail.com>`