### PR TITLE
perf: Remove unwanted check

### DIFF
--- a/bench/cli.py
+++ b/bench/cli.py
@@ -19,7 +19,7 @@ def cli():
 	if len(sys.argv) > 2 and sys.argv[1] == "frappe":
 		return old_frappe_cli()
 
-	elif len(sys.argv) > 1 and sys.argv[1] in get_frappe_commands():
+	elif len(sys.argv) > 1:
 		return frappe_cmd()
 
 	elif len(sys.argv) > 1 and sys.argv[1] in ("--site", "--verbose", "--force", "--profile"):


### PR DESCRIPTION
`get_frappe_commands` returns a list of valid frappe commands which is used to check if the user command is valid. But this is unnecessary because even without it bench can report the command not found error. This saves ~1 second.