### PR TITLE
[Readme]Update Python info in pre-requisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To manually install frappe/erpnext, you can follow this [this wiki](https://gith
 
 #### 1. Install Pre-requisites
 
-- Python 2.7 [Python3.5+ also supported, but not recommended for production]
+- Python 3.6+
 - MariaDB 10+
 - Nginx (for production)
 - Nodejs


### PR DESCRIPTION
Removed the requirement for Python 2.7 and replaced with Python 3.6+. Removed reference of Python 3.5 not being recommended for production.