### PR TITLE
Create dockerfile for quick build, for those who want to avoid complex setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+## Dockerfile for quick build, not for production use.
+FROM ubuntu:latest
+
+RUN mkdir -p /erpnext
+
+WORKDIR /erpnext
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get clean && apt-get update && \
+    apt-get install -y python-minimal build-essential python-setuptools wget sudo dbus systemd locales && \
+    wget https://raw.githubusercontent.com/frappe/bench/master/playbooks/install.py && \
+    useradd -m -s /bin/bash erpnextuser && usermod -aG sudo erpnextuser && \
+    echo "erpnextuser ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
+    echo "%erpnextuser  ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
+    chown -R erpnextuser /erpnext && \
+    apt-get install dbus && mkdir -p /run/dbus && \
+    service dbus start || true && \
+    dbus-daemon --system || true
+
+RUN apt-get -y install python-apt
+RUN apt-get -y install cron
+USER erpnextuser
+
+## Password for mysql and admin is admin@123
+RUN sudo service dbus start && sudo locale-gen en_US.UTF-8 && sudo localectl set-locale LANG=en_US.utf8 && \
+    mkdir -p /home/erpnextuser/.npm; sudo chown -R $USER:$GROUP ~/.npm || true && \
+    mkdir -p /home/erpnextuser/.config; sudo chown -R $USER:$GROUP ~/.config &&\
+    yes "admin@123" | sudo python install.py --develop --container
+
+WORKDIR /home/erpnextuser/frappe-bench
+RUN cd /home/erpnextuser/frappe-bench/apps/erpnext; yarn install
+RUN cd /home/erpnextuser/frappe-bench/apps/frappe; yarn install
+RUN npm install socket.io redis express superagent cookie chalk --save
+
+EXPOSE 8000/tcp
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+COPY entrypoint.sh /home/erpnextuser/frappe-bench/entrypoint.sh
+CMD ["/bin/bash","entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+echo "Starting mysql server"
+sudo service mysql start
+echo "Starting bench"
+bench start


### PR DESCRIPTION
Added a dockerfile for quick build, should not be used in production.
Build using: `docker build -t erpnext .`

Pull-Request

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [x] Have you lint your code locally prior to submission?
- [x] Have you successfully run tests with your changes locally?
- [x] Does your commit message have an explanation for your changes and why you'd like us to include them?
- [x] Docs have been added / updated
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Did you modify the existing test cases? If yes, why?

---

What type of a PR is this? 

- [ ] Changes to Existing Features
- [x] New Feature Submissions
- [ ] Bug Fix
- [ ] Breaking Change

--- 

- **Motivation and Context (What existing problem does the pull request solve):**
Setup for even testing out product wasn't easy. This Dockerfile just basically does that, only if now we could put these images somewhere, so people can pull and start the images and not have to rely on a virtual box image.
