### PR TITLE
Fix: deprecated squash_actions

### DIFF
--- a/playbooks/macosx.yml
+++ b/playbooks/macosx.yml
@@ -8,12 +8,13 @@
   tasks:
     # install pre-requisites
     - name: install prequisites
-      homebrew: name={{ item }} state=present
-      with_items:
-        - cmake
-        - redis
-        - mariadb
-        - nodejs
+      homebrew:
+        state: present
+        name:
+          - cmake
+          - redis
+          - mariadb
+          - nodejs
 
     # install wkhtmltopdf
     - name: cask installs

--- a/playbooks/roles/bench/tasks/setup_firewall.yml
+++ b/playbooks/roles/bench/tasks/setup_firewall.yml
@@ -10,7 +10,9 @@
       when: ansible_distribution == 'CentOS'
 
     - name: Install firewalld
-      yum: name=firewalld state=present
+      yum:
+        name: firewalld 
+        state: present
       when: ansible_distribution == 'CentOS'
 
     - name: Enable Firewall
@@ -31,10 +33,12 @@
 
       # For Ubuntu / Debian
     - name: Install ufw
-      apt: name={{ item }} state=present force=yes
-      with_items:
-       - python-selinux
-       - ufw
+      apt:
+        state: present 
+        force: yes
+        name:
+        - python-selinux
+        - ufw
       when: ansible_distribution == 'Ubuntu' or ansible_distribution == 'Debian'
 
     - name: Enable Firewall

--- a/playbooks/roles/common/tasks/debian.yml
+++ b/playbooks/roles/common/tasks/debian.yml
@@ -4,21 +4,23 @@
   pip: name=pyOpenSSL version=16.2.0
 
 - name: install pillow prerequisites for Debian < 8
-  apt: pkg={{ item }} state=present
-  with_items:
-    - libjpeg8-dev
-    - libtiff4-dev
-    - tcl8.5-dev
-    - tk8.5-dev
+  apt:
+    state: present
+    pkg:
+      - libjpeg8-dev
+      - libtiff4-dev
+      - tcl8.5-dev
+      - tk8.5-dev
   when: ansible_distribution_version | version_compare('8', 'lt')
 
 - name: install pillow prerequisites for Debian >= 8
-  apt: pkg={{ item }} state=present
-  with_items:
-    - libjpeg62-turbo-dev
-    - libtiff5-dev
-    - tcl8.5-dev
-    - tk8.5-dev
+  apt:
+    state: present
+    pkg:
+      - libjpeg62-turbo-dev
+      - libtiff5-dev
+      - tcl8.5-dev
+      - tk8.5-dev
   when: ansible_distribution_version | version_compare('8', 'ge')
 
 ...

--- a/playbooks/roles/common/tasks/debian_family.yml
+++ b/playbooks/roles/common/tasks/debian_family.yml
@@ -3,37 +3,39 @@
 - name: Install prerequisites using apt-get
   become: yes
   become_user: root
-  apt: pkg={{ item }} state=present force=yes
-  with_items:
-    - dnsmasq
-    - fontconfig
-    - git                     # Version control
-    - htop                    # Server stats
-    - libcrypto++-dev
-    - libfreetype6-dev
-    - liblcms2-dev
-    - libssl-dev
-    - libwebp-dev
-    - libxext6
-    - libxrender1
-    - libxslt1-dev
-    - libxslt1.1
-    - libffi-dev
-    - ntp                     # Clock synchronization
-    - postfix                 # Mail Server
-    - python-dev              # Installing python developer suite 
-    - python3-dev             # For python3 compatibility
-    - python-tk
-    - screen                  # To aid ssh sessions with connectivity problems 
-    - vim                     # Is that supposed to be a question!?
-    - xfonts-75dpi
-    - xfonts-base
-    - zlib1g-dev
-    - apt-transport-https
-    - libsasl2-dev
-    - libldap2-dev
-    - libcups2-dev
-    - pv                      # Show progress during database restore
+  apt:
+    state: present 
+    force: yes
+    pkg:
+      - dnsmasq
+      - fontconfig
+      - git                     # Version control
+      - htop                    # Server stats
+      - libcrypto++-dev
+      - libfreetype6-dev
+      - liblcms2-dev
+      - libssl-dev
+      - libwebp-dev
+      - libxext6
+      - libxrender1
+      - libxslt1-dev
+      - libxslt1.1
+      - libffi-dev
+      - ntp                     # Clock synchronization
+      - postfix                 # Mail Server
+      - python-dev              # Installing python developer suite 
+      - python3-dev             # For python3 compatibility
+      - python-tk
+      - screen                  # To aid ssh sessions with connectivity problems 
+      - vim                     # Is that supposed to be a question!?
+      - xfonts-75dpi
+      - xfonts-base
+      - zlib1g-dev
+      - apt-transport-https
+      - libsasl2-dev
+      - libldap2-dev
+      - libcups2-dev
+      - pv                      # Show progress during database restore
     
 - include_tasks: debian.yml
   when: ansible_distribution == 'Debian'

