### PR TITLE
fix: restart supervisord process after change in conf

### DIFF
--- a/bench/patches/v5/fix_user_permissions.py
+++ b/bench/patches/v5/fix_user_permissions.py
@@ -5,7 +5,7 @@ import subprocess
 
 # imports - module imports
 from bench.cli import change_uid_msg
-from bench.config.production_setup import get_supervisor_confdir, is_centos7
+from bench.config.production_setup import get_supervisor_confdir, is_centos7, service
 from bench.config.common_site_config import get_config
 from bench.utils import exec_cmd, get_bench_name, get_cmd_output
 
@@ -53,7 +53,8 @@ def execute(bench_path):
 	user = get_config('.').get("frappe_user") or getpass.getuser()
 
 	if is_sudoers_set():
-		exec_cmd("sudo bench setup sudoers {user}".format(user=user))
-
 		if is_production_set(bench_path):
 			exec_cmd("sudo bench setup supervisor --yes --user {user}".format(user=user))
+			service("supervisord", "restart")
+
+		exec_cmd("sudo bench setup sudoers {user}".format(user=user))


### PR DESCRIPTION
Issues Fixed:
- after setting up new bench sudoers, `sudo bench setup supervisor` would fail as sudo doesn't get user password
- Supervisord restarted with the new configuration