### PR TITLE
fix: yarn install --production for bench not in dev mode

### DIFF
--- a/bench/utils.py
+++ b/bench/utils.py
@@ -497,7 +497,10 @@ def update_node_packages(bench_path='.'):
 		update_yarn_packages(bench_path)
 
 def update_yarn_packages(bench_path='.'):
+	from bench.config.common_site_config import get_config
+
 	apps_dir = os.path.join(bench_path, 'apps')
+	production_mode = "" if get_config(".").get("developer_mode") else "--production"
 
 	if not find_executable('yarn'):
 		print("Please install yarn using below command and try again.")
@@ -507,7 +510,7 @@ def update_yarn_packages(bench_path='.'):
 	for app in os.listdir(apps_dir):
 		app_path = os.path.join(apps_dir, app)
 		if os.path.exists(os.path.join(app_path, 'package.json')):
-			exec_cmd('yarn install', cwd=app_path)
+			exec_cmd('yarn install {}'.format(production_mode), cwd=app_path)
 
 
 def update_npm_packages(bench_path='.'):


### PR DESCRIPTION
`bench setup requirements --node` will produce a _less_ bloated node_modules folder for bench not in developer mode

- **`yarn install`**

![Screenshot 2020-02-11 at 12 58 48 AM](https://user-images.githubusercontent.com/36654812/74182775-afa00b80-4c69-11ea-9a3f-5d329f0852a7.png)

- **`yarn install --production`**

![Screenshot 2020-02-11 at 12 57 52 AM](https://user-images.githubusercontent.com/36654812/74182782-b169cf00-4c69-11ea-88ed-6c8bc164ed50.png)

Closes #771