### PR TITLE
feat: Allow CORS at SiteLevel

### DIFF
--- a/bench/config/nginx.py
+++ b/bench/config/nginx.py
@@ -50,7 +50,7 @@ def make_nginx_conf(bench_path, yes=False):
 		})
 
 	nginx_conf = template.render(**template_vars)
-
+	print("All Good!")
 
 	with open(conf_path, "w") as f:
 		f.write(nginx_conf)
@@ -314,7 +314,7 @@ def parse_cors_config(cors_config):
 				continue
 			v = config.get(prop)
 			if isinstance(v, list):
-				v = ", ".join(v)
+				v = "\"{}\"".format(", ".join(v))
 			elif prop == "allow_credentials":
 				v = "true" if v else "false"
 			parsed_config[prop][origin] = v

--- a/bench/config/nginx.py
+++ b/bench/config/nginx.py
@@ -319,6 +319,9 @@ def parse_cors_config(cors_config):
 				v = "true" if v else "false"
 			parsed_config[prop][origin] = v
 
+		if not parsed_config["max_age"].get(origin):
+			parsed_config["max_age"][origin] = 864000
+
 	return parsed_config
 
 def merge_cors_configs(sites):

--- a/bench/config/nginx.py
+++ b/bench/config/nginx.py
@@ -51,7 +51,6 @@ def make_nginx_conf(bench_path, yes=False):
 		})
 
 	nginx_conf = template.render(**template_vars)
-	print("All Good!")
 
 	with open(conf_path, "w") as f:
 		f.write(nginx_conf)
@@ -304,6 +303,7 @@ def parse_cors_config(cors_config):
 		"max_age": {},
 		"expose_headers": {},
 		"origins": {},
+		"wildcard_origin": False
 	}
 
 	for origin, config in cors_config.items():
@@ -311,9 +311,10 @@ def parse_cors_config(cors_config):
 			continue
 
 		if origin == "*":
-			origin = "_wildcard_origin"
-
-		parsed_config["origins"][origin] = origin
+			origin = "default"
+			parsed_config["wildcard_origin"] = True
+		else:
+			parsed_config["origins"][origin] = origin
 		for prop in ("allow_credentials", "headers", "methods", "max_age", "expose_headers"):
 			if not config.get(prop):
 				continue

--- a/bench/config/templates/nginx.conf
+++ b/bench/config/templates/nginx.conf
@@ -10,7 +10,7 @@ map {{ from_variable }} {{ to_variable }} {
 }
 {%- endmacro %}
 
