### PR TITLE
feat(error): Show SyntaxError found in frappe

### DIFF
--- a/bench/cli.py
+++ b/bench/cli.py
@@ -98,7 +98,9 @@ def get_frappe_commands(bench_path='.'):
 		output = get_cmd_output("{python} -m frappe.utils.bench_helper get-frappe-commands".format(python=python), cwd=sites_path)
 		# output = output.decode('utf-8')
 		return json.loads(output)
-	except subprocess.CalledProcessError:
+	except subprocess.CalledProcessError as e:
+		if e.stderr:
+			print(e.stderr.decode('utf-8'))
 		return []
 
 def get_frappe_help(bench_path='.'):

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -359,7 +359,7 @@ def check_git_for_shallow_clone():
 
 def get_cmd_output(cmd, cwd='.'):
 	try:
-		output = subprocess.check_output(cmd, cwd=cwd, shell=True, stderr=open(os.devnull, 'wb')).strip()
+		output = subprocess.check_output(cmd, cwd=cwd, shell=True, stderr=subprocess.PIPE).strip()
 		output = output.decode('utf-8')
 		return output
 	except subprocess.CalledProcessError as e:


### PR DESCRIPTION
https://github.com/frappe/frappe/issues/6784

### Before this patch

bench shows the wrong error message when frappe contains a syntax error

For example with `bench doctor`
```shell
Usage: bench [OPTIONS] COMMAND [ARGS]...

Error: No such command "doctor".
```
To correctly obtain the position of error one has to do the following
```shell
cd sites
../env/bin/python ../apps/frappe/frappe/utils/bench_helper.py frappe doctor
```

or as an alternative

```shell
cd sites
../env/bin/python -m frappe.utils.bench_helper frappe doctor
```

Which will then report error correctly

```python-traceback
Traceback (most recent call last):
  File "../apps/frappe/frappe/utils/bench_helper.py", line 3, in <module>
    import frappe
  File "/Users/aditya/Frappe/frappe/apps/frappe/frappe/__init__.py", line 25
    class _dict(dict)
                    ^
SyntaxError: invalid syntax
```

### After this patch

For example, output of `bench doctor` now includes SyntaxError

```python-traceback
Traceback (most recent call last):
  File "/usr/local/Cellar/python/3.7.0/Frameworks/Python.framework/Versions/3.7/lib/python3.7/runpy.py", line 183, in _run_module_as_main
    mod_name, mod_spec, code = _get_module_details(mod_name, _Error)
  File "/usr/local/Cellar/python/3.7.0/Frameworks/Python.framework/Versions/3.7/lib/python3.7/runpy.py", line 109, in _get_module_details
    __import__(pkg_name)
  File "/Users/aditya/Frappe/frappe/apps/frappe/frappe/__init__.py", line 25
    class _dict(dict)
                    ^
SyntaxError: invalid syntax

Usage: bench [OPTIONS] COMMAND [ARGS]...

Error: No such command "doctor".
```