### PR TITLE
fix: bump MariaDB version

### DIFF
--- a/bench/commands/install.py
+++ b/bench/commands/install.py
@@ -14,7 +14,7 @@ def install_prerequisites():
 
 @click.command('mariadb')
 @click.option('--mysql_root_password')
-@click.option('--version', default="10.2")
+@click.option('--version', default="10.3")
 def install_maridb(mysql_root_password='', version=''):
 	if mysql_root_password:
 		extra_vars.update({


### PR DESCRIPTION
Update MariaDB version from `10.2` to `10.3` to match requirement in README.

By the way, is there any reason for the empty string being the default password and version?

```py
def install_maridb(mysql_root_password='', version=''):
    # ...
```