### PR TITLE
chore: pin ansible version to 2.8.5

### DIFF
--- a/playbooks/install.py
+++ b/playbooks/install.py
@@ -61,7 +61,7 @@ def install_bench(args):
 				})
 
 	success = run_os_command({
-		'pip': "sudo pip install --upgrade setuptools cryptography ansible pip"
+		'pip': "sudo pip install --upgrade setuptools cryptography ansible==2.8.5 pip"
 	})
 
 	if not success:


### PR DESCRIPTION
i think some changes to the newer version of ansible api (2.9.0) causes mariadb installation to fail spectacularly. pinning the ansible version to 2.8.5 should fix this issue for now.

