### PR TITLE
fix(easy_install): log files saved with timestamp

### DIFF
--- a/playbooks/install.py
+++ b/playbooks/install.py
@@ -1,10 +1,16 @@
 #!/usr/bin/env python3
-import os, sys, subprocess, getpass, json, multiprocessing, shutil, platform, warnings
+import os, sys, subprocess, getpass, json, multiprocessing, shutil, platform, warnings, datetime
 
 
 tmp_bench_repo = os.path.join('/', 'tmp', '.bench')
 tmp_log_folder = os.path.join('/', 'tmp', 'logs')
-log_path = os.path.join(tmp_log_folder, 'install_bench.log')
+
+execution_day = "{:%Y-%m-%d}".format(datetime.datetime.utcnow())
+execution_time = "{:%H-%M}".format(datetime.datetime.utcnow())
+execution_ts = "{0}__{1}".format(execution_day, execution_time)
+
+log_file_name = "easy-install__{}.log".format(execution_ts)
+log_path = os.path.join(tmp_log_folder, log_file_name)
 log_stream = sys.stdout
 
 
@@ -29,6 +35,7 @@ def setup_log_stream(args):
 			os.makedirs(tmp_log_folder)
 		log_stream = open(log_path, 'w')
 		log("Logs are saved under {0}".format(log_path), level=3)
+		print("Install script run at {}\n\n".format(execution_ts), file=log_stream)
 
 
 def check_environment():
@@ -73,6 +80,7 @@ def check_distribution_compatibility():
 		if float(dist_version) in supported_dists[dist_name]:
 			log("{0} {1} is compatible!".format(dist_name, dist_version), level=1)
 		else:
+			log("{0} {1} is detected".format(dist_name, dist_version), level=1)
 			log("Install on {0} {1} instead".format(dist_name, supported_dists[dist_name][-1]), level=3)
 	else:
 		log("Sorry, the installer doesn't support {0}. Aborting installation!".format(dist_name), level=2)
@@ -277,12 +285,16 @@ def clone_bench_repo(args):
 	return success
 
 
+def passwords_didnt_match(context=''):
+	log("{} passwords did not match!".format(context), level=3)
+
+
 def get_passwords(args):
 	"""
 	Returns a dict of passwords for further use
 	and creates passwords.txt in the bench user's home directory
 	"""
-	log("Input mySQL and Frappe Administrator passwords:")
+	log("Input MySQL and Frappe Administrator passwords:")
 	ignore_prompt = args.run_travis or args.without_bench_setup
 	mysql_root_password, admin_password = '', ''
 	passwords_file_path = os.path.join(os.path.expanduser('~' + args.user), 'passwords.txt')
@@ -309,6 +321,7 @@ def get_passwords(args):
 				conf_mysql_passwd = getpass.unix_getpass(prompt='Re-enter mysql root password: ')
 
 				if mysql_root_password != conf_mysql_passwd or mysql_root_password == '':
+					passwords_didnt_match("MySQL")
 					mysql_root_password = ''
 					continue
 
@@ -318,6 +331,7 @@ def get_passwords(args):
 				conf_admin_passswd = getpass.unix_getpass(prompt='Re-enter Administrator password: ')
 
 				if admin_password != conf_admin_passswd or admin_password == '':
+					passwords_didnt_match("Administrator")
 					admin_password = ''
 					continue
 

--- a/playbooks/install.py
+++ b/playbooks/install.py
@@ -4,12 +4,10 @@ import os, sys, subprocess, getpass, json, multiprocessing, shutil, platform, wa
 
 tmp_bench_repo = os.path.join('/', 'tmp', '.bench')
 tmp_log_folder = os.path.join('/', 'tmp', 'logs')
-
-execution_day = "{:%Y-%m-%d}".format(datetime.datetime.utcnow())
-execution_time = "{:%H-%M}".format(datetime.datetime.utcnow())
-execution_ts = "{0}__{1}".format(execution_day, execution_time)
-
-log_file_name = "easy-install__{}.log".format(execution_ts)
+execution_timestamp = datetime.datetime.utcnow()
+execution_day = "{:%Y-%m-%d}".format(execution_timestamp)
+execution_time = "{:%H:%M}".format(execution_timestamp)
+log_file_name = "easy-install__{0}__{1}.log".format(execution_day, execution_time.replace(':', '-'))
 log_path = os.path.join(tmp_log_folder, log_file_name)
 log_stream = sys.stdout
 
@@ -35,7 +33,7 @@ def setup_log_stream(args):
 			os.makedirs(tmp_log_folder)
 		log_stream = open(log_path, 'w')
 		log("Logs are saved under {0}".format(log_path), level=3)
-		print("Install script run at {}\n\n".format(execution_ts), file=log_stream)
+		print("Install script run at {0} on {1}\n\n".format(execution_time, execution_day), file=log_stream)
 
 
 def check_environment():


### PR DESCRIPTION
Log files won't overwrite after each run of easy install script. 

Saved as `/tmp/logs/easy-install__{date}__{time}.log`

eg:

**date:** `2020-01-07` (YYYY-MM-DD)
**time:** `08:50` (24 hour format)
**file_name:** `/tmp/logs/easy-install__2020-01-07__08-50.log`

**_Note:_** UTC timestamps used



Misc. Additions:
- "Passwords don't match" message added
- Current distribution displayed while check