### PR TITLE
fix(easy_install): overwrite config files

### DIFF
--- a/playbooks/roles/bench/tasks/setup_bench_production.yml
+++ b/playbooks/roles/bench/tasks/setup_bench_production.yml
@@ -2,7 +2,7 @@
 - name: Setup production
   become: yes
   become_user: root
-  command: bench setup production {{ frappe_user }}
+  command: bench setup production {{ frappe_user }} --yes
   args:
     chdir: '{{ bench_path }}'
 


### PR DESCRIPTION
Easy install fails if run again after config files exist. Adding the `--yes` flag in the playbooks will overwrite any existing config files.

![Screenshot 2020-01-06 at 12 31 58 PM](https://user-images.githubusercontent.com/36654812/71801294-8d223d80-3080-11ea-9319-ab1042b1d3ed.png)
