### PR TITLE
fix: install node modules only if package.json exists

### DIFF
--- a/bench/app.py
+++ b/bench/app.py
@@ -181,7 +181,10 @@ def install_app(app, bench_path=".", verbose=False, no_cache=False, postprocess=
 	cache_flag = "--no-cache-dir" if no_cache else ""
 
 	exec_cmd("{pip} install {quiet} -U -e {app} {no_cache}".format(pip=pip_path, quiet=quiet_flag, app=app_path, no_cache=cache_flag))
-	exec_cmd("yarn install", cwd=app_path)
+
+	if os.path.exists(os.path.join(app_path, 'package.json')):
+		exec_cmd("yarn install", cwd=app_path)
+
 	add_to_appstxt(app, bench_path=bench_path)
 
 	if postprocess:


### PR DESCRIPTION
Bug introduced in https://github.com/frappe/bench/pull/983