--- a/playbooks/roles/common/tasks/macos.yml
+++ b/playbooks/roles/common/tasks/macos.yml
@@ -9,18 +9,20 @@
   tasks:
     # install pre-requisites
     - name: install prequisites
-      homebrew: name={{ item }} state=present
-      with_items:
-        - cmake
-        - redis
-        - mariadb
-        - nodejs
+      homebrew:
+        state: present
+        name:
+          - cmake
+          - redis
+          - mariadb
+          - nodejs
 
     # install wkhtmltopdf
     - name: cask installs
-      homebrew_cask: name={{ item }} state=present
-      with_items:
-        - wkhtmltopdf
+      homebrew_cask:
+        state: present
+        name:
+          - wkhtmltopdf
 
     - name: configure mariadb
       include_tasks: roles/mariadb/tasks/main.yml

--- a/playbooks/roles/common/tasks/redhat_family.yml
+++ b/playbooks/roles/common/tasks/redhat_family.yml
@@ -10,42 +10,43 @@
 - name: "Setup prerequisites using yum"
   become: yes
   become_user: root
-  yum: name={{ item }} state=present
-  with_items:
-    - bzip2-devel
-    - cronie
-    - dnsmasq
-    - freetype-devel
-    - git
-    - htop
-    - lcms2-devel
-    - libjpeg-devel
-    - libtiff-devel
-    - libffi-devel
-    - libwebp-devel
-    - libXext
-    - libXrender
-    - libzip-devel
-    - libffi-devel
-    - ntp
-    - openssl-devel
-    - postfix
-    - python36u
-    - python-devel
-    - python-setuptools
-    - python-pip
-    - redis
-    - screen
-    - sudo
-    - tcl-devel
-    - tk-devel
-    - vim
-    - which
-    - xorg-x11-fonts-75dpi
-    - xorg-x11-fonts-Type1
-    - zlib-devel
-    - openssl-devel
-    - openldap-devel
-    - libselinux-python
-    - cups-libs
+  yum:
+    state: present
+    name:
+        - bzip2-devel
+        - cronie
+        - dnsmasq
+        - freetype-devel
+        - git
+        - htop
+        - lcms2-devel
+        - libjpeg-devel
+        - libtiff-devel
+        - libffi-devel
+        - libwebp-devel
+        - libXext
+        - libXrender
+        - libzip-devel
+        - libffi-devel
+        - ntp
+        - openssl-devel
+        - postfix
+        - python36u
+        - python-devel
+        - python-setuptools
+        - python-pip
+        - redis
+        - screen
+        - sudo
+        - tcl-devel
+        - tk-devel
+        - vim
+        - which
+        - xorg-x11-fonts-75dpi
+        - xorg-x11-fonts-Type1
+        - zlib-devel
+        - openssl-devel
+        - openldap-devel
+        - libselinux-python
+        - cups-libs
 ...

--- a/playbooks/roles/common/tasks/ubuntu.yml
+++ b/playbooks/roles/common/tasks/ubuntu.yml
@@ -1,21 +1,25 @@
 ---
 
 - name: install pillow prerequisites for Ubuntu < 14.04
-  apt: pkg={{ item }} state=present force=yes
-  with_items:
-   - libjpeg8-dev
-   - libtiff4-dev
-   - tcl8.5-dev
-   - tk8.5-dev
+  apt:
+    state: present
+    force: yes
+    pkg:
+      - libjpeg8-dev
+      - libtiff4-dev
+      - tcl8.5-dev
+      - tk8.5-dev
   when: ansible_distribution_version | version_compare('14.04', 'lt')
 
 - name: install pillow prerequisites for Ubuntu >= 14.04
