### PR TITLE
fix: use six to check for string types

### DIFF
--- a/bench/config/nginx.py
+++ b/bench/config/nginx.py
@@ -1,5 +1,6 @@
 import os, json, click, random, string, hashlib
 from bench.utils import get_sites, get_bench_name, exec_cmd
+from six import string_types
 
 def make_nginx_conf(bench_path, yes=False):
 	from bench import env
@@ -214,7 +215,7 @@ def get_sites_with_config(bench_path):
 		if dns_multitenant and site_config.get('domains'):
 			for domain in site_config.get('domains'):
 				# domain can be a string or a dict with 'domain', 'ssl_certificate', 'ssl_certificate_key'
-				if isinstance(domain, str) or isinstance(domain, unicode):
+				if isinstance(domain, string_types):
 					domain = { 'domain': domain }
 
 				domain['name'] = site
@@ -227,7 +228,7 @@ def get_sites_with_config(bench_path):
 def use_wildcard_certificate(bench_path, ret):
 	'''
 		stored in common_site_config.json as:
-	    "wildcard": {
+		"wildcard": {
 			"domain": "*.erpnext.com",
 			"ssl_certificate": "/path/to/erpnext.com.cert",
 			"ssl_certificate_key": "/path/to/erpnext.com.key"


### PR DESCRIPTION
fixes #873 where `unicode` keyword does not exist for python3:

```python-traceback
Traceback (most recent call last):
  File "/usr/local/bin/bench", line 11, in <module>
    load_entry_point('bench', 'console_scripts', 'bench')()
  File "/home/frappe/.bench/bench/cli.py", line 40, in cli
    bench_command()
  File "/usr/local/lib/python3.6/dist-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.6/dist-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.6/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.6/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.6/dist-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.6/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/frappe/.bench/bench/commands/setup.py", line 22, in setup_nginx
    make_nginx_conf(bench_path=".", yes=yes)
  File "/home/frappe/.bench/bench/config/nginx.py", line 13, in make_nginx_conf
    sites = prepare_sites(config, bench_path)
  File "/home/frappe/.bench/bench/config/nginx.py", line 100, in prepare_sites
    sites_configs = get_sites_with_config(bench_path=bench_path)
  File "/home/frappe/.bench/bench/config/nginx.py", line 217, in get_sites_with_config
    if isinstance(domain, str) or isinstance(domain, unicode):
NameError: name 'unicode' is not defined
```
