### PR TITLE
fix: SocketIO HTTPs bug

### DIFF
--- a/bench/config/templates/nginx.conf
+++ b/bench/config/templates/nginx.conf
@@ -41,7 +41,7 @@ server {
 	ssl_stapling_verify on;
 	ssl_protocols TLSv1.2 TLSv1.3;
 	ssl_ciphers EECDH+AESGCM:EDH+AESGCM;
-	ssl_ecdh_curve secp384r1;
+	ssl_ecdh_curve auto;
 	ssl_prefer_server_ciphers on;
 	{% endif %}
 


### PR DESCRIPTION
Socket IO messages are not received on HTTPs when the configuration:
`ssl_ecdh_curve` is set to `secp384r1`

Setting it to `auto` solves it according to Telegram Developer's Group message by Shadoyip