### PR TITLE
fix: take backup before pulling the code and make site available after restarting the processes

### DIFF
--- a/bench/commands/update.py
+++ b/bench/commands/update.py
@@ -69,8 +69,8 @@ def _update(pull=False, patch=False, build=False, update_bench=False, auto=False
 
 	before_update(bench_path=bench_path, requirements=requirements)
 
-	config.update({ "maintenance_mode": 1, "pause_scheduler": 1 })
-	update_config(config, bench_path=bench_path)
+	conf.update({ "maintenance_mode": 1, "pause_scheduler": 1 })
+	update_config(conf, bench_path=bench_path)
 
 	if not no_backup:
 		print('Backing up sites...')
@@ -107,8 +107,8 @@ def _update(pull=False, patch=False, build=False, update_bench=False, auto=False
 	if restart_systemd or conf.get('restart_systemd_on_update'):
 		restart_systemd_processes(bench_path=bench_path)
 
-	config.update({ "maintenance_mode": 0, "pause_scheduler": 0 })
-	update_config(config, bench_path=bench_path)
+	conf.update({ "maintenance_mode": 0, "pause_scheduler": 0 })
+	update_config(conf, bench_path=bench_path)
 
 	print("_"*80)
 	print("Bench: Deployment tool for Frappe and ERPNext (https://erpnext.org).")

--- a/bench/commands/update.py
+++ b/bench/commands/update.py
@@ -1,6 +1,6 @@
 import click
 import sys, os
-from bench.config.common_site_config import get_config
+from bench.config.common_site_config import get_config, update_config
 from bench.app import pull_all_apps, is_version_upgrade
 from bench.utils import (update_bench, validate_upgrade, pre_upgrade, post_upgrade, before_update,
 	update_requirements, update_node_packages, backup_all_sites, patch_sites, build_assets,
@@ -69,6 +69,13 @@ def _update(pull=False, patch=False, build=False, update_bench=False, auto=False
 
 	before_update(bench_path=bench_path, requirements=requirements)
 
+	config.update({ "maintenance_mode": 1, "pause_scheduler": 1 })
+	update_config(config, bench_path=bench_path)
+
+	if not no_backup:
+		print('Backing up sites...')
+		backup_all_sites(bench_path=bench_path)
+
 	if pull:
 		pull_all_apps(bench_path=bench_path, reset=reset)
 
@@ -89,10 +96,6 @@ def _update(pull=False, patch=False, build=False, update_bench=False, auto=False
 			reload(bench.app)
 
 	if patch:
-		if not no_backup:
-			print('Backing up sites...')
-			backup_all_sites(bench_path=bench_path)
-
 		print('Patching sites...')
 		patch_sites(bench_path=bench_path)
 	if build:
@@ -103,6 +106,9 @@ def _update(pull=False, patch=False, build=False, update_bench=False, auto=False
 		restart_supervisor_processes(bench_path=bench_path)
 	if restart_systemd or conf.get('restart_systemd_on_update'):
 		restart_systemd_processes(bench_path=bench_path)
+
+	config.update({ "maintenance_mode": 0, "pause_scheduler": 0 })
+	update_config(config, bench_path=bench_path)
 
 	print("_"*80)
 	print("Bench: Deployment tool for Frappe and ERPNext (https://erpnext.org).")


### PR DESCRIPTION
- While doing bench update, the system pulls the latest code first. Then it takes the backup of the sites, which can take a lot of time. In the meantime, the sites are not down and run the latest js code (which don't need to rebuild) and it can lead to errors. Thus taking a backup first before pulling the latest code.

- Another thing, as soon as migration finishes for one site, the site comes online. But supervisor reloaded only after migrating all sites. Which can lead to error due to inconsistent codebase and meta


