### PR TITLE
fix: dont abort script if not overwriting scripts

### DIFF
--- a/bench/config/nginx.py
+++ b/bench/config/nginx.py
@@ -1,14 +1,23 @@
-import os, json, click, random, string, hashlib
-from bench.utils import get_sites, get_bench_name, exec_cmd
+# imports - standard imports
+import hashlib
+import json
+import os
+import random
+import string
+
+# imports - third party imports
+import click
 from six import string_types
-from six.moves import input
+
+# imports - module imports
+from bench.utils import exec_cmd, get_bench_name, get_sites
 
 
 def make_nginx_conf(bench_path, yes=False):
 	conf_path = os.path.join(bench_path, "config", "nginx.conf")
 
 	if not yes and os.path.exists(conf_path):
-		if input('nginx.conf already exists and this will overwrite it. Do you want to continue? [y/N]').lower() == 'n':
+		if not click.confirm('nginx.conf already exists and this will overwrite it. Do you want to continue?'):
 			return
 
 	from bench import env

--- a/bench/config/nginx.py
+++ b/bench/config/nginx.py
@@ -1,6 +1,5 @@
 # imports - standard imports
 import hashlib
-import json
 import os
 import random
 import string
@@ -10,7 +9,7 @@ import click
 from six import string_types
 
 # imports - module imports
-from bench.utils import exec_cmd, get_bench_name, get_sites
+from bench.utils import get_bench_name, get_sites
 
 
 def make_nginx_conf(bench_path, yes=False):

--- a/bench/config/nginx.py
+++ b/bench/config/nginx.py
@@ -1,8 +1,16 @@
 import os, json, click, random, string, hashlib
 from bench.utils import get_sites, get_bench_name, exec_cmd
 from six import string_types
+from six.moves import input
+
 
 def make_nginx_conf(bench_path, yes=False):
+	conf_path = os.path.join(bench_path, "config", "nginx.conf")
+
+	if not yes and os.path.exists(conf_path):
+		if input('nginx.conf already exists and this will overwrite it. Do you want to continue? [y/N]').lower() == 'n':
+			return
+
 	from bench import env
 	from bench.config.common_site_config import get_config
 
@@ -37,10 +45,6 @@ def make_nginx_conf(bench_path, yes=False):
 
 	nginx_conf = template.render(**template_vars)
 
-	conf_path = os.path.join(bench_path, "config", "nginx.conf")
-	if not yes and os.path.exists(conf_path):
-		click.confirm('nginx.conf already exists and this will overwrite it. Do you want to continue?',
-			abort=True)
 
 	with open(conf_path, "w") as f:
 		f.write(nginx_conf)

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -77,7 +77,8 @@ def init(path, apps_path=None, no_procfile=False, no_backups=False, no_auto_upda
 	if os.path.exists(path) and not ignore_exist:
 		log('Path {path} already exists!'.format(path=path))
 		sys.exit(0)
-	else:
+	elif not os.path.exists(path):
+		# only create dir if it does not exist
 		os.makedirs(path)
 
 	for dirname in folders_in_bench:


### PR DESCRIPTION
currently, running of `bench ` or `bench setup production` creates nginx conf files and asks for confirmation before overwriting them. in case user doesn't want to overwrite files, `setup production` and `lets-encrypt` is exitted abruptly and nginx isn't started again after. 

this happens because click abort was being used which sends a script termination signal in case of `n` instead of returning control to parent function.