### PR TITLE
fix(install): Replace platform.dist with distro.linux_distribution for PY3.8+ compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,17 +58,17 @@ matrix:
   - name: "Python 3.6 Easy Install"
     python: 3.6
     env: TEST=easy_install
-    script: sudo python3 $TRAVIS_BUILD_DIR/install.py --user travis --run-travis --production --verbose
+    script: sudo -H python3 $TRAVIS_BUILD_DIR/install.py --user travis --run-travis --production --verbose
 
   - name: "Python 3.7 Easy Install"
     python: 3.7
     env: TEST=easy_install
-    script: sudo python3 $TRAVIS_BUILD_DIR/install.py --user travis --run-travis --production --verbose
+    script: sudo -H python3 $TRAVIS_BUILD_DIR/install.py --user travis --run-travis --production --verbose
 
   - name: "Python 3.8 Easy Install"
     python: 3.8
     env: TEST=easy_install
-    script: sudo python3 $TRAVIS_BUILD_DIR/install.py --user travis --run-travis --production --verbose
+    script: sudo -H python3 $TRAVIS_BUILD_DIR/install.py --user travis --run-travis --production --verbose
 
 install:
   - pip install urllib3 pyOpenSSL ndg-httpsclient pyasn1

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,17 +58,17 @@ matrix:
   - name: "Python 3.6 Easy Install"
     python: 3.6
     env: TEST=easy_install
-    script: sudo python $TRAVIS_BUILD_DIR/install.py --user travis --run-travis --production --verbose
+    script: sudo python3 $TRAVIS_BUILD_DIR/install.py --user travis --run-travis --production --verbose
 
   - name: "Python 3.7 Easy Install"
     python: 3.7
     env: TEST=easy_install
-    script: sudo python $TRAVIS_BUILD_DIR/install.py --user travis --run-travis --production --verbose
+    script: sudo python3 $TRAVIS_BUILD_DIR/install.py --user travis --run-travis --production --verbose
 
   - name: "Python 3.8 Easy Install"
     python: 3.8
     env: TEST=easy_install
-    script: sudo python $TRAVIS_BUILD_DIR/install.py --user travis --run-travis --production --verbose
+    script: sudo python3 $TRAVIS_BUILD_DIR/install.py --user travis --run-travis --production --verbose
 
 install:
   - pip install urllib3 pyOpenSSL ndg-httpsclient pyasn1

--- a/install.py
+++ b/install.py
@@ -11,13 +11,18 @@ import platform
 import warnings
 import datetime
 import importlib
-try:
-    importlib.import_module(distro)
-except ImportError:
-    import pip
-    pip.main(['install', distro])
-finally:
-    globals()[package] = importlib.import_module(distro)
+
+def install_and_import(package):
+    import importlib
+    try:
+        importlib.import_module(package)
+    except ImportError:
+        import pip
+        pip.main(['install', package])
+    finally:
+        globals()[package] = importlib.import_module(package)
+
+install_and_import('distro')
 
 tmp_bench_repo = os.path.join('/', 'tmp', '.bench')
 tmp_log_folder = os.path.join('/', 'tmp', 'logs')

--- a/install.py
+++ b/install.py
@@ -10,12 +10,14 @@ import shutil
 import platform
 import warnings
 import datetime
+import importlib
 try:
-  import distro
+    importlib.import_module(distro)
 except ImportError:
-  print("Trying to Install required module: distro")
-  os.system('python -m pip install distro')
-import distro
+    import pip
+    pip.main(['install', distro])
+finally:
+    globals()[package] = importlib.import_module(distro)
 
 tmp_bench_repo = os.path.join('/', 'tmp', '.bench')
 tmp_log_folder = os.path.join('/', 'tmp', 'logs')

