### PR TITLE
feat: "bench find", print log api

### DIFF
--- a/bench/cli.py
+++ b/bench/cli.py
@@ -93,7 +93,7 @@ def get_frappe_commands(bench_path='.'):
 	python = get_env_cmd('python', bench_path=bench_path)
 	sites_path = os.path.join(bench_path, 'sites')
 	if not os.path.exists(sites_path):
-		log("WARN: Command not being executed in bench directory", level=3)
+		log("Command not being executed in bench directory", level=3)
 		return []
 	try:
 		output = get_cmd_output("{python} -m frappe.utils.bench_helper get-frappe-commands".format(python=python), cwd=sites_path)

--- a/bench/cli.py
+++ b/bench/cli.py
@@ -1,6 +1,6 @@
 import click
 import os, sys, logging, json, pwd, subprocess
-from bench.utils import is_root, PatchError, drop_privileges, get_env_cmd, get_cmd_output, get_frappe
+from bench.utils import is_root, PatchError, drop_privileges, get_env_cmd, get_cmd_output, get_frappe, log
 from bench.app import get_apps
 from bench.config.common_site_config import get_config
 from bench.commands import bench_command
@@ -43,7 +43,7 @@ def cli():
 
 def check_uid():
 	if cmd_requires_root() and not is_root():
-		print('superuser privileges required for this command')
+		log('superuser privileges required for this command', level=3)
 		sys.exit(1)
 
 def cmd_requires_root():
@@ -71,7 +71,7 @@ def change_uid():
 			drop_privileges(uid_name=frappe_user, gid_name=frappe_user)
 			os.environ['HOME'] = pwd.getpwnam(frappe_user).pw_dir
 		else:
-			print('You should not run this command as root')
+			log('You should not run this command as root', level=3)
 			sys.exit(1)
 
 def old_frappe_cli(bench_path='.'):
@@ -93,6 +93,7 @@ def get_frappe_commands(bench_path='.'):
 	python = get_env_cmd('python', bench_path=bench_path)
 	sites_path = os.path.join(bench_path, 'sites')
 	if not os.path.exists(sites_path):
+		log("WARN: Command not being executed in bench directory", level=3)
 		return []
 	try:
 		output = get_cmd_output("{python} -m frappe.utils.bench_helper get-frappe-commands".format(python=python), cwd=sites_path)

--- a/bench/commands/__init__.py
+++ b/bench/commands/__init__.py
@@ -47,7 +47,7 @@ bench_command.add_command(switch_to_develop)
 
 from bench.commands.utils import (start, restart, set_nginx_port, set_ssl_certificate, set_ssl_certificate_key, set_url_root,
 	set_mariadb_host, set_default_site, download_translations, shell, backup_site, backup_all_sites, release, renew_lets_encrypt,
-	disable_production, bench_src, prepare_beta_release, set_redis_cache_host, set_redis_queue_host, set_redis_socketio_host)
+	disable_production, bench_src, prepare_beta_release, set_redis_cache_host, set_redis_queue_host, set_redis_socketio_host, find_benches)
 bench_command.add_command(start)
 bench_command.add_command(restart)
 bench_command.add_command(set_nginx_port)
@@ -68,6 +68,7 @@ bench_command.add_command(renew_lets_encrypt)
 bench_command.add_command(disable_production)
 bench_command.add_command(bench_src)
 bench_command.add_command(prepare_beta_release)
+bench_command.add_command(find_benches)
 
 from bench.commands.setup import setup
 bench_command.add_command(setup)

--- a/bench/commands/utils.py
+++ b/bench/commands/utils.py
@@ -190,3 +190,11 @@ def bench_src():
 	"""Prints bench source folder path, which can be used as: cd `bench src` """
 	import bench
 	print(os.path.dirname(bench.__path__[0]))
+
+
+@click.command('find')
+@click.argument('location', default='')
+def find_benches(location):
+	"""Finds benches recursively from location"""
+	from bench.utils import find_benches
+	find_benches(directory=location)

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -17,15 +17,27 @@ logger = logging.getLogger(__name__)
 folders_in_bench = ('apps', 'sites', 'config', 'logs', 'config/pids')
 
 
-def is_bench_directory():
-	cur_dir = os.path.curdir
+def is_bench_directory(directory=os.path.curdir):
 	is_bench = True
 
 	for folder in folders_in_bench:
-		path = os.path.join(cur_dir, folder)
+		path = os.path.abspath(os.path.join(directory, folder))
 		is_bench = is_bench and os.path.exists(path)
 
 	return is_bench
+
+
+def log(message, level=0):
+	levels = {
+		0: '\033[94m',	# normal
+		1: '\033[92m',	# success
+		2: '\033[91m',	# fail
+		3: '\033[93m'	# warn/suggest
+	}
+	start = levels.get(level) or ''
+	end = '\033[0m'
+
+	print(start + message + end)
 
 
 def safe_decode(string, encoding = 'utf-8'):

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -31,8 +31,8 @@ def log(message, level=0):
 	levels = {
 		0: '\033[94m',	# normal
 		1: '\033[92m',	# success
-		2: '\033[91m',	# fail
-		3: '\033[93m'	# warn/suggest
+		2: '\033[91mERROR: ',	# fail
+		3: '\033[93mWARN: '	# warn/suggest
 	}
 	start = levels.get(level) or ''
 	end = '\033[0m'
@@ -872,3 +872,31 @@ def run_playbook(playbook_name, extra_vars=None, tag=None):
 		args.extend(['-t', tag])
 
 	subprocess.check_call(args, cwd=os.path.join(os.path.dirname(bench.__path__[0]), 'playbooks'))
+
+def find_benches(directory=None):
+	if not directory:
+		directory = os.path.expanduser("~")
+	elif os.path.exists(directory):
+		directory = os.path.abspath(directory)
+	else:
+		log("Directory doesn't exist", level=2)
+		sys.exit(1)
+
+	if is_bench_directory(directory):
+		if os.path.curdir == directory:
+			print("You are in a bench directory!")
+		else:
+			print("{0} is a bench directory!".format(directory))
+		return
+
+	benches = []
+	for sub in os.listdir(directory):
+		sub = os.path.join(directory, sub)
+		if os.path.isdir(sub) and not os.path.islink(sub):
+			if is_bench_directory(sub):
+				print("{} found!".format(sub))
+				benches.append(sub)
+			else:
+				benches.extend(find_benches(sub))
+
+	return benches


### PR DESCRIPTION
**Feat:** 

1. New command "bench find [search-directory]"
    - accepts a search directory parameter which defaults to home
    - if run from a bench directory, it'll tell you so
    - if run from any other directory without directory parameter then it'll find benches recursively from the search directory

![Screenshot 2020-01-10 at 4 16 26 PM](https://user-images.githubusercontent.com/36654812/72147551-c500ec00-33c4-11ea-964e-bc50e5a0608f.png)
![Screenshot 2020-01-10 at 4 51 37 PM](https://user-images.githubusercontent.com/36654812/72149590-87529200-33c9-11ea-9fdf-0fc5497d318c.png)


2. Log print function "bench.utils.log"
    - Depending on the level, `WARN` and `ERROR` tags will be appended to the message to directed stdout

![Screenshot 2020-01-10 at 4 51 50 PM](https://user-images.githubusercontent.com/36654812/72149591-87529200-33c9-11ea-9af3-bc39a59ba015.png)
   
