### PR TITLE
fix(debian_family): no need to install npm seperately

### DIFF
--- a/playbooks/roles/nodejs/tasks/debian_family.yml
+++ b/playbooks/roles/nodejs/tasks/debian_family.yml
@@ -7,9 +7,8 @@
 
 - name: Install nodejs {{ node_version }}
   apt:
-    name: 
+    name:
       - nodejs
-      - npm
     state: present
     update_cache: yes
     force: yes


### PR DESCRIPTION
**Error**:
```
fatal: [localhost]: FAILED! => {
    "cache_update_time": 1577095593,
    "cache_updated": false,
    "changed": false,
    "invocation": {
        "module_args": {
            "allow_unauthenticated": false,
            "autoclean": false,
            "autoremove": false,
            "cache_valid_time": 0,
            "deb": null,
            "default_release": null,
            "dpkg_options": "force-confdef,force-confold",
            "force": true,
            "force_apt_get": false,
            "install_recommends": null,
            "name": [
                "nodejs",
                "npm"
            ],
            "only_upgrade": false,
            "package": [
                "nodejs",
                "npm"
            ],
            "policy_rc_d": null,
            "purge": false,
            "state": "present",
            "update_cache": true,
            "upgrade": null
        }
    },
    "msg": "'/usr/bin/apt-get -y -o \"Dpkg::Options::=--force-confdef\" -o \"Dpkg::Options::=--force-confold\"   --force-yes   install 'nodejs' 'npm'' failed: W: --force-yes is deprecated, use one of the options starting with --allow instead.\nE: Unable to correct problems, you have held broken packages.\n",
    "rc": 100,
    "stderr": "W: --force-yes is deprecated, use one of the options starting with --allow instead.\nE: Unable to correct problems, you have held broken packages.\n",
    "stderr_lines": [
        "W: --force-yes is deprecated, use one of the options starting with --allow instead.",
        "E: Unable to correct problems, you have held broken packages."
    ],
    "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\nSome packages could not be installed. This may mean that you have\nrequested an impossible situation or if you are using the unstable\ndistribution that some required packages have not yet been created\nor been moved out of Incoming.\nThe following information may help to resolve the situation:\n\nThe following packages have unmet dependencies:\n nodejs : Conflicts: npm\n",
    "stdout_lines": [
        "Reading package lists...",
        "Building dependency tree...",
        "Reading state information...",
        "Some packages could not be installed. This may mean that you have",
        "requested an impossible situation or if you are using the unstable",
        "distribution that some required packages have not yet been created",
        "or been moved out of Incoming.",
        "The following information may help to resolve the situation:",
        "",
        "The following packages have unmet dependencies:",
        " nodejs : Conflicts: npm"
    ]
}
```
**Solution**: Nodejs package includes both nodejs-dev and npm. No need to install npm separately.
**Reference**: https://stackoverflow.com/questions/16302436/install-node-js-on-ubuntu