### PR TITLE
fix: default caching of pip packages and other changes

### DIFF
--- a/bench/app.py
+++ b/bench/app.py
@@ -174,7 +174,7 @@ def install_app(app, bench_path='.', verbose=False, no_cache=False):
 	exec_cmd("{pip} install {quiet} {find_links} -e {app} {no_cache}".format(
 				pip=os.path.join(bench_path, 'env', 'bin', 'pip'),
 				quiet="-q" if not verbose else "",
-				no_cache='--no-cache-dir' if not no_cache else '',
+				no_cache='--no-cache-dir' if no_cache else '',
 				app=os.path.join(bench_path, 'apps', app),
 				find_links=find_links))
 	add_to_appstxt(app, bench_path=bench_path)

--- a/bench/config/production_setup.py
+++ b/bench/config/production_setup.py
@@ -52,8 +52,7 @@ def disable_production(bench_path='.'):
 		os.unlink(supervisor_conf)
 
 	if get_config(bench_path).get('restart_supervisor_on_update'):
-		exec_cmd('sudo supervisorctl reread')
-		exec_cmd('sudo supervisorctl update')
+		reload_supervisor()
 
 	# nginx
 	nginx_conf = '/etc/nginx/conf.d/{bench_name}.conf'.format(bench_name=bench_name)


### PR DESCRIPTION
- default caching of pip packages
- use `reload_supervisor` in `disable_production` (handles more cases, prevents tests from failing randomly)