-{%- macro server_block(bench_name, port, server_names, site_name, sites_path, ssl_certificate, ssl_certificate_key, allow_cors) %}
+{%- macro server_block(bench_name, port, server_names, site_name, sites_path, ssl_certificate, ssl_certificate_key, cors_config) %}
 server {
 	{% if ssl_certificate and ssl_certificate_key %}
 	listen {{ port }} ssl;
@@ -49,8 +49,8 @@ server {
 	add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload";
 	add_header X-Content-Type-Options nosniff;
 	add_header X-XSS-Protection "1; mode=block";
-	{% if allow_cors %}
-		{{ add_cors_headers() }}
+	{% if cors_config %}
+		{{ add_cors_headers(cors_config) }}
 	{% endif %}
 
 	location /assets {
@@ -163,18 +163,52 @@ server {
 
 {%- endmacro -%}
 
-{%- macro add_cors_headers() %}
+{%- macro add_cors_headers(cors_config) %}
 	# CORS Headers
 	proxy_hide_header Access-Control-Allow-Origin;
 	proxy_hide_header Access-Control-Allow-Credentials;
-	add_header Access-Control-Allow-Origin $http_origin always;
-	add_header Access-Control-Allow-Credentials true always;
-	add_header Access-Control-Allow-Methods 'GET, POST, PUT, DELETE, OPTIONS' always;
-	add_header Access-Control-Allow-Headers 'Origin, X-Requested-With, Content-Type, Accept, Authorization, x-client-site' always;
+	{% if cors_config.origins %}
+		add_header Access-Control-Allow-Origin {{ "$cors_origins_{0}".format(cors_config.random_string) }} always;
+	{% endif %}
+	{% if cors_config.headers %}
+		add_header Access-Control-Allow-Headers {{ "$cors_headers_{0}".format(cors_config.random_string) }} always;
+	{% endif %}
+	{% if cors_config.methods %}
+		add_header Access-Control-Allow-Methods {{ "$cors_methods_{0}".format(cors_config.random_string) }} always;
+	{% endif %}
+	{% if cors_config.expose_headers %}
+		add_header Access-Control-Expose-Headers {{ "$cors_expose_headers_{0}".format(cors_config.random_string) }} always;
+	{% endif %}
+	{% if cors_config.max_age %}
+		add_header Access-Control-Max-Age {{ "$cors_max_age_{0}".format(cors_config.random_string) }} always;
+	{% endif %}
+	add_header Access-Control-Allow-Credentials {{ "$cors_allow_creds_{0}".format(cors_config.random_string) }} always;
 
 	if ($request_method = OPTIONS ) {
 		return 200;
 	}
+{%- endmacro -%}
+
+{%- macro add_cors_map(cors_config) %}
+	{% if cors_config.origins %}
+		{{ nginx_map(from_variable="$http_origin", to_variable="$cors_origins_{0}".format(cors_config.random_string), values=cors_config.origins) }}
+	{% endif %}
+
+	{% if cors_config.headers %}
+		{{ nginx_map(from_variable="$http_origin", to_variable="$cors_headers_{0}".format(cors_config.random_string), values=cors_config.headers) }}
+	{% endif %}
+	{% if cors_config.allow_credentials %}
+		{{ nginx_map(from_variable="$http_origin", to_variable="$cors_allow_creds_{0}".format(cors_config.random_string), values=cors_config.allow_credentials) }}
+	{% endif %}
+	{% if cors_config.methods %}
+		{{ nginx_map(from_variable="$http_origin", to_variable="$cors_methods_{0}".format(cors_config.random_string), values=cors_config.methods) }}
+	{% endif %}
+	{% if cors_config.max_age %}
+		{{ nginx_map(from_variable="$http_origin", to_variable="$cors_max_age_{0}".format(cors_config.random_string), values=cors_config.max_age) }}
+	{% endif %}
+	{% if cors_config.expose_headers %}
+		{{ nginx_map(from_variable="$http_origin", to_variable="$cors_expose_headers_{0}".format(cors_config.random_string), values=cors_config.expose_headers) }}
+	{% endif %}
 {%- endmacro -%}
 
 upstream {{ bench_name }}-frappe {
@@ -199,42 +233,29 @@ limit_conn_zone $host zone=per_host_{{ bench_name_hash }}:{{ limit_conn_shared_m
 
 # server blocks
 {% if sites.that_use_dns -%}
-
-	{{ server_block(bench_name, port=80, server_names=sites.that_use_dns, site_name=site_name_variable, sites_path=sites_path) }}
-
-{%- endif %}
-
-{% if sites.that_use_dns_with_cors -%}
-
-	{{ server_block(bench_name, port=80, server_names=sites.that_use_dns_with_cors,
-		site_name=site_name_variable, sites_path=sites_path, allow_cors=1) }}
-
+	{% for site in sites.that_use_dns -%}
+		{{ add_cors_map(site.cors_config) }}
+		{{ server_block(bench_name, port=80, server_names=site.server_names,
+			site_name=site_name_variable, sites_path=sites_path, cors_config=site.cors_config) }}
+	{% endfor %}
 {%- endif %}
 
 {% if sites.that_use_wildcard_ssl -%}
+	{% for site in sites.that_use_dns -%}
+		{{ add_cors_map(site.cors_config) }}
+		{{ server_block(bench_name, port=443, server_names=site.server_names,
+			site_name=site_name_variable, sites_path=sites_path,
+			ssl_certificate=sites.wildcard_ssl_certificate, cors_config=site.cors_config,
+			ssl_certificate_key=sites.wildcard_ssl_certificate_key) }}
 
-	{{ server_block(bench_name, port=443, server_names=sites.that_use_wildcard_ssl,
-		site_name=site_name_variable, sites_path=sites_path,
-		ssl_certificate=sites.wildcard_ssl_certificate,
-		ssl_certificate_key=sites.wildcard_ssl_certificate_key) }}
-
-{%- endif %}
-
-{% if sites.that_use_wildcard_ssl_with_cors -%}
-
-	{{ server_block(bench_name, port=443, server_names=sites.that_use_wildcard_ssl_with_cors,
-		allow_cors=1,
-		site_name=site_name_variable, sites_path=sites_path,
-		ssl_certificate=sites.wildcard_ssl_certificate,
-		ssl_certificate_key=sites.wildcard_ssl_certificate_key) }}
-
+	{% endfor %}
 {%- endif %}
 
 {%- if sites.that_use_ssl -%}
 	{% for site in sites.that_use_ssl -%}
-
+		{{ add_cors_map(site.cors_config) }}
 		{{ server_block(bench_name, port=443, server_names=[site.domain or site.name],
-				site_name=site_name_variable, sites_path=sites_path, allow_cors=site.allow_cors,
+				site_name=site_name_variable, sites_path=sites_path, cors_config=site.cors_config,
 				ssl_certificate=site.ssl_certificate, ssl_certificate_key=site.ssl_certificate_key) }}
 
 	{% endfor %}
@@ -242,9 +263,9 @@ limit_conn_zone $host zone=per_host_{{ bench_name_hash }}:{{ limit_conn_shared_m
 
 {% if sites.that_use_port -%}
 	{%- for site in sites.that_use_port -%}
-
+		{{ add_cors_map(site.cors_config) }}
 		{{ server_block(bench_name, port=site.port, server_names=[site.name],
-				site_name=site.name, sites_path=sites_path, allow_cors=site.allow_cors,) }}
+				site_name=site.name, sites_path=sites_path, cors_config=site.cors_config) }}
 
 	{%- endfor %}
 {% endif %}

--- a/bench/config/templates/nginx.conf
+++ b/bench/config/templates/nginx.conf
@@ -164,10 +164,10 @@ server {
 {%- endmacro -%}
 
 {%- macro add_cors_headers(cors_config) %}
+	{%- if cors_config.origins %}
 	# CORS Headers
 	proxy_hide_header Access-Control-Allow-Origin;
 	proxy_hide_header Access-Control-Allow-Credentials;
-	{%- if cors_config.origins %}
 	add_header Access-Control-Allow-Origin {{ "$cors_origins_{0}".format(cors_config.random_string) }} always;
 	{%- endif %}
 	{%- if cors_config.headers %}
@@ -235,7 +235,7 @@ limit_conn_zone $host zone=per_host_{{ bench_name_hash }}:{{ limit_conn_shared_m
 # server blocks
 {% if sites.that_use_dns -%}
 	{% for site in sites.that_use_dns -%}
-		{{ add_cors_map(site.cors_config) }}
+		{{ add_cors_map(site.cors_config) -}}
 		{{ server_block(bench_name, port=80, server_names=site.server_names,
 			site_name=site_name_variable, sites_path=sites_path, cors_config=site.cors_config) }}
 	{% endfor %}
@@ -243,7 +243,7 @@ limit_conn_zone $host zone=per_host_{{ bench_name_hash }}:{{ limit_conn_shared_m
 
 {% if sites.that_use_wildcard_ssl -%}
 	{% for site in sites.that_use_dns -%}
-		{{ add_cors_map(site.cors_config) }}
+		{{ add_cors_map(site.cors_config) -}}
 		{{ server_block(bench_name, port=443, server_names=site.server_names,
 			site_name=site_name_variable, sites_path=sites_path,
 			ssl_certificate=sites.wildcard_ssl_certificate, cors_config=site.cors_config,
@@ -254,7 +254,7 @@ limit_conn_zone $host zone=per_host_{{ bench_name_hash }}:{{ limit_conn_shared_m
 
 {%- if sites.that_use_ssl -%}
 	{% for site in sites.that_use_ssl -%}
-		{{ add_cors_map(site.cors_config) }}
+		{{ add_cors_map(site.cors_config) -}}
 		{{ server_block(bench_name, port=443, server_names=[site.domain or site.name],
 				site_name=site_name_variable, sites_path=sites_path, cors_config=site.cors_config,
 				ssl_certificate=site.ssl_certificate, ssl_certificate_key=site.ssl_certificate_key) }}
@@ -264,7 +264,7 @@ limit_conn_zone $host zone=per_host_{{ bench_name_hash }}:{{ limit_conn_shared_m
 
 {% if sites.that_use_port -%}
 	{%- for site in sites.that_use_port -%}
-		{{ add_cors_map(site.cors_config) }}
+		{{ add_cors_map(site.cors_config) -}}
 		{{ server_block(bench_name, port=site.port, server_names=[site.name],
 				site_name=site.name, sites_path=sites_path, cors_config=site.cors_config) }}
 

--- a/bench/config/templates/nginx.conf
+++ b/bench/config/templates/nginx.conf
@@ -167,22 +167,24 @@ server {
 	# CORS Headers
 	proxy_hide_header Access-Control-Allow-Origin;
 	proxy_hide_header Access-Control-Allow-Credentials;
-	{% if cors_config.origins %}
-		add_header Access-Control-Allow-Origin {{ "$cors_origins_{0}".format(cors_config.random_string) }} always;
-	{% endif %}
-	{% if cors_config.headers %}
-		add_header Access-Control-Allow-Headers {{ "$cors_headers_{0}".format(cors_config.random_string) }} always;
-	{% endif %}
-	{% if cors_config.methods %}
-		add_header Access-Control-Allow-Methods {{ "$cors_methods_{0}".format(cors_config.random_string) }} always;
-	{% endif %}
-	{% if cors_config.expose_headers %}
-		add_header Access-Control-Expose-Headers {{ "$cors_expose_headers_{0}".format(cors_config.random_string) }} always;
-	{% endif %}
-	{% if cors_config.max_age %}
-		add_header Access-Control-Max-Age {{ "$cors_max_age_{0}".format(cors_config.random_string) }} always;
-	{% endif %}
+	{%- if cors_config.origins %}
+	add_header Access-Control-Allow-Origin {{ "$cors_origins_{0}".format(cors_config.random_string) }} always;
+	{%- endif %}
+	{%- if cors_config.headers %}
+	add_header Access-Control-Allow-Headers {{ "$cors_headers_{0}".format(cors_config.random_string) }} always;
+	{%- endif %}
+	{%- if cors_config.methods %}
+	add_header Access-Control-Allow-Methods {{ "$cors_methods_{0}".format(cors_config.random_string) }} always;
+	{%- endif %}
+	{%- if cors_config.expose_headers %}
+	add_header Access-Control-Expose-Headers {{ "$cors_expose_headers_{0}".format(cors_config.random_string) }} always;
+	{%- endif %}
+	{%- if cors_config.max_age %}
+	add_header Access-Control-Max-Age {{ "$cors_max_age_{0}".format(cors_config.random_string) }} always;
+	{%- endif %}
+	{%- if cors_config.allow_credentials %}
 	add_header Access-Control-Allow-Credentials {{ "$cors_allow_creds_{0}".format(cors_config.random_string) }} always;
+	{%- endif %}
 
 	if ($request_method = OPTIONS ) {
 		return 200;
@@ -190,25 +192,24 @@ server {
 {%- endmacro -%}
 
 {%- macro add_cors_map(cors_config) %}
-	{% if cors_config.origins %}
+	{% if cors_config.origins -%}
 		{{ nginx_map(from_variable="$http_origin", to_variable="$cors_origins_{0}".format(cors_config.random_string), values=cors_config.origins) }}
-	{% endif %}
-
-	{% if cors_config.headers %}
+	{% endif -%}
+	{% if cors_config.headers -%}
 		{{ nginx_map(from_variable="$http_origin", to_variable="$cors_headers_{0}".format(cors_config.random_string), values=cors_config.headers) }}
-	{% endif %}
-	{% if cors_config.allow_credentials %}
+	{% endif -%}
+	{% if cors_config.allow_credentials -%}
 		{{ nginx_map(from_variable="$http_origin", to_variable="$cors_allow_creds_{0}".format(cors_config.random_string), values=cors_config.allow_credentials) }}
-	{% endif %}
-	{% if cors_config.methods %}
+	{% endif -%}
+	{% if cors_config.methods -%}
 		{{ nginx_map(from_variable="$http_origin", to_variable="$cors_methods_{0}".format(cors_config.random_string), values=cors_config.methods) }}
-	{% endif %}
-	{% if cors_config.max_age %}
+	{% endif -%}
+	{% if cors_config.max_age -%}
 		{{ nginx_map(from_variable="$http_origin", to_variable="$cors_max_age_{0}".format(cors_config.random_string), values=cors_config.max_age) }}
-	{% endif %}
-	{% if cors_config.expose_headers %}
+	{% endif -%}
+	{% if cors_config.expose_headers -%}
 		{{ nginx_map(from_variable="$http_origin", to_variable="$cors_expose_headers_{0}".format(cors_config.random_string), values=cors_config.expose_headers) }}
-	{% endif %}
+	{% endif -%}
 {%- endmacro -%}
 
 upstream {{ bench_name }}-frappe {

--- a/bench/config/templates/nginx.conf
+++ b/bench/config/templates/nginx.conf
@@ -184,7 +184,7 @@ server {
 {%- macro add_cors_map(cors_config) %}
 	{% if cors_config.origins -%}
 		{{ nginx_map(from_variable="$http_origin", to_variable="$cors_origins_{0}".format(cors_config.random_string),
-			values=cors_config.origins, default="$http_origin" if cors_config.origins._wildcard_origin else "" ) }}
+			values=cors_config.origins, default="$http_origin" if cors_config.wildcard_origin else "" ) }}
 	{% endif -%}
 	{% for cors_header in ["headers", "allow_credentials", "methods", "max_age", "expose_headers"] -%}
 		{% if cors_config.get(cors_header) -%}

--- a/bench/config/templates/nginx.conf
+++ b/bench/config/templates/nginx.conf
@@ -169,22 +169,12 @@ server {
 	proxy_hide_header Access-Control-Allow-Origin;
 	proxy_hide_header Access-Control-Allow-Credentials;
 	add_header Access-Control-Allow-Origin {{ "$cors_origins_{0}".format(cors_config.random_string) }} always;
-	{%- endif %}
-	{%- if cors_config.headers %}
-	add_header Access-Control-Allow-Headers {{ "$cors_headers_{0}".format(cors_config.random_string) }} always;
-	{%- endif %}
-	{%- if cors_config.methods %}
-	add_header Access-Control-Allow-Methods {{ "$cors_methods_{0}".format(cors_config.random_string) }} always;
-	{%- endif %}
-	{%- if cors_config.expose_headers %}
-	add_header Access-Control-Expose-Headers {{ "$cors_expose_headers_{0}".format(cors_config.random_string) }} always;
-	{%- endif %}
-	{%- if cors_config.max_age %}
-	add_header Access-Control-Max-Age {{ "$cors_max_age_{0}".format(cors_config.random_string) }} always;
-	{%- endif %}
-	{%- if cors_config.allow_credentials %}
-	add_header Access-Control-Allow-Credentials {{ "$cors_allow_creds_{0}".format(cors_config.random_string) }} always;
-	{%- endif %}
+	{%- endif -%}
+	{% for cors_header in ["headers", "allow_credentials", "methods", "max_age", "expose_headers"] -%}
+		{%- if cors_config.get(cors_header) %}
+	add_header {{ cors_headers.get(cors_header) }} {{ "$cors_{0}_{1}".format(cors_header, cors_config.random_string) }} always;
+		{%- endif -%}
+	{%- endfor %}
 
 	if ($request_method = OPTIONS ) {
 		return 200;
@@ -193,23 +183,15 @@ server {
 
 {%- macro add_cors_map(cors_config) %}
 	{% if cors_config.origins -%}
-		{{ nginx_map(from_variable="$http_origin", to_variable="$cors_origins_{0}".format(cors_config.random_string), values=cors_config.origins) }}
+		{{ nginx_map(from_variable="$http_origin", to_variable="$cors_origins_{0}".format(cors_config.random_string),
+			values=cors_config.origins, default="$http_origin" if cors_config.origins._wildcard_origin else "" ) }}
 	{% endif -%}
-	{% if cors_config.headers -%}
-		{{ nginx_map(from_variable="$http_origin", to_variable="$cors_headers_{0}".format(cors_config.random_string), values=cors_config.headers) }}
-	{% endif -%}
-	{% if cors_config.allow_credentials -%}
-		{{ nginx_map(from_variable="$http_origin", to_variable="$cors_allow_creds_{0}".format(cors_config.random_string), values=cors_config.allow_credentials) }}
-	{% endif -%}
-	{% if cors_config.methods -%}
-		{{ nginx_map(from_variable="$http_origin", to_variable="$cors_methods_{0}".format(cors_config.random_string), values=cors_config.methods) }}
-	{% endif -%}
-	{% if cors_config.max_age -%}
-		{{ nginx_map(from_variable="$http_origin", to_variable="$cors_max_age_{0}".format(cors_config.random_string), values=cors_config.max_age) }}
-	{% endif -%}
-	{% if cors_config.expose_headers -%}
-		{{ nginx_map(from_variable="$http_origin", to_variable="$cors_expose_headers_{0}".format(cors_config.random_string), values=cors_config.expose_headers) }}
-	{% endif -%}
+	{% for cors_header in ["headers", "allow_credentials", "methods", "max_age", "expose_headers"] -%}
+		{% if cors_config.get(cors_header) -%}
+			{{ nginx_map(from_variable="$http_origin", to_variable="$cors_{0}_{1}".format(cors_header, cors_config.random_string),
+				values=cors_config.get(cors_header)) }}
+		{% endif -%}
+	{% endfor -%}
 {%- endmacro -%}
 
 upstream {{ bench_name }}-frappe {

--- a/bench/config/templates/nginx.conf
+++ b/bench/config/templates/nginx.conf
@@ -10,7 +10,7 @@ map {{ from_variable }} {{ to_variable }} {
 }
 {%- endmacro %}
 
-{%- macro server_block(bench_name, port, server_names, site_name, sites_path, ssl_certificate, ssl_certificate_key) %}
+{%- macro server_block(bench_name, port, server_names, site_name, sites_path, ssl_certificate, ssl_certificate_key, allow_cors) %}
 server {
 	{% if ssl_certificate and ssl_certificate_key %}
 	listen {{ port }} ssl;
@@ -49,6 +49,9 @@ server {
 	add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload";
 	add_header X-Content-Type-Options nosniff;
 	add_header X-XSS-Protection "1; mode=block";
+	{% if allow_cors %}
+		{{ add_cors_headers() }}
+	{% endif %}
 
 	location /assets {
 		try_files $uri =404;
@@ -160,6 +163,20 @@ server {
 
 {%- endmacro -%}
 
+{%- macro add_cors_headers() %}
+	# CORS Headers
+	proxy_hide_header Access-Control-Allow-Origin;
+	proxy_hide_header Access-Control-Allow-Credentials;
+	add_header Access-Control-Allow-Origin $http_origin always;
+	add_header Access-Control-Allow-Credentials true always;
+	add_header Access-Control-Allow-Methods 'GET, POST, PUT, DELETE, OPTIONS' always;
+	add_header Access-Control-Allow-Headers 'Origin, X-Requested-With, Content-Type, Accept, Authorization, x-client-site' always;
+
+	if ($request_method = OPTIONS ) {
+		return 200;
+	}
+{%- endmacro -%}
+
 upstream {{ bench_name }}-frappe {
 	server 127.0.0.1:{{ webserver_port or 8000 }} fail_timeout=0;
 }
@@ -187,9 +204,26 @@ limit_conn_zone $host zone=per_host_{{ bench_name_hash }}:{{ limit_conn_shared_m
 
 {%- endif %}
 
+{% if sites.that_use_dns_with_cors -%}
+
+	{{ server_block(bench_name, port=80, server_names=sites.that_use_dns_with_cors,
+		site_name=site_name_variable, sites_path=sites_path, allow_cors=1) }}
+
+{%- endif %}
+
 {% if sites.that_use_wildcard_ssl -%}
 
 	{{ server_block(bench_name, port=443, server_names=sites.that_use_wildcard_ssl,
+		site_name=site_name_variable, sites_path=sites_path,
+		ssl_certificate=sites.wildcard_ssl_certificate,
+		ssl_certificate_key=sites.wildcard_ssl_certificate_key) }}
+
+{%- endif %}
+
+{% if sites.that_use_wildcard_ssl_with_cors -%}
+
+	{{ server_block(bench_name, port=443, server_names=sites.that_use_wildcard_ssl_with_cors,
+		allow_cors=1,
 		site_name=site_name_variable, sites_path=sites_path,
 		ssl_certificate=sites.wildcard_ssl_certificate,
 		ssl_certificate_key=sites.wildcard_ssl_certificate_key) }}
@@ -200,7 +234,7 @@ limit_conn_zone $host zone=per_host_{{ bench_name_hash }}:{{ limit_conn_shared_m
 	{% for site in sites.that_use_ssl -%}
 
 		{{ server_block(bench_name, port=443, server_names=[site.domain or site.name],
-				site_name=site_name_variable, sites_path=sites_path,
+				site_name=site_name_variable, sites_path=sites_path, allow_cors=site.allow_cors,
 				ssl_certificate=site.ssl_certificate, ssl_certificate_key=site.ssl_certificate_key) }}
 
 	{% endfor %}
@@ -209,7 +243,8 @@ limit_conn_zone $host zone=per_host_{{ bench_name_hash }}:{{ limit_conn_shared_m
 {% if sites.that_use_port -%}
 	{%- for site in sites.that_use_port -%}
 
-		{{ server_block(bench_name, port=site.port, server_names=[site.name], site_name=site.name, sites_path=sites_path) }}
+		{{ server_block(bench_name, port=site.port, server_names=[site.name],
+				site_name=site.name, sites_path=sites_path, allow_cors=site.allow_cors,) }}
 
 	{%- endfor %}
 {% endif %}


### PR DESCRIPTION
What type of a PR is this?
- [x] New Feature Submissions
---

CORS can be a very helpful feature for sites hosted on static hosting providers. I would like to propose a config/flag to allow CORS on specific sites. By specifying `cors_config` either in the common site config / site config enables this.
The approach taken for the headers allows SocketIO connections to establish from a different domain,

All the following 6 CORS Response headers are supported in this PR:
- [Access-Control-Allow-Origin](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin)
- [Access-Control-Expose-Headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers)
- [Access-Control-Max-Age](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age)
- [Access-Control-Allow-Credentials](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Credentials)
- [Access-Control-Allow-Methods](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Methods)
- [Access-Control-Allow-Headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers)

An example site_config configuration:
```json
"cors_config": {
  "*": { 
    "enabled": 1,
    "allow_credentials": 1,
    "headers": ["X-Frappe-SiteName"],
    "methods": ["GET", "POST"],
    "max_age": 864000,
    "expose_headers": []
  },
  "http://localhost": {
    "enabled": 1,
    "methods": ["GET"]
  },
  "https://myrandomsite.com": {
    "enabled": 1
  }
}
```

The generated nginx configuration will have `nginx_maps` to resolve the header values for each origin.
```
map $http_origin $cors_headers_twwhxds {
	http://localhost 'X-Frappe-Site-Name, X-Client-Site';
	http://randomsite.com 'X-Frappe-Site, X-Custom-Header';	
}
```

In the server block,
```
# CORS Headers
proxy_hide_header Access-Control-Allow-Origin;
proxy_hide_header Access-Control-Allow-Credentials;
add_header Access-Control-Allow-Origin $cors_origins_twwhxds always;
add_header Access-Control-Allow-Headers $cors_headers_twwhxds always;
add_header Access-Control-Allow-Methods $cors_methods_twwhxds always;
add_header Access-Control-Max-Age $cors_max_age_twwhxds always;
add_header Access-Control-Allow-Credentials $cors_allow_creds_twwhxds always;
```

TODO:
- [x] Site level Origin CORS Configuration
- [x] Support for wildcard origin
- [ ] Tests  
- [ ] Updating Documentations  
Unfortunately I was unable to find docs related to wildcard_ssls or configs related to nginx in this repo, is it in frappe/frappe ?