### PR TITLE
security(nginx): use only strong ciphers over ssl

### DIFF
--- a/bench/config/templates/nginx.conf
+++ b/bench/config/templates/nginx.conf
@@ -12,7 +12,12 @@ map {{ from_variable }} {{ to_variable }} {
 
 {%- macro server_block(bench_name, port, server_names, site_name, sites_path, ssl_certificate, ssl_certificate_key) %}
 server {
+	{% if ssl_certificate and ssl_certificate_key %}
+	listen {{ port }} ssl;
+	{% else %}
 	listen {{ port }};
+	{% endif %}
+
 	server_name
 		{% for name in server_names -%}
 		{{ name }}

--- a/bench/config/templates/nginx.conf
+++ b/bench/config/templates/nginx.conf
@@ -30,12 +30,20 @@ server {
 	ssl_certificate      {{ ssl_certificate }};
 	ssl_certificate_key  {{ ssl_certificate_key }};
 	ssl_session_timeout  5m;
-	ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-	ssl_ciphers "EECDH+ECDSA+AESGCM EECDH+aRSA+AESGCM EECDH+ECDSA+SHA384 EECDH+ECDSA+SHA256 EECDH+aRSA+SHA384 EECDH+aRSA+SHA256 EECDH+aRSA+RC4 EECDH EDH+aRSA RC4 !aNULL !eNULL !LOW !3DES !MD5 !EXP !PSK !SRP !DSS";
-	ssl_prefer_server_ciphers   on;
+	ssl_session_cache shared:SSL:10m;
+	ssl_session_tickets off;
+	ssl_stapling on;
+	ssl_stapling_verify on;
+	ssl_protocols TLSv1.2 TLSv1.3;
+	ssl_ciphers EECDH+AESGCM:EDH+AESGCM;
+	ssl_ecdh_curve secp384r1;
+	ssl_prefer_server_ciphers on;
 	{% endif %}
 
 	add_header X-Frame-Options "SAMEORIGIN";
+	add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload";
+	add_header X-Content-Type-Options nosniff;
+	add_header X-XSS-Protection "1; mode=block";
 
 	location /assets {
 		try_files $uri =404;


### PR DESCRIPTION
* drop support for TLSv1 and TLSv1.1, and add support for TLSv1.3
* disable all ciphers else for EECDH+AESGCM and EDH+AESGCM
* disable session ticketing
* use secp384r1 as certificate curve
* enable strict transport security with preloading
* enable xss-protection

[SSLLabs Result](https://www.ssllabs.com/ssltest/analyze.html?d=frappe.io) for frappe.io:

![image](https://user-images.githubusercontent.com/11243138/70369386-a0ee4e80-18de-11ea-9d13-4a778a4bfd96.png)


