### PR TITLE
chore: remove updating "bench tool" from update

### DIFF
--- a/bench/app.py
+++ b/bench/app.py
@@ -60,10 +60,7 @@ def write_appstxt(apps, bench_path='.'):
 		return f.write('\n'.join(apps))
 
 def check_url(url, raise_err=True):
-	try:
-		from urlparse import urlparse
-	except ImportError:
-		from urllib.parse import urlparse
+	from six.moves.urllib.parse import urlparse
 
 	parsed = urlparse(url)
 	if not parsed.scheme:

--- a/bench/commands/config.py
+++ b/bench/commands/config.py
@@ -25,12 +25,6 @@ def config_restart_systemd_on_update(state):
 	update_config({'restart_systemd_on_update': state == 'on'})
 
 
-@click.command('update_bench_on_update', help='Enable/Disable bench updates on running bench update')
-@click.argument('state', type=click.Choice(['on', 'off']))
-def config_update_bench_on_update(state):
-	update_config({'update_bench_on_update': state == 'on'})
-
-
 @click.command('dns_multitenant', help='Enable/Disable bench multitenancy on running bench update')
 @click.argument('state', type=click.Choice(['on', 'off']))
 def config_dns_multitenant(state):
@@ -83,7 +77,6 @@ def remove_common_config(keys):
 	put_config(common_site_config)
 
 
-config.add_command(config_update_bench_on_update)
 config.add_command(config_restart_supervisor_on_update)
 config.add_command(config_restart_systemd_on_update)
 config.add_command(config_dns_multitenant)

--- a/bench/commands/update.py
+++ b/bench/commands/update.py
@@ -14,16 +14,15 @@ from bench.utils import post_upgrade, patch_sites, build_assets
 @click.option('--pull', is_flag=True, help="Pull updates for all the apps in bench")
 @click.option('--patch', is_flag=True, help="Run migrations for all sites in the bench")
 @click.option('--build', is_flag=True, help="Build JS and CSS assets for the bench")
-@click.option('--bench', is_flag=True, help="Update bench CLI tool")
 @click.option('--requirements', is_flag=True, help="Update requirements. If run alone, equivalent to `bench setup requirements`")
 @click.option('--restart-supervisor', is_flag=True, help="Restart supervisor processes after update")
 @click.option('--restart-systemd', is_flag=True, help="Restart systemd units after update")
 @click.option('--no-backup', is_flag=True, help="If this flag is set, sites won't be backed up prior to updates. Note: This is not recommended in production.")
 @click.option('--force', is_flag=True, help="Forces major version upgrades")
 @click.option('--reset', is_flag=True, help="Hard resets git branch's to their new states overriding any changes and overriding rebase on pull")
-def update(pull, patch, build, bench, requirements, restart_supervisor, restart_systemd, no_backup, force, reset):
+def update(pull, patch, build, requirements, restart_supervisor, restart_systemd, no_backup, force, reset):
 	from bench.utils import update
-	update(pull=pull, patch=patch, build=build, bench=bench, requirements=requirements, restart_supervisor=restart_supervisor, restart_systemd=restart_systemd, backup= not no_backup, force=force, reset=reset)
+	update(pull=pull, patch=patch, build=build, requirements=requirements, restart_supervisor=restart_supervisor, restart_systemd=restart_systemd, backup=not no_backup, force=force, reset=reset)
 
 
 @click.command('retry-upgrade', help="Retry a failed upgrade")

--- a/bench/config/common_site_config.py
+++ b/bench/config/common_site_config.py
@@ -1,9 +1,12 @@
-import os, multiprocessing, getpass, json
+# imports - standard imports
+import getpass
+import json
+import multiprocessing
+import os
 
-try:
-	from urllib.parse import urlparse
-except ImportError:
-	from urlparse import urlparse
+# imports - third party imports
+from six.moves.urllib.parse import urlparse
+
 
 default_config = {
 	'restart_supervisor_on_update': False,
@@ -11,7 +14,6 @@ default_config = {
 	'auto_update': False,
 	'serve_default_site': True,
 	'rebase_on_pull': False,
-	'update_bench_on_update': True,
 	'frappe_user': getpass.getuser(),
 	'shallow_clone': True,
 	'background_workers': 1

--- a/bench/config/redis.py
+++ b/bench/config/redis.py
@@ -1,11 +1,16 @@
-from .common_site_config import get_config
-import re, os, subprocess, semantic_version
-import bench
+# imports - standard imports
+import os
+import re
+import subprocess
 
-try:
-	from urllib.parse import urlparse
-except ImportError:
-	from urlparse import urlparse
+# imports - third party imports
+import semantic_version
+from six.moves.urllib.parse import urlparse
+
+# imports - module imports
+import bench
+from bench.config.common_site_config import get_config
+
 
 def generate_config(bench_path):
 	config = get_config(bench_path)


### PR DESCRIPTION
- removes `bench_update_on_update`
- removes `restart_update`
- removes `validate_pillow_dependencies`
- adds setup_env: find venv in current python and failure log 
- style fixes 

_Pending:_ docs update