### PR TITLE
fix(backups): setup backups for bench sites

### DIFF
--- a/bench/utils.py
+++ b/bench/utils.py
@@ -375,7 +375,7 @@ def setup_backups(bench_path='.'):
 	if bench.FRAPPE_VERSION == 4:
 		backup_command = "cd {sites_dir} && {frappe} --backup all".format(frappe=get_frappe(bench_path=bench_path),)
 	else:
-		backup_command = "cd {bench_dir} && {bench} --site all backup".format(bench_dir=bench_dir, bench=sys.argv[0])
+		backup_command = "cd {bench_dir} && {bench} --verbose --site all backup".format(bench_dir=bench_dir, bench=sys.argv[0])
 
 	job_command = "{backup_command} >> {logfile} 2>&1".format(backup_command=backup_command, logfile=logfile)
 

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -367,7 +367,7 @@ def setup_backups(bench_path='.'):
 	logger.info('setting up backups')
 
 	bench_dir = os.path.abspath(bench_path)
-	user = get_config('.').get('frappe_user')
+	user = get_config(bench_path=bench_dir).get('frappe_user')
 	logfile = os.path.join(bench_dir, 'logs', 'backup.log')
 	bench.set_frappe_version(bench_path=bench_path)
 	system_crontab = CronTab(user=user)


### PR DESCRIPTION
Using python-crontab library instead of manual processing

```
INFO:bench.utils:setting up backups
no crontab for revant
SUCCESS: Bench fbench initialized
crontab: usage error: file name or - (for stdin) must be specified for replace
Usage:
 crontab [options] file
 crontab [options]
 crontab -n [hostname]

Options:
 -u <user>  define user
 -e         edit user's crontab
 -l         list user's crontab
 -r         delete user's crontab
 -i         prompt before deleting
 -n <host>  set host in cluster to run users' crontabs
 -c         get host in cluster to run users' crontabs
 -V         print version and exit
 -x <mask>  enable debugging

Default operation is replace, per 1003.2

```

Reference: https://github.com/frappe/bench/pull/967#issuecomment-613731509