### PR TITLE
commands to set redis hosts

### DIFF
--- a/bench/commands/__init__.py
+++ b/bench/commands/__init__.py
@@ -47,7 +47,7 @@ bench_command.add_command(switch_to_develop)
 
 from bench.commands.utils import (start, restart, set_nginx_port, set_ssl_certificate, set_ssl_certificate_key, set_url_root,
 	set_mariadb_host, set_default_site, download_translations, shell, backup_site, backup_all_sites, release, renew_lets_encrypt,
-	disable_production, bench_src, prepare_beta_release)
+	disable_production, bench_src, prepare_beta_release, set_redis_cache_host, set_redis_queue_host, set_redis_socketio_host)
 bench_command.add_command(start)
 bench_command.add_command(restart)
 bench_command.add_command(set_nginx_port)
@@ -55,6 +55,9 @@ bench_command.add_command(set_ssl_certificate)
 bench_command.add_command(set_ssl_certificate_key)
 bench_command.add_command(set_url_root)
 bench_command.add_command(set_mariadb_host)
+bench_command.add_command(set_redis_cache_host)
+bench_command.add_command(set_redis_queue_host)
+bench_command.add_command(set_redis_socketio_host)
 bench_command.add_command(set_default_site)
 bench_command.add_command(download_translations)
 bench_command.add_command(shell)

--- a/bench/commands/utils.py
+++ b/bench/commands/utils.py
@@ -71,9 +71,8 @@ def set_mariadb_host(host):
 @click.argument('host')
 def set_redis_cache_host(host):
 	"""
-		Set Redis cache host for bench
-
-		Eg: bench set-redis-cache-host localhost:6379/1
+	Set Redis cache host for bench
+	Eg: bench set-redis-cache-host localhost:6379/1
 	"""
 	from bench.utils import set_redis_cache_host
 	set_redis_cache_host(host)
@@ -82,9 +81,8 @@ def set_redis_cache_host(host):
 @click.argument('host')
 def set_redis_queue_host(host):
 	"""
-		Set Redis queue host for bench
-
-		Eg: bench set-redis-queue-host localhost:6379/2
+	Set Redis queue host for bench
+	Eg: bench set-redis-queue-host localhost:6379/2
 	"""
 	from bench.utils import set_redis_queue_host
 	set_redis_queue_host(host)
@@ -93,9 +91,8 @@ def set_redis_queue_host(host):
 @click.argument('host')
 def set_redis_socketio_host(host):
 	"""
-		Set Redis socketio host for bench
-
-		Eg: bench set-redis-socketio-host localhost:6379/3
+	Set Redis socketio host for bench
+	Eg: bench set-redis-socketio-host localhost:6379/3
 	"""
 	from bench.utils import set_redis_socketio_host
 	set_redis_socketio_host(host)

--- a/bench/commands/utils.py
+++ b/bench/commands/utils.py
@@ -67,6 +67,39 @@ def set_mariadb_host(host):
 	from bench.utils import set_mariadb_host
 	set_mariadb_host(host)
 
+@click.command('set-redis-cache-host')
+@click.argument('host')
+def set_redis_cache_host(host):
+	"""
+		Set Redis cache host for bench
+
+		Eg: bench set-redis-cache-host localhost:6379/1
+	"""
+	from bench.utils import set_redis_cache_host
+	set_redis_cache_host(host)
+
+@click.command('set-redis-queue-host')
+@click.argument('host')
+def set_redis_queue_host(host):
+	"""
+		Set Redis queue host for bench
+
+		Eg: bench set-redis-queue-host localhost:6379/2
+	"""
+	from bench.utils import set_redis_queue_host
+	set_redis_queue_host(host)
+
+@click.command('set-redis-socketio-host')
+@click.argument('host')
+def set_redis_socketio_host(host):
+	"""
+		Set Redis socketio host for bench
+
+		Eg: bench set-redis-socketio-host localhost:6379/3
+	"""
+	from bench.utils import set_redis_socketio_host
+	set_redis_socketio_host(host)
+
 
 @click.command('set-default-site')
 @click.argument('site')

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -524,6 +524,15 @@ def is_root():
 def set_mariadb_host(host, bench_path='.'):
 	update_common_site_config({'db_host': host}, bench_path=bench_path)
 
+def set_redis_cache_host(host, bench_path='.'):
+	update_common_site_config({'redis_cache': "redis://{}".format(host)}, bench_path=bench_path)
+
+def set_redis_queue_host(host, bench_path='.'):
+	update_common_site_config({'redis_queue': "redis://{}".format(host)}, bench_path=bench_path)
+
+def set_redis_socketio_host(host, bench_path='.'):
+	update_common_site_config({'redis_socketio': "redis://{}".format(host)}, bench_path=bench_path)
+
 def update_common_site_config(ddict, bench_path='.'):
 	update_json_file(os.path.join(bench_path, 'sites', 'common_site_config.json'), ddict)
 


### PR DESCRIPTION
Set redis hosts from command line.

bench set-redis-cache-host <host>:<port>/<db>
bench set-redis-queue-host <host>:<port>/<db>
bench set-redis-socketio-host <host>:<port>/<db>

port and db are optional