### PR TITLE
fix: setup cron job for renewing ssl certificate

### DIFF
--- a/bench/config/lets_encrypt.py
+++ b/bench/config/lets_encrypt.py
@@ -82,11 +82,10 @@ def run_certbot_and_setup_ssl(site, custom_domain, bench_path, interactive=True)
 
 def setup_crontab():
 	job_command = '/opt/certbot-auto renew -a nginx --post-hook "systemctl reload nginx"'
-	system_crontab = CronTab(tabfile='/etc/crontab', user=True)
+	system_crontab = CronTab(user='root')
 	if job_command not in str(system_crontab):
-		job  = system_crontab.new(command=job_command, comment="Renew lets-encrypt every month")
-		job.every().month()
-		job.enable()
+		job = system_crontab.new(command=job_command, comment="Renew lets-encrypt every month")
+		job.day.on(1)
 		system_crontab.write()
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Click==7.0
 GitPython==2.1.11
 honcho==1.0.1
 Jinja2==2.10.3
-python_crontab==2.4.0
+python-crontab==2.4.0
 requests==2.22.0
 semantic_version==2.8.2
 setuptools==40.8.0


### PR DESCRIPTION
**What this does:** sets cron job under `root` user set for 1st of every month

**Reason:** `setup_crontab` failed silently on multiple tries on new Ubuntu 18.04 droplet and macOS 18.7.0

**Package Ref:** [python-crontab](https://gitlab.com/doctormo/python-crontab)