### PR TITLE
chore: changed bench.utils.log API prefix 

### DIFF
--- a/bench/utils.py
+++ b/bench/utils.py
@@ -61,7 +61,7 @@ def is_bench_directory(directory=os.path.curdir):
 
 def log(message, level=0):
 	levels = {
-		0: color.blue + 'LOG',			# normal
+		0: color.blue + 'INFO',			# normal
 		1: color.green + 'SUCCESS',		# success
 		2: color.red + 'ERROR',			# fail
 		3: color.yellow + 'WARN'		# warn/suggest


### PR DESCRIPTION
changed default message prefix from `LOG` to `INFO`