--- a/install.py
+++ b/install.py
@@ -136,7 +136,6 @@ def install_prerequisites():
 	# pre-requisites for bench repo cloning
 	run_os_command({
 		'apt-get': [
-			'sudo apt-get update',
 			'sudo apt-get install -y git build-essential python3-setuptools python3-dev libffi-dev'
 		],
 		'yum': [
@@ -183,6 +182,10 @@ def install_package(package, package_name=None):
 
 
 def install_pip():
+	run_os_command({
+		'apt-get': 'sudo apt-get update',
+		'yum': 'sudo yum check-update'
+	})
 	if PY3:
 		install_package('pip3', 'python3-pip')
 	else:

--- a/install.py
+++ b/install.py
@@ -109,13 +109,8 @@ def get_distribution_info():
 
     # return distribution name and major version
 
-    if platform.system() == 'Linux':
-        if sys.version_info < (3, 7):
-            current_dist = platform.dist()
-        else:
-            current_dist = (distro.id(), distro.major_version())
-	
-            return (current_dist[0].lower(), current_dist[1].rsplit(".")[0])
+	if platform.system() == 'Linux':
+		return (distro.id(), distro.major_version())
 	
     elif platform.system() == 'Darwin':
 

--- a/install.py
+++ b/install.py
@@ -17,8 +17,7 @@ def install_and_import(package):
     try:
         importlib.import_module(package)
     except ImportError:
-        import pip
-        pip.main(['install', package])
+		subprocess.check_call('{0} -m pip install {1}'.format(sys.executable, package))
     finally:
         globals()[package] = importlib.import_module(package)
 

--- a/install.py
+++ b/install.py
@@ -21,7 +21,7 @@ execution_time = "{:%H:%M}".format(execution_timestamp)
 log_file_name = "easy-install__{0}__{1}.log".format(execution_day, execution_time.replace(':', '-'))
 log_path = os.path.join(tmp_log_folder, log_file_name)
 log_stream = sys.stdout
-PY2 = sys.version[0] == '2'
+PY2 = sys.version_info.major == 2
 PY3 = not PY2
 
 def log(message, level=0):

--- a/install.py
+++ b/install.py
@@ -112,7 +112,6 @@ def get_distribution_info():
             return (distro.id(), distro.major_version())
 	
         elif platform.system() == 'Darwin':
-
             current_dist = platform.mac_ver()
             return ('macos', current_dist[0].rsplit('.', 1)[0])
 

--- a/install.py
+++ b/install.py
@@ -13,7 +13,6 @@ import datetime
 import importlib
 
 def install_and_import(package):
-    import importlib
     try:
         importlib.import_module(package)
     except ImportError:

--- a/install.py
+++ b/install.py
@@ -8,10 +8,14 @@ import json
 import multiprocessing
 import shutil
 import platform
-import distro
 import warnings
 import datetime
-
+try:
+  import distro
+except ImportError:
+  print "Trying to Install required module: requests\n"
+  os.system('python -m pip install distro')
+import distro
 
 tmp_bench_repo = os.path.join('/', 'tmp', '.bench')
 tmp_log_folder = os.path.join('/', 'tmp', 'logs')

--- a/install.py
+++ b/install.py
@@ -21,7 +21,7 @@ def install_and_import(package):
     finally:
         globals()[package] = importlib.import_module(package)
 
-install_and_import('distro')
+
 
 tmp_bench_repo = os.path.join('/', 'tmp', '.bench')
 tmp_log_folder = os.path.join('/', 'tmp', 'logs')
@@ -445,6 +445,7 @@ if __name__ == '__main__':
 	with warnings.catch_warnings():
 		warnings.simplefilter("ignore")
 		setup_log_stream(args)
+		install_and_import('distro')
 		check_distribution_compatibility()
 		check_system_package_managers()
 		check_environment()

--- a/install.py
+++ b/install.py
@@ -111,7 +111,7 @@ def get_distribution_info():
 
     if platform.system() == 'Linux':
         if sys.version_info < (3, 7):
-            current_dist = platfor.dist()
+            current_dist = platform.dist()
         else:
             return (distro.id(), distro.major_version())
     elif platform.system() == 'Darwin':

--- a/install.py
+++ b/install.py
@@ -114,11 +114,7 @@ def get_distribution_info():
                + platform.python_version_tuple()[1]) <= 3.7:
             current_dist = platfor.dist()
         else:
-            current_dist = \
-                distro.linux_distribution(full_distribution_name=True)
-
-            return (current_dist[0].lower(), current_dist[1].rsplit('.'
-                    )[0])
+            return (distro.id(), distro.major_version())
     elif platform.system() == 'Darwin':
 
         current_dist = platform.mac_ver()

--- a/install.py
+++ b/install.py
@@ -95,18 +95,23 @@ def check_distribution_compatibility():
 
 
 def get_distribution_info():
-	# return distribution name and major version
-	if platform.system() == "Linux":
-        if (platform.python_version_tuple()[0] + platform.python_version_tuple()[1]) == '2.7':
-            current_dist = platfor.dist()
-        elif :
-            current_dist = distro.linux_distribution(full_distribution_name=True)
-            
-		return current_dist[0].lower(), current_dist[1].rsplit('.')[0]
 
-	elif platform.system() == "Darwin":
-		current_dist = platform.mac_ver()
-		return "macos", current_dist[0].rsplit('.', 1)[0]
+    # return distribution name and major version
+
+    if platform.system() == 'Linux':
+        if int(platform.python_version_tuple()[0]
+               + platform.python_version_tuple()[1]) <= 3.7:
+            current_dist = platfor.dist()
+        else:
+            current_dist = \
+                distro.linux_distribution(full_distribution_name=True)
+
+            return (current_dist[0].lower(), current_dist[1].rsplit('.'
+                    )[0])
+    elif platform.system() == 'Darwin':
+
+        current_dist = platform.mac_ver()
+        return ('macos', current_dist[0].rsplit('.', 1)[0])
 
 
 def run_os_command(command_map):

--- a/install.py
+++ b/install.py
@@ -17,7 +17,7 @@ def install_and_import(package):
         importlib.import_module(package)
     except ImportError:
 	print("Trying to Install required module: " + package)
-	subprocess.check_call('{0} -m pip install {1}'.format(sys.executable, package))
+	subprocess.check_call([sys.executable, "-m", "pip", "install", package])
     finally:
         globals()[package] = importlib.import_module(package)
 

--- a/install.py
+++ b/install.py
@@ -67,7 +67,6 @@ def check_system_package_managers():
 			raise Exception('''
 			Please install brew package manager before proceeding with bench setup. Please run following
 			to install brew package manager on your machine,
-
 			/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 			''')
 	if 'Linux' in os.uname():
@@ -98,7 +97,11 @@ def check_distribution_compatibility():
 def get_distribution_info():
 	# return distribution name and major version
 	if platform.system() == "Linux":
-		current_dist = distro.linux_distribution(full_distribution_name=True)
+        if (platform.python_version_tuple()[0] + platform.python_version_tuple()[1]) == '2.7':
+            current_dist = platfor.dist()
+        elif :
+            current_dist = distro.linux_distribution(full_distribution_name=True)
+            
 		return current_dist[0].lower(), current_dist[1].rsplit('.')[0]
 
 	elif platform.system() == "Darwin":

--- a/install.py
+++ b/install.py
@@ -110,8 +110,7 @@ def get_distribution_info():
     # return distribution name and major version
 
     if platform.system() == 'Linux':
-        if int(platform.python_version_tuple()[0]
-               + platform.python_version_tuple()[1]) <= 3.7:
+        if sys.version_info < (3, 7):
             current_dist = platfor.dist()
         else:
             return (distro.id(), distro.major_version())

--- a/install.py
+++ b/install.py
@@ -8,6 +8,7 @@ import json
 import multiprocessing
 import shutil
 import platform
+import distro
 import warnings
 import datetime
 
@@ -78,7 +79,7 @@ def check_distribution_compatibility():
 	dist_name, dist_version = get_distribution_info()
 	supported_dists = {
 		'macos': [10.9, 10.10, 10.11, 10.12],
-		'ubuntu': [14, 15, 16, 18, 19],
+		'ubuntu': [14, 15, 16, 18, 19, 20],
 		'debian': [8, 9],
 		'centos': [7]
 	}
@@ -97,7 +98,7 @@ def check_distribution_compatibility():
 def get_distribution_info():
 	# return distribution name and major version
 	if platform.system() == "Linux":
-		current_dist = platform.dist()
+		current_dist = distro.linux_distribution(full_distribution_name=True)
 		return current_dist[0].lower(), current_dist[1].rsplit('.')[0]
 
 	elif platform.system() == "Darwin":

--- a/install.py
+++ b/install.py
@@ -16,7 +16,7 @@ def install_and_import(package):
     try:
         importlib.import_module(package)
     except ImportError:
-		subprocess.check_call('{0} -m pip install {1}'.format(sys.executable, package))
+	subprocess.check_call('{0} -m pip install {1}'.format(sys.executable, package))
     finally:
         globals()[package] = importlib.import_module(package)
 

--- a/install.py
+++ b/install.py
@@ -16,11 +16,11 @@ def install_and_import(package):
     try:
         importlib.import_module(package)
     except ImportError:
+	print("Trying to Install required module: " + package)
 	subprocess.check_call('{0} -m pip install {1}'.format(sys.executable, package))
     finally:
         globals()[package] = importlib.import_module(package)
 
-print("Trying to Install required module: distro")
 install_and_import('distro')
 
 tmp_bench_repo = os.path.join('/', 'tmp', '.bench')

--- a/install.py
+++ b/install.py
@@ -110,12 +110,12 @@ def get_distribution_info():
     # return distribution name and major version
 
 	if platform.system() == 'Linux':
-		return (distro.id(), distro.major_version())
+            return (distro.id(), distro.major_version())
 	
-    elif platform.system() == 'Darwin':
+        elif platform.system() == 'Darwin':
 
-        current_dist = platform.mac_ver()
-        return ('macos', current_dist[0].rsplit('.', 1)[0])
+            current_dist = platform.mac_ver()
+            return ('macos', current_dist[0].rsplit('.', 1)[0])
 
 
 def run_os_command(command_map):

--- a/install.py
+++ b/install.py
@@ -20,6 +20,7 @@ def install_and_import(package):
     finally:
         globals()[package] = importlib.import_module(package)
 
+print("Trying to Install required module: distro")
 install_and_import('distro')
 
 tmp_bench_repo = os.path.join('/', 'tmp', '.bench')

--- a/install.py
+++ b/install.py
@@ -13,7 +13,7 @@ import datetime
 try:
   import distro
 except ImportError:
-  print "Trying to Install required module: requests\n"
+  print("Trying to Install required module: distro")
   os.system('python -m pip install distro')
 import distro
 

--- a/install.py
+++ b/install.py
@@ -113,7 +113,10 @@ def get_distribution_info():
         if sys.version_info < (3, 7):
             current_dist = platform.dist()
         else:
-            return (distro.id(), distro.major_version())
+            current_dist = (distro.id(), distro.major_version())
+	
+            return (current_dist[0].lower(), current_dist[1].rsplit(".")[0])
+	
     elif platform.system() == 'Darwin':
 
         current_dist = platform.mac_ver()

--- a/install.py
+++ b/install.py
@@ -12,7 +12,7 @@ import warnings
 import datetime
 import importlib
 
-def install_and_import(package):
+def install_python_package(package):
     try:
         importlib.import_module(package)
     except ImportError:
@@ -445,7 +445,7 @@ if __name__ == '__main__':
 	with warnings.catch_warnings():
 		warnings.simplefilter("ignore")
 		setup_log_stream(args)
-		install_and_import('distro')
+		install_python_package('distro')
 		check_distribution_compatibility()
 		check_system_package_managers()
 		check_environment()


### PR DESCRIPTION
Replace platform.dist() with distro.linux_distribution in install.py | platform.dist() not supported by python3.8


Distro Information (Required)

Python >= 3.5
Ubuntu 20.04 LTS
And for all new distros in future

Possible Solution

To replace Replace platform.dist() with **distro.linux_distribution** in install.py

Use this module https://github.com/nir0s/distro for getting distro/system verion information.

Install distro module

`
Sudo pip install distro

`
