### PR TITLE
fix: install app instead of requirements.txt

### DIFF
--- a/bench/utils.py
+++ b/bench/utils.py
@@ -176,7 +176,6 @@ def setup_env(bench_path='.', python = 'python'):
 	exec_cmd('virtualenv -q {} -p {}'.format('env', python), cwd=bench_path)
 	exec_cmd('{} -q install --upgrade pip'.format(pip), cwd=bench_path)
 	exec_cmd('{} -q install wheel'.format(pip), cwd=bench_path)
-	# exec_cmd('{pip} -q install https://github.com/frappe/MySQLdb1/archive/MySQLdb-1.2.5-patched.tar.gz'.format(pip), cwd=bench_path)
 	exec_cmd('{} -q install six'.format(pip), cwd=bench_path)
 	exec_cmd('{} -q install -e git+https://github.com/frappe/python-pdfkit.git#egg=pdfkit'.format(pip), cwd=bench_path)
 
@@ -430,9 +429,9 @@ def update_requirements(bench_path='.'):
 	bench_req_file = os.path.join(os.path.dirname(bench.__path__[0]), 'requirements.txt')
 	install_requirements(pip, bench_req_file)
 
+	from .app import install_app
 	for app in os.listdir(apps_dir):
-		req_file = os.path.join(apps_dir, app, 'requirements.txt')
-		install_requirements(pip, req_file)
+		install_app(app, bench_path=bench_path)
 
 def update_node_packages(bench_path='.'):
 	print('Updating node packages...')


### PR DESCRIPTION
pip installs the frappe apps instead of just their requirements.txt
It needs to be done so as to prevent update the app version for pip and
to prevent conflits for the dependencies in requirements.txt
