### PR TITLE
fix: bench update compatible venv installed pkg

### DIFF
--- a/bench/utils.py
+++ b/bench/utils.py
@@ -503,6 +503,10 @@ def update_npm_packages(bench_path='.'):
 
 def install_requirements(pip, req_file, user=False):
 	if os.path.exists(req_file):
+		# sys.real_prefix exists only in a virtualenv
+		if hasattr(sys, 'real_prefix'):
+			user = False
+
 		user_flag = "--user" if user else ""
 		exec_cmd("{pip} install {user_flag} -q -U -r {req_file}".format(pip=pip, user_flag=user_flag, req_file=req_file))
 


### PR DESCRIPTION
Fixes "bench update" if bench is installed in a virtual environment

![Screenshot 2019-11-29 at 5 19 18 PM](https://user-images.githubusercontent.com/36654812/69867305-68da8080-12cc-11ea-9b35-139ca526541a.png)
