### PR TITLE
feat(easy_install): add support for debian 10

### DIFF
--- a/playbooks/install.py
+++ b/playbooks/install.py
@@ -142,7 +142,7 @@ def install_bench(args):
 		shutil.rmtree(tmp_bench_repo)
 
 def check_distribution_compatibility():
-	supported_dists = {'ubuntu': [14, 15, 16, 18, 19], 'debian': [8, 9],
+	supported_dists = {'ubuntu': [14, 15, 16, 18, 19], 'debian': [8, 9, 10],
 		'centos': [7], 'macos': [10.9, 10.10, 10.11, 10.12]}
 
 	dist_name, dist_version = get_distribution_info()
@@ -389,7 +389,7 @@ def parse_commandline_args():
 
 	# set passwords
 	parser.add_argument('--mysql-root-password', dest='mysql_root_password', help='Set mysql root password')
-	parser.add_argument('--mariadb-version', dest='mariadb_version', default='10.2', help='Specify mariadb version')
+	parser.add_argument('--mariadb-version', dest='mariadb_version', default='10.4', help='Specify mariadb version')
 	parser.add_argument('--admin-password', dest='admin_password', help='Set admin password')
 	parser.add_argument('--bench-name', dest='bench_name', help='Create bench with specified name. Default name is frappe-bench')
 

--- a/playbooks/roles/common/tasks/debian.yml
+++ b/playbooks/roles/common/tasks/debian.yml
@@ -12,14 +12,33 @@
     - tk8.5-dev
   when: ansible_distribution_version | version_compare('8', 'lt')
 
-- name: install pillow prerequisites for Debian >= 8
+- name: install pillow prerequisites for Debian 8
   apt: pkg={{ item }} state=present
   with_items:
     - libjpeg62-turbo-dev
     - libtiff5-dev
     - tcl8.5-dev
     - tk8.5-dev
-  when: ansible_distribution_version | version_compare('8', 'ge')
+  when: ansible_distribution_version | version_compare('8', 'eq')
+
+- name: install pillow prerequisites for Debian 9
+  apt: pkg={{ item }} state=present
+  with_items:
+    - libjpeg62-turbo-dev
+    - libtiff5-dev
+    - tcl8.5-dev
+    - tk8.5-dev
+  when: ansible_distribution_version | version_compare('9', 'eq')
+
+
+- name: install pillow prerequisites for Debian >= 10
+  apt: pkg={{ item }} state=present
+  with_items:
+    - libjpeg62-turbo-dev
+    - libtiff5-dev
+    - tcl8.6-dev
+    - tk8.6-dev
+  when: ansible_distribution_version | version_compare('10', 'ge')
 
 - name: install pdf prerequisites debian
   apt: pkg={{ item }} state=present force=yes

--- a/playbooks/roles/nodejs/tasks/debian_family.yml
+++ b/playbooks/roles/nodejs/tasks/debian_family.yml
@@ -7,7 +7,9 @@
 
 - name: Install nodejs {{ node_version }}
   apt:
-    name: nodejs
+    name: 
+      - nodejs
+      - npm
     state: present
     update_cache: yes
     force: yes


### PR DESCRIPTION
Pull-Request
---
What type of a PR is this? 

- [x] Changes to Existing Features
- [x] New Feature Submissions
- [ ] Bug Fix
- [ ] Breaking Change

--- 

- Easy Installer did not support Debian 10 Buster, so I changed the playbooks to support Debian 10.
- Related Issue: #831 
- Tested in a newly deployed Debian 10 Buster running on KVM and in a brand new deployed LXC Container (--container) also running fine.
