### PR TITLE
Replaced libssl1.0-dev packange name with libssl-dev

### DIFF
--- a/playbooks/install.py
+++ b/playbooks/install.py
@@ -14,7 +14,7 @@ def install_bench(args):
 	success = run_os_command({
 		'apt-get': [
 			'sudo apt-get update',
-			'sudo apt-get install -y git build-essential python3-setuptools python3-dev libffi-dev libssl1.0-dev'
+			'sudo apt-get install -y git build-essential python3-setuptools python3-dev libffi-dev libssl-dev'
 		],
 		'yum': [
 			'sudo yum groupinstall -y "Development tools"',

--- a/playbooks/roles/common/tasks/debian_family.yml
+++ b/playbooks/roles/common/tasks/debian_family.yml
@@ -12,7 +12,7 @@
     - libcrypto++-dev
     - libfreetype6-dev
     - liblcms2-dev
-    - libssl1.0-dev
+    - libssl-dev
     - libwebp-dev
     - libxext6
     - libxrender1


### PR DESCRIPTION
---

Bug Fix: Cannot install on Ubuntu 18.04 LTS

---

**libssl1.0-dev** package name is replaced by **libssl-dev** .
Modified `install.py` and `debian_family.yml` files.

