### PR TITLE
fix(fonts): remove unused setup_fonts method

### DIFF
--- a/bench/commands/setup.py
+++ b/bench/commands/setup.py
@@ -41,12 +41,6 @@ def setup_redis():
 	generate_config('.')
 
 
-@click.command('fonts')
-def setup_fonts():
-	"Add frappe fonts to system"
-	from bench.utils import setup_fonts
-	setup_fonts()
-
 @click.command('production')
 @click.argument('user')
 @click.option('--yes', help='Yes to regeneration config', is_flag=True, default=False)
@@ -324,7 +318,6 @@ setup.add_command(setup_socketio)
 setup.add_command(setup_requirements)
 setup.add_command(setup_manager)
 setup.add_command(setup_config)
-setup.add_command(setup_fonts)
 setup.add_command(add_domain)
 setup.add_command(remove_domain)
 setup.add_command(sync_domains)

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -794,20 +794,6 @@ def validate_pillow_dependencies(bench_path, requirements):
 def get_bench_name(bench_path):
 	return os.path.basename(os.path.abspath(bench_path))
 
-def setup_fonts():
-	fonts_path = os.path.join('/tmp', 'fonts')
-
-	if os.path.exists('/etc/fonts_backup'):
-		return
-
-	exec_cmd("git clone https://github.com/frappe/fonts.git", cwd='/tmp')
-	os.rename('/etc/fonts', '/etc/fonts_backup')
-	os.rename('/usr/share/fonts', '/usr/share/fonts_backup')
-	os.rename(os.path.join(fonts_path, 'etc_fonts'), '/etc/fonts')
-	os.rename(os.path.join(fonts_path, 'usr_share_fonts'), '/usr/share/fonts')
-	shutil.rmtree(fonts_path)
-	exec_cmd("fc-cache -fv")
-
 def set_git_remote_url(git_url, bench_path='.'):
 	"Set app remote git url"
 	app = git_url.rsplit('/', 1)[1].rsplit('.', 1)[0]


### PR DESCRIPTION
this method replaces existing system fonts directory under `/etc/fonts` and `/usr/share/fonts` with fonts that are probably obsolete by now and are no longer used.

removing this method so that it does not mess with anybody's system fonts.