### PR TITLE
remove-app: fix for python3.7

### DIFF
--- a/bench/app.py
+++ b/bench/app.py
@@ -191,7 +191,7 @@ def remove_app(app, bench_path='.'):
 	for site in os.listdir(site_path):
 		req_file = os.path.join(site_path, site, 'site_config.json')
 		if os.path.exists(req_file):
-			out = subprocess.check_output(["bench", "--site", site, "list-apps"], cwd=bench_path)
+			out = subprocess.check_output(["bench", "--site", site, "list-apps"], cwd=bench_path).decode('utf-8')
 			if re.search(r'\b' + app + r'\b', out):
 				print("Cannot remove, app is installed on site: {0}".format(site))
 				sys.exit(1)


### PR DESCRIPTION
`bench remove-app <app>` exits with TypeError on python3.7

converting the subprocess output to string fixes this issue.
