### PR TITLE
fix: exit with appropriate return code

### DIFF
--- a/bench/app.py
+++ b/bench/app.py
@@ -127,6 +127,7 @@ Do you want to continue and overwrite it?'''.format(repo_name)):
 			install_app(app=app_name, bench_path=bench_path, verbose=verbose, skip_assets=skip_assets)
 			sys.exit()
 
+	print('\n{0}Getting {1}{2}'.format(color.yellow, repo_name, color.nc))
 	logger.log('Getting app {0}'.format(repo_name))
 	exec_cmd("git clone {git_url} {branch} {shallow_clone} --origin upstream".format(
 		git_url=git_url,

--- a/bench/cli.py
+++ b/bench/cli.py
@@ -59,8 +59,10 @@ def cli():
 	try:
 		bench_command()
 	except BaseException as e:
-		logger.warn("{0} executed with exit code {1}".format(command, getattr(e, "code", None)))
-		sys.exit(1)
+		return_code = getattr(e, "code", 0)
+		if return_code:
+			logger.warning("{0} executed with exit code {1}".format(command, return_code))
+		sys.exit(return_code)
 
 
 def check_uid():

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -302,7 +302,7 @@ def exec_cmd(cmd, cwd='.'):
 	cmd = shlex.split(cmd)
 	return_code = subprocess.call(cmd, cwd=cwd, universal_newlines=True)
 	if return_code:
-		logger.warn("{0} executed with exit code {1}".format(cmd_log, return_code))
+		logger.warning("{0} executed with exit code {1}".format(cmd_log, return_code))
 
 
 def which(executable, raise_err = False):
@@ -449,13 +449,8 @@ def setup_logging(bench_path='.'):
 		hdlr = logging.FileHandler(log_file)
 		hdlr.setFormatter(formatter)
 
-		log_hndlr = logging.StreamHandler(sys.stdout)
-		log_hndlr.setFormatter(logging.Formatter('%(message)s'))
-		log_hndlr.addFilter(log_filter(LOG_LEVEL))
-
 		logger.addHandler(hdlr)
-		logger.addHandler(log_hndlr)
-		logger.setLevel(logging.INFO)
+		logger.setLevel(logging.DEBUG)
 
 		return logger
 
@@ -985,7 +980,7 @@ def migrate_env(python, backup=False):
 		logger.log('Clearing Redis DataBase...')
 		exec_cmd('{redis} FLUSHDB'.format(redis = redis))
 	except:
-		logger.warn('Please ensure Redis Connections are running or Daemonized.')
+		logger.warning('Please ensure Redis Connections are running or Daemonized.')
 
 	# Backup venv: restore using `virtualenv --relocatable` if needed
 	if backup:
@@ -1015,7 +1010,7 @@ def migrate_env(python, backup=False):
 		logger.log('Migration Successful to {}'.format(python))
 	except:
 		if venv_creation or packages_setup:
-			logger.warn('Migration Error')
+			logger.warning('Migration Error')
 
 
 def is_dist_editable(dist):

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -455,7 +455,7 @@ def setup_logging(bench_path='.'):
 
 		logger.addHandler(hdlr)
 		logger.addHandler(log_hndlr)
-		logger.setLevel(logging.DEBUG)
+		logger.setLevel(logging.INFO)
 
 		return logger
 

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -435,20 +435,12 @@ def setup_logging(bench_path='.'):
 			self._log(LOG_LEVEL, message, args, **kws)
 	logging.Logger.log = logv
 
-	class log_filter(object):
-		def __init__(self, level):
-			self.__level = level
-
-		def filter(self, logRecord):
-			return logRecord.levelno == self.__level
-
 	if os.path.exists(os.path.join(bench_path, 'logs')):
 		logger = logging.getLogger(bench.PROJECT_NAME)
 		log_file = os.path.join(bench_path, 'logs', 'bench.log')
 		formatter = logging.Formatter('%(asctime)s %(levelname)s %(message)s')
 		hdlr = logging.FileHandler(log_file)
 		hdlr.setFormatter(formatter)
-
 		logger.addHandler(hdlr)
 		logger.setLevel(logging.DEBUG)
 


### PR DESCRIPTION
- exit with appropriate return code
- remove stdout logging for LOG status; maintain data only in `bench.log`
- update deprecated logger `warn` API to `warning`