### PR TITLE
bench.get_sites now do same checks to validate a site folder like frappe.utils.get_sites

### DIFF
--- a/bench/commands/utils.py
+++ b/bench/commands/utils.py
@@ -139,7 +139,7 @@ def shell(bench_path='.'):
 def backup_site(site):
 	"backup site"
 	from bench.utils import get_sites, backup_site
-	if not site in get_sites(bench_path='.'):
+	if site not in get_sites(bench_path='.'):
 		print('site not found')
 		sys.exit(1)
 	backup_site(site, bench_path='.')

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -208,10 +208,15 @@ def build_assets(bench_path='.', app=None):
 		exec_cmd(command, cwd=bench_path)
 
 def get_sites(bench_path='.'):
-	sites_dir = os.path.join(bench_path, "sites")
-	sites = [site for site in os.listdir(sites_dir)
-		if os.path.isdir(os.path.join(sites_dir, site)) and site not in ('assets',)]
-	return sites
+	sites_path = os.path.join(bench_path, 'sites')
+	sites = []
+	for site in os.listdir(sites_path):
+		path = os.path.join(sites_path, site)
+		if (os.path.isdir(path)
+			and not os.path.islink(path)
+			and os.path.exists(os.path.join(path, 'site_config.json'))):
+			sites.append(site)
+	return sorted(sites)
 
 def get_sites_dir(bench_path='.'):
 	return os.path.abspath(os.path.join(bench_path, 'sites'))

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -209,17 +209,8 @@ def build_assets(bench_path='.', app=None):
 
 def get_sites(bench_path='.'):
 	sites_path = os.path.join(bench_path, 'sites')
-	sites = []
-	for site in os.listdir(sites_path):
-		path = os.path.join(sites_path, site)
-		if (os.path.isdir(path)
-			and not os.path.islink(path)
-			and os.path.exists(os.path.join(path, 'site_config.json'))):
-			sites.append(site)
-	return sorted(sites)
-
-def get_sites_dir(bench_path='.'):
-	return os.path.abspath(os.path.join(bench_path, 'sites'))
+	sites = (site for site in os.listdir(sites_path) if os.path.exists(os.path.join(sites_path, site, 'site_config.json')))
+	return sites
 
 def get_bench_dir(bench_path='.'):
 	return os.path.abspath(bench_path)
@@ -425,7 +416,7 @@ def restart_systemd_processes(bench_path='.', web_workers=False):
 	exec_cmd('sudo systemctl start -- $(systemctl show -p Requires {bench_name}.target | cut -d= -f2)'.format(bench_name=bench_name))
 
 def set_default_site(site, bench_path='.'):
-	if not site in get_sites(bench_path=bench_path):
+	if site not in get_sites(bench_path=bench_path):
 		raise Exception("Site not in bench")
 	exec_cmd("{frappe} --use {site}".format(frappe=get_frappe(bench_path=bench_path), site=site),
 			cwd=os.path.join(bench_path, 'sites'))


### PR DESCRIPTION
Pull-Request

- [X] Have you followed the guidelines in our Contributing document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [X] Have you lint your code locally prior to submission?
- [X] Have you successfully run tests with your changes locally?
- [X] Does your commit message have an explanation for your changes and why you'd like us to include them?
- [ ] Docs have been added / updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Did you modify the existing test cases? If yes, why?

---

What type of a PR is this? 

- [ ] Changes to Existing Features
- [ ] New Feature Submissions
- [X] Bug Fix
- [ ] Breaking Change

--- 

- Motivation and Context (What existing problem does the pull request solve):
get_sites from bench differs from get_sites from frappe.utils generating errors when there is a "jupyter_notebooks" folder created by the "bench jupyter" command

- Related Issue: 
If you used "bench jupyter" the bench creates a "jupyter_notebooks" folder inside "sites" where it stores all notebooks.
If you run "bench update" it does not run because it does not check if that folder is a real site and stops when doing site backups.
I just move the same site verifications into frappe.utils.get_sites to bench.get_sites and solve the issue.

- Screenshots (if applicable, remember, a picture tells a thousand words): 
None
