### PR TITLE
chore: pin gitdb2 only for python < 3.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ semantic_version==2.8.2
 setuptools==40.8.0
 six==1.12.0
 virtualenv==16.6.0
-gitdb2==2.0.6
+gitdb2==2.0.6;python_version<'3.4'
 MarkupSafe==1.1.1
 python-dateutil==2.8.1
 idna==2.8


### PR DESCRIPTION
pip allows pinning requirement using [environment markers][0]

[0]: https://www.python.org/dev/peps/pep-0508/#environment-markers

improves: #932 