### PR TITLE
fix(ansible): call the correct handler-typo fix #765

### DIFF
--- a/playbooks/roles/dns_caching/handlers/main.yml
+++ b/playbooks/roles/dns_caching/handlers/main.yml
@@ -1,4 +1,4 @@
 ---
-- name: Restart network manager
+- name: restart network manager
   service: name=NetworkManager state=restarted
 ...


### PR DESCRIPTION
fixed a single typo that was causing an error during the installation on Centos7. Bug #765



What type of a PR is this? 

- [ ] Changes to Existing Features
- [ ] New Feature Submissions
- [x] Bug Fix
- [ ] Breaking Change

