### PR TITLE
fix(Crontab): ArchLinux which uses the FreeBSD syntax

### DIFF
--- a/bench/utils.py
+++ b/bench/utils.py
@@ -243,7 +243,7 @@ def add_to_crontab(line):
 	line = str.encode(line)
 	if not line in current_crontab:
 		cmd = ["crontab"]
-		if platform.system() == 'FreeBSD':
+		if platform.system() == 'FreeBSD' or platform.linux_distribution()[0]=="arch":
 			cmd = ["crontab", "-"]
 		s = subprocess.Popen(cmd, stdin=subprocess.PIPE)
 		s.stdin.write(current_crontab)


### PR DESCRIPTION
What type of a PR is this? 
- [X ] Bug Fix
--- 

- Motivation and Context (What existing problem does the pull request solve):

_bench init_ on Arch Linux fails to set up a crontab due to missing input argument. It shows the following error:

`INFO:bench.utils:setting up auto update
crontab: usage error: file name or - (for stdin) must be specified for replace`

This pull request modifies the setup script to detect Arch Linux and use the correct arguments resulting in the crontab being set-up successfully.