### PR TITLE
fix: adding dirmngr as dependency for debian, ubuntu playbooks

### DIFF
--- a/playbooks/develop/debian.yml
+++ b/playbooks/develop/debian.yml
@@ -31,6 +31,7 @@
       # basic installs
       - build-essential
       - redis-server
+      - dirmngr
 
       # for mariadb
       - software-properties-common

--- a/playbooks/develop/ubuntu.yml
+++ b/playbooks/develop/ubuntu.yml
@@ -15,6 +15,7 @@
       # basic installs
       - build-essential
       - redis-server
+      - dirmngr
 
       # for mariadb
       - software-properties-common


### PR DESCRIPTION
Pull-Request

- [X] Have you followed the guidelines in our Contributing document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [ ] Have you lint your code locally prior to submission?
- [ ] Have you successfully run tests with your changes locally?
- [ ] Does your commit message have an explanation for your changes and why you'd like us to include them?
- [ ] Docs have been added / updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Did you modify the existing test cases? If yes, why?

---

What type of a PR is this? 

- [ ] Changes to Existing Features
- [ ] New Feature Submissions
- [X] Bug Fix
- [ ] Breaking Change

--- 

- Motivation and Context (What existing problem does the pull request solve):
- Related Issue: 
- Screenshots (if applicable, remember, a picture tells a thousand words): 

This resolves the missing dependency issue (#808) for Debian/ubuntu for _dirmngr_.
See also https://discuss.erpnext.com/t/install-script-fails-on-debian-9-2019-07-29/51252


