### PR TITLE
fix: requests package dependancy for centos

### DIFF
--- a/playbooks/install.py
+++ b/playbooks/install.py
@@ -50,12 +50,18 @@ def install_bench(args):
 		})
 
 		if success:
-			run_os_command({
-				'pip': 'sudo pip install --upgrade setuptools requests cryptography pip'
-			})
+			dist_name, dist_version = get_distribution_info()
+			if dist_name == 'centos':
+				run_os_command({
+					'pip': 'sudo pip install --upgrade --ignore-installed requests'
+				})
+			else:
+				run_os_command({
+					'pip': 'sudo pip install --upgrade requests'
+				})
 
 	success = run_os_command({
-		'pip': "sudo pip install --upgrade cryptography ansible"
+		'pip': "sudo pip install --upgrade setuptools cryptography ansible pip"
 	})
 
 	if not success:


### PR DESCRIPTION
```

Installing collected packages: setuptools, urllib3, chardet, idna, certifi, requests, enum34, asn1crypto, pycparser, cffi, cryptography
  Found existing installation: setuptools 0.9.8
    Uninstalling setuptools-0.9.8:
      Successfully uninstalled setuptools-0.9.8
  Found existing installation: urllib3 1.10.2
    Uninstalling urllib3-1.10.2:
      Successfully uninstalled urllib3-1.10.2
  Found existing installation: chardet 2.2.1
    Uninstalling chardet-2.2.1:
      Successfully uninstalled chardet-2.2.1
  Found existing installation: requests 2.6.0
ERROR: Cannot uninstall 'requests'. It is a distutils installed project and thus we cannot accurately determine which files belong to it which would lead to only a partial uninstall.
Traceback (most recent call last):
  File "install.py", line 426, in <module>
    install_bench(args)
  File "install.py", line 54, in install_bench
    'pip': 'sudo pip install --upgrade setuptools requests cryptography pip'
  File "install.py", line 234, in run_os_command
    returncode = subprocess.check_call(command, shell=True)
  File "/usr/lib64/python2.7/subprocess.py", line 542, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command 'sudo pip install --upgrade setuptools requests cryptography pip' returned non-zero exit status 1

```