-  apt: pkg={{ item }} state=present force=yes
-  with_items:
-   - libjpeg8-dev
-   - libtiff5-dev
-   - tcl8.6-dev
-   - tk8.6-dev
+  apt:
+    state: present
+    force: yes
+    pkg:
+      - libjpeg8-dev
+      - libtiff5-dev
+      - tcl8.6-dev
+      - tk8.6-dev
   when: ansible_distribution_version | version_compare('14.04', 'ge')
 
 ...

--- a/playbooks/roles/fail2ban/tasks/main.yml
+++ b/playbooks/roles/fail2ban/tasks/main.yml
@@ -1,10 +1,14 @@
 ---
 - name: Install fail2ban
-  yum: name=fail2ban state=present
+  yum:
+    name: fail2ban
+    state: present
   when: ansible_distribution == 'CentOS'
 
 - name: Install fail2ban
-  apt: name=fail2ban state=present
+  apt:
+    name: fail2ban 
+    state: present
   when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
 
 - name: Enable fail2ban

--- a/playbooks/roles/frappe_selinux/tasks/main.yml
+++ b/playbooks/roles/frappe_selinux/tasks/main.yml
@@ -1,9 +1,10 @@
 ---
 - name: Install deps
-  yum: name="{{item}}" state=present
-  with_items:
-    - policycoreutils-python
-    - selinux-policy-devel
+  yum:
+    state: present
+    name:
+      - policycoreutils-python
+      - selinux-policy-devel
   when: ansible_distribution == 'CentOS'
 
 - name: Check enabled SELinux modules

--- a/playbooks/roles/logwatch/tasks/main.yml
+++ b/playbooks/roles/logwatch/tasks/main.yml
@@ -1,10 +1,14 @@
 ---
 - name: Install logwatch
-  yum: name=logwatch state=present
+  yum:
+    name: logwatch 
+    state: present
   when: ansible_distribution == 'CentOS'
 
 - name: Install logwatch on Ubuntu or Debian
-  apt: name=logwatch state=present
+  apt:
+    name: logwatch
+    state: present
   when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
 
 - name: Copy logwatch config

--- a/playbooks/roles/mariadb/tasks/centos.yml
+++ b/playbooks/roles/mariadb/tasks/centos.yml
@@ -3,11 +3,15 @@
   template: src=mariadb_centos.repo.j2 dest=/etc/yum.repos.d/mariadb.repo owner=root group=root mode=0644
 
 - name: Install MariaDB
-  yum: name={{ item }} enablerepo=mariadb state=present
-  with_items:
-    - MariaDB-server
-    - MariaDB-client
+  yum:
+    enablerepo: mariadb
+    state: present
+    name:
+      - MariaDB-server
+      - MariaDB-client
 
 - name: Install MySQLdb Python package for secure installations.
-  yum: name=MySQL-python state=present
+  yum:
+    state: present
+    name: MySQL-python
   when: mysql_secure_installation and mysql_root_password is defined

--- a/playbooks/roles/nodejs/tasks/redhat_family.yml
+++ b/playbooks/roles/nodejs/tasks/redhat_family.yml
@@ -6,6 +6,8 @@
   shell: "curl --silent --location https://rpm.nodesource.com/setup_{{ node_version }}.x | sudo bash -"
 
 - name: Install node v{{ node_version }}
-  yum: name=nodejs state=present
+  yum:
+    name: nodejs
+    state: present
   when: ansible_os_family == 'RedHat'
 ...

--- a/playbooks/roles/ntpd/tasks/main.yml
+++ b/playbooks/roles/ntpd/tasks/main.yml
@@ -1,9 +1,10 @@
 ---
 - name: Install ntpd
-  yum: name="{{item}}" state=installed
-  with_items:
-    - ntp
-    - ntpdate
+  yum:
+    state: installed
+    name:
+      - ntp
+      - ntpdate
   when: ansible_distribution == 'CentOS'
 
 - name: Enable ntpd
@@ -11,10 +12,11 @@
   when: ansible_distribution == 'CentOS'
 
 - name: Install ntpd
-  apt: name="{{item}}" state=installed
-  with_items:
-    - ntp
-    - ntpdate
+  apt:
+    state: installed
+    name:
+      - ntp
+      - ntpdate
   when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
 
 - name: Enable ntpd

--- a/playbooks/roles/packer/tasks/redhat_family.yml
+++ b/playbooks/roles/packer/tasks/redhat_family.yml
@@ -1,7 +1,8 @@
 ---
 
 - name: Install unzip
