### PR TITLE
fix: validate branch in bench update

### DIFF
--- a/bench/app.py
+++ b/bench/app.py
@@ -423,7 +423,10 @@ def get_apps_json(path):
 		return json.load(f)
 
 def validate_branch():
-	for app in ['frappe', 'erpnext']:
+	installed_apps = get_apps()
+	check_apps = ['frappe', 'erpnext'] #this is a dirty work-around. bench update should not assume that erpnext is installed
+	intersection_apps = list(set(installed_apps) & set(check_apps))
+	for app in intersection_apps:
 		branch = get_current_branch(app)
 
 		if branch == "master":

--- a/bench/app.py
+++ b/bench/app.py
@@ -423,14 +423,22 @@ def get_apps_json(path):
 		return json.load(f)
 
 def validate_branch():
-	installed_apps = get_apps()
-	check_apps = ['frappe', 'erpnext'] #this is a dirty work-around. bench update should not assume that erpnext is installed
-	intersection_apps = list(set(installed_apps) & set(check_apps))
+	installed_apps = set(get_apps())
+	check_apps = set(['frappe', 'erpnext'])
+	intersection_apps = installed_apps and check_apps
+
 	for app in intersection_apps:
 		branch = get_current_branch(app)
 
 		if branch == "master":
-			print(''' master branch is renamed to version-11 and develop to version-12. Please switch to new branches to get future updates.
+			print("""'master' branch is renamed to 'version-11' since 'version-12' release.
+As of January 2020, the following branches are
+version		Frappe			ERPNext
+11		version-11		version-11
+12		version-12		version-12
+13		develop			develop
 
-To switch to version 11, run the following commands: bench switch-to-branch version-11''')
+Please switch to new branches to get future updates.
+To switch to your required branch, run the following commands: bench switch-to-branch [branch-name]""")
+
 			sys.exit(1)


### PR DESCRIPTION
bench update assumes that erpnext is an installed app in the bench. This is a wrong assumption. This work around checks for the intersection of installed apps with  the list ['frappe', 'erpnext'] and only attempts to get the current branch of apps that occur in the intersection. This way, if erpnext is not installed (very likely for those using frappe only to build their own apps) there wont be an error when get_current_branch is called for erpnext. The need to perform the kind of check being performed in validate_branch is a strong case for considering apps being able to add "bench update" hooks in their hooks.py

See this topic https://discuss.erpnext.com/t/bench-update-error-no-such-file-or-directory-apps-erpnext/56932?u=chude_osiegbu

Pull-Request

- [ ] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [ ] Have you lint your code locally prior to submission?
- [x] Have you successfully run tests with your changes locally?
- [x] Does your commit message have an explanation for your changes and why you'd like us to include them?
- [ ] Docs have been added / updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Did you modify the existing test cases? If yes, why?

---

What type of a PR is this? 

- [ ] Changes to Existing Features
- [ ] New Feature Submissions
- [x] Bug Fix
- [ ] Breaking Change

--- 

- Motivation and Context (What existing problem does the pull request solve):
- Related Issue: 
- Screenshots (if applicable, remember, a picture tells a thousand words): 

**Please don't be intimidated by the long list of options you've fill. Try to fill out as much as you can. Remember, the more the information the easier it is for us to test and get your pull request merged** :grin: 

