### PR TITLE
perf: faster bench

### DIFF
--- a/bench/commands/__init__.py
+++ b/bench/commands/__init__.py
@@ -47,7 +47,8 @@ bench_command.add_command(switch_to_develop)
 
 from bench.commands.utils import (start, restart, set_nginx_port, set_ssl_certificate, set_ssl_certificate_key, set_url_root,
 	set_mariadb_host, set_default_site, download_translations, shell, backup_site, backup_all_sites, release, renew_lets_encrypt,
-	disable_production, bench_src, prepare_beta_release, set_redis_cache_host, set_redis_queue_host, set_redis_socketio_host)
+	disable_production, bench_src, prepare_beta_release, set_redis_cache_host, set_redis_queue_host, set_redis_socketio_host,
+	generate_command_cache, clear_command_cache)
 bench_command.add_command(start)
 bench_command.add_command(restart)
 bench_command.add_command(set_nginx_port)
@@ -68,6 +69,8 @@ bench_command.add_command(renew_lets_encrypt)
 bench_command.add_command(disable_production)
 bench_command.add_command(bench_src)
 bench_command.add_command(prepare_beta_release)
+bench_command.add_command(generate_command_cache)
+bench_command.add_command(clear_command_cache)
 
 from bench.commands.setup import setup
 bench_command.add_command(setup)

--- a/bench/commands/update.py
+++ b/bench/commands/update.py
@@ -5,7 +5,7 @@ from bench.config.common_site_config import get_config, update_config
 from bench.app import pull_all_apps, is_version_upgrade, validate_branch
 from bench.utils import (update_bench, validate_upgrade, pre_upgrade, post_upgrade, before_update,
 	update_requirements, update_node_packages, backup_all_sites, patch_sites, build_assets,
-	restart_supervisor_processes, restart_systemd_processes, is_bench_directory)
+	restart_supervisor_processes, restart_systemd_processes, is_bench_directory, clear_command_cache)
 from bench import patches
 from six.moves import reload_module
 
@@ -29,6 +29,8 @@ def update(pull=False, patch=False, build=False, bench=False, auto=False, restar
 		"""Update only bench if bench update called from outside a bench"""
 		update_bench(bench_repo=True, requirements=True)
 		sys.exit()
+
+	clear_command_cache(bench_path='.')
 
 	if not (pull or patch or build or bench or requirements):
 		pull, patch, build, bench, requirements = True, True, True, True, True

--- a/bench/commands/utils.py
+++ b/bench/commands/utils.py
@@ -190,3 +190,23 @@ def bench_src():
 	"""Prints bench source folder path, which can be used as: cd `bench src` """
 	import bench
 	print(os.path.dirname(bench.__path__[0]))
+
+
+@click.command('generate-command-cache')
+def generate_command_cache(bench_path='.'):
+	"""
+	Caches Frappe commands (speeds up bench commands execution)
+	Default caching behaviour: generated the first time any command is run
+	"""
+	from bench.utils import generate_command_cache
+	return generate_command_cache(bench_path=bench_path)
+
+
+@click.command('clear-command-cache')
+def clear_command_cache(bench_path='.'):
+	"""
+	Clears commands cached
+	Default invalidation behaviour: destroyed on each run of `bench update`
+	"""
+	from bench.utils import clear_command_cache
+	return clear_command_cache(bench_path=bench_path)

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -69,7 +69,7 @@ def init(path, apps_path=None, no_procfile=False, no_backups=False,
 		try:
 			os.makedirs(os.path.join(path, dirname))
 		except OSError as e:
-			if e.errno == os.errno.EEXIST:
+			if e.errno == errno.EEXIST:
 				pass
 
 	setup_logging()
@@ -716,7 +716,7 @@ def update_translations_p(args):
 		print('Download failed for', args[0], args[1])
 
 def download_translations_p():
-	pool = multiprocessing.Pool(4)
+	pool = multiprocessing.Pool(multiprocessing.cpu_count())
 
 	langs = get_langs()
 	apps = ('frappe', 'erpnext')


### PR DESCRIPTION
What this does:
- caches Frappe commands in the bench folder in `.frappe-cmd` file
- re-generates the file on a run of `bench update` or manually by `bench clear-commands-cache`
- generates the cache file if not previously generated on execution of any bench command (like console, mariadb, etc) in the respective bench directory

New commands:
 - generate-commands-cache
 - clear-commands-cache

Misc. Changes:
- Run a single process to pip install prerequisites for new env setups
- Spawn processes as many as available CPUs for downloading translations