### PR TITLE
fix: Use 'venv' instead of 'virtualenv' for Python 3.4+

### DIFF
--- a/bench/utils.py
+++ b/bench/utils.py
@@ -175,7 +175,11 @@ def setup_env(bench_path='.', python = 'python3'):
 	python = which(python, raise_err = True)
 	pip    = os.path.join('env', 'bin', 'pip')
 
-	exec_cmd('virtualenv -q {} -p {}'.format('env', python), cwd=bench_path)
+	# Check Python version for which virtual environment command to use.
+	if sys.version_info[0] == 3 and sys.version_info[1] >= 4:
+		exec_cmd('{} -m venv {}'.format(python, 'env'), cwd=bench_path)
+	else:
+		exec_cmd('virtualenv -q {} -p {}'.format('env', python), cwd=bench_path)
 	exec_cmd('{} -q install --upgrade pip'.format(pip), cwd=bench_path)
 	exec_cmd('{} -q install wheel'.format(pip), cwd=bench_path)
 	exec_cmd('{} -q install six'.format(pip), cwd=bench_path)


### PR DESCRIPTION
Pull-Request

- [ x ] Have you followed the guidelines in our Contributing document?
- [ x ] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [ x ] Have you lint your code locally prior to submission?
- [ x ] Have you successfully run tests with your changes locally?
- [ ] Does your commit message have an explanation for your changes and why you'd like us to include them?
- [ ] Docs have been added / updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Did you modify the existing test cases? If yes, why?

---

What type of a PR is this? 

- [ x ] Changes to Existing Features
- [ ] New Feature Submissions
- [ ] Bug Fix
- [ ] Breaking Change

--- 

Newer versions of Python use the 'venv' command to create Virtual Environments.  The old 'virtualenv' and 'pyenv' ways of creating environments are deprecated.

https://docs.python.org/3/library/venv.html

To test, I created a fresh install of Ubuntu 18.10, installed Python 3.7 but *without* virtualenv.  Then I manually installed Python venv.  This small change "utils.py" made Bench recognize that I was running a new version of Python, and that 'venv' should be used to create the virtual environments.

Let me know what you think?  I'm currently using this in my personal branch of Bench.