-  yum: name={{ item }} state=present
-  with_items:
-    - unzip
+  yum:
+    state: present
+    name:
+        - unzip
 ...

--- a/playbooks/roles/redis/tasks/main.yml
+++ b/playbooks/roles/redis/tasks/main.yml
@@ -1,21 +1,25 @@
 ---
   - name: Install yum packages
-    yum: name={{ item }} state=present
-    with_items:
-      - redis
+    yum:
+      state: present
+      name:
+        - redis
     when: ansible_os_family == 'RedHat'
 
   # Prerequisite for Debian and Ubuntu
   - name: Install apt packages
-    apt: pkg={{ item }} state=present force=yes
-    with_items:
-      - redis-server
+    apt:
+      state: present
+      force: yes
+      pkg:
+        - redis-server
     when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
 
   # Prerequisite for MACOS
   - name: install prequisites for macos
-    homebrew: name={{ item }} state=present
-    with_items:
-      - redis
+    homebrew:
+      state: present
+      name:
+        - redis
     when: ansible_distribution == 'MacOSX'
 ...

--- a/playbooks/roles/supervisor/tasks/main.yml
+++ b/playbooks/roles/supervisor/tasks/main.yml
@@ -1,8 +1,13 @@
 ---
 - name: Install supervisor on centos
-  yum: name=supervisor state=present
+  yum:
+    name: supervisor
+    state: present
   when: ansible_os_family == 'RedHat'
 
 - name: Install supervisor on debian
-  apt: pkg=supervisor state=present force=yes
+  apt:
+    state: present
+    force: yes
+    pkg: supervisor
   when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'

--- a/playbooks/roles/virtualbox/tasks/redhat_family.yml
+++ b/playbooks/roles/virtualbox/tasks/redhat_family.yml
@@ -5,10 +5,11 @@
     state: present
 
 - name: Install dependencies
-  yum: name={{ item }} state=present
-  with_items:
-    - kernel-devel
-    - deltarpm
+  yum: 
+    state: present
+    name:
+      - kernel-devel
+      - deltarpm
 
 - copy: src=virtualbox_centos.repo dest=/etc/yum.repos.d/virtualbox.repo owner=root group=root mode=0644 force=no
 

--- a/playbooks/roles/wkhtmltopdf/tasks/main.yml
+++ b/playbooks/roles/wkhtmltopdf/tasks/main.yml
@@ -1,20 +1,23 @@
 ---
 - name: install base fonts
-  yum: name={{ item }} state=present
-  with_items:
-    - libXrender
-    - libXext
-    - xorg-x11-fonts-75dpi
-    - xorg-x11-fonts-Type1
+  yum:
+    state: present
+    name:
+      - libXrender
+      - libXext
+      - xorg-x11-fonts-75dpi
+      - xorg-x11-fonts-Type1
   when: ansible_os_family == 'RedHat'
 
 - name: install base fonts
-  apt: name={{ item }} state=present force=yes
-  with_items:
-    - libxrender1
-    - libxext6
-    - xfonts-75dpi
-    - xfonts-base
+  apt:
+    state: present
+    force: yes
+    name:
+      - libxrender1
+      - libxext6
+      - xfonts-75dpi
+      - xfonts-base
   when: ansible_os_family == 'Debian'
 
 # wkhtmltopdf has been locked down to 0.12.3 intentionally since 0.12.4 has problems.


### PR DESCRIPTION
Fix deprecated squash actions according to : https://docs.ansible.com/ansible/devel/porting_guides/porting_guide_2.7.html#using-a-loop-on-a-package-module-via-squash-actions

### Changes

```yaml
- name: Install packages
  yum:
    state: present
    name: "{{ item }}"
  with_items: 
    - package_1
    - package_2
```

becomes

```yaml
- name: Install packages
  yum:
    state: present
    name:
      - package_1
      - package_2
```

### Effect

This will remove warnings like this one:

```
TASK [wkhtmltopdf : install base fonts] ****************************************
[DEPRECATION WARNING]: Invoking "yum" only once while using a loop via 
squash_actions is deprecated. Instead of using a loop to supply multiple items 
and specifying `name: "{{ item }}"`, please use `name: ['libXrender', 
'libXext', 'xorg-x11-fonts-75dpi', 'xorg-x11-fonts-Type1']` and remove the 
loop. This feature will be removed in version 2.11. Deprecation warnings can be
 disabled by setting deprecation_warnings=False in ansible.cfg.
```