### PR TITLE
chore: use http_host instead of host for nginx

### DIFF
--- a/bench/config/templates/nginx.conf
+++ b/bench/config/templates/nginx.conf
@@ -65,7 +65,7 @@ server {
 		proxy_set_header Connection "upgrade";
 		proxy_set_header X-Frappe-Site-Name {{ site_name }};
 		proxy_set_header Origin $scheme://$http_host;
-		proxy_set_header Host $host;
+		proxy_set_header Host $http_host;
 
 		proxy_pass http://{{ bench_name }}-socketio-server;
 	}
@@ -88,7 +88,7 @@ server {
 		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 		proxy_set_header X-Forwarded-Proto $scheme;
 		proxy_set_header X-Frappe-Site-Name {{ site_name }};
-		proxy_set_header Host $host;
+		proxy_set_header Host $http_host;
 		proxy_set_header X-Use-X-Accel-Redirect True;
 		proxy_read_timeout {{ http_timeout or 120 }};
 		proxy_redirect off;


### PR DESCRIPTION
bench port for https://github.com/frappe/frappe_docker/pull/184