### PR TITLE
fix: Change ownership of all log and config files

### DIFF
--- a/bench/utils.py
+++ b/bench/utils.py
@@ -1,4 +1,4 @@
-import os, sys, shutil, subprocess, logging, itertools, requests, json, platform, select, pwd, grp, multiprocessing, hashlib
+import os, sys, shutil, subprocess, logging, itertools, requests, json, platform, select, pwd, grp, multiprocessing, hashlib, glob
 from distutils.spawn import find_executable
 import bench
 import semantic_version
@@ -556,16 +556,6 @@ def drop_privileges(uid_name='nobody', gid_name='nogroup'):
 
 def fix_prod_setup_perms(bench_path='.', frappe_user=None):
 	from .config.common_site_config import get_config
-	files = [
-		"logs/web.error.log",
-		"logs/web.log",
-		"logs/workerbeat.error.log",
-		"logs/workerbeat.log",
-		"logs/worker.error.log",
-		"logs/worker.log",
-		"config/nginx.conf",
-		"config/supervisor.conf",
-	]
 
 	if not frappe_user:
 		frappe_user = get_config(bench_path).get('frappe_user')
@@ -574,8 +564,9 @@ def fix_prod_setup_perms(bench_path='.', frappe_user=None):
 		print("frappe user not set")
 		sys.exit(1)
 
-	for path in files:
-		if os.path.exists(path):
+	globs = ["logs/*", "config/*"]
+	for glob_name in globs:
+		for path in glob.glob(glob_name):
 			uid = pwd.getpwnam(frappe_user).pw_uid
 			gid = grp.getgrnam(frappe_user).gr_gid
 			os.chown(path, uid, gid)


### PR DESCRIPTION
A version of this was added in #787 and reverted in #789 

Circle CI shows following traceback.
```python-traceback
ERROR: test_setup_production (bench.tests.test_setup_production.TestSetupProduction)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "bench/tests/test_setup_production.py", line 21, in test_setup_production
    setup_production(user, bench_path)
  File "bench/config/production_setup.py", line 17, in setup_production
    fix_prod_setup_perms(bench_path, frappe_user=user)
  File "bench/utils.py", line 569, in fix_prod_setup_perms
    for path in glob.glob(glob_name, recursive=True):
TypeError: glob() got an unexpected keyword argument 'recursive'
```

Removed `recursive=True`