### PR TITLE
fix(playbooks): Use libssl1.1 for ubuntu >=18.04 

### DIFF
--- a/bench/playbooks/roles/common/tasks/ubuntu.yml
+++ b/bench/playbooks/roles/common/tasks/ubuntu.yml
@@ -33,7 +33,7 @@
 - name: install pdf prerequisites for Ubuntu >= 18.04
   apt:
     pkg:
-      - libssl1.0-dev
+      - libssl1.1
     state: present
     force: yes
   when: ansible_distribution_version is version_compare('18.04', 'ge')


### PR DESCRIPTION
For ubuntu >=18.04 use libssl1.1 to support upgrade of OS since libssl1.0-dev is not supported by Ubuntu20.04 LTS.
