### PR TITLE
fix: random failings from subprocesses and command formatting

### DIFF
--- a/bench/utils.py
+++ b/bench/utils.py
@@ -28,6 +28,7 @@ class color:
 	green = '\033[92m'
 	yellow = '\033[93m'
 	red = '\033[91m'
+	silver = '\033[90m'
 
 
 def is_bench_directory(directory=os.path.curdir):
@@ -175,6 +176,7 @@ def exec_cmd(cmd, cwd='.'):
 	import shlex
 	logger.info(cmd)
 	cmd = shlex.split(cmd)
+	print("{0}$ {1}{2}".format(color.silver, cmd, color.nc))
 	subprocess.call(cmd, cwd=cwd, universal_newlines=True)
 
 def which(executable, raise_err = False):

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -172,26 +172,10 @@ def clone_apps_from(bench_path, clone_from, update_app=True):
 		setup_app(app)
 
 def exec_cmd(cmd, cwd='.'):
-	from .cli import from_command_line
-
-	is_async = False if from_command_line else True
-	if is_async:
-		stderr = stdout = subprocess.PIPE
-	else:
-		stderr = stdout = None
-
+	import shlex
 	logger.info(cmd)
-
-	p = subprocess.Popen(cmd, cwd=cwd, shell=True, stdout=stdout, stderr=stderr,
-		universal_newlines=True)
-
-	if is_async:
-		return_code = print_output(p)
-	else:
-		return_code = p.wait()
-
-	if return_code > 0:
-		raise CommandFailedError(cmd)
+	cmd = shlex.split(cmd)
+	subprocess.call(cmd, cwd=cwd, universal_newlines=True)
 
 def which(executable, raise_err = False):
 	from distutils.spawn import find_executable


### PR DESCRIPTION
* Async executions of multiple processes leads to various errors. Proposed solution to this is to execute blocking subprocesses. 


eg: get-app operation runs a "git clone" at the same time "pip install" is run. This causes failures as the folder either does not exist or isn't complete.


* readable formatting of system commands executed

Before:
![Screenshot 2020-03-02 at 10 19 26 AM](https://user-images.githubusercontent.com/36654812/75646371-7575c880-5c6f-11ea-8308-4d32f7f46115.png)

After:
![Screenshot 2020-03-02 at 10 17 59 AM](https://user-images.githubusercontent.com/36654812/75646374-77d82280-5c6f-11ea-9564-9e62b46bd0e0.png)

