### PR TITLE
feat(release): option to prevent frontport

### DIFF
--- a/bench/commands/utils.py
+++ b/bench/commands/utils.py
@@ -129,11 +129,13 @@ def backup_all_sites():
 @click.option('--remote', default='upstream')
 @click.option('--owner', default='frappe')
 @click.option('--repo-name')
-def release(app, bump_type, from_branch, to_branch, owner, repo_name, remote):
+@click.option('--dont-frontport', is_flag=True, default=False, help='Front port fixes to new branches, example merging hotfix(v10) into staging-fixes(v11)')
+def release(app, bump_type, from_branch, to_branch, owner, repo_name, remote, dont_frontport):
 	"Release app (internal to the Frappe team)"
 	from bench.release import release
+	frontport = not dont_frontport
 	release(bench_path='.', app=app, bump_type=bump_type, from_branch=from_branch, to_branch=to_branch,
-		remote=remote, owner=owner, repo_name=repo_name)
+		remote=remote, owner=owner, repo_name=repo_name, frontport=frontport)
 
 
 @click.command('prepare-beta-release')


### PR DESCRIPTION
Option to prevent frontporting code to new branches, for example
v11(staging-fixes) should go into v12(develop)

Reason: To offload tasks to bot for normal releases, which can be done
without conflicts on a regular basis. However the frontporting releases
need manual intervention since merge conflicts arise.
