### PR TITLE
feat(playbooks): wkthmltox for Ubuntu 20

### DIFF
--- a/bench/playbooks/roles/wkhtmltopdf/tasks/main.yml
+++ b/bench/playbooks/roles/wkhtmltopdf/tasks/main.yml
@@ -19,7 +19,6 @@
     state: present
     force: yes
   when: ansible_os_family == 'Debian'
-  
 
 - name: download wkthmltox Ubuntu 20
   get_url:

--- a/bench/playbooks/roles/wkhtmltopdf/tasks/main.yml
+++ b/bench/playbooks/roles/wkhtmltopdf/tasks/main.yml
@@ -20,6 +20,13 @@
     force: yes
   when: ansible_os_family == 'Debian'
 
+- name: download wkthmltox Ubuntu 20
+  get_url:
+    url: https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.focal_amd64.deb
+    dest: /tmp/wkhtmltox.deb
+    checksum: "sha256:{{ 'db48fa1a043309c4bfe8c8e0e38dc06c183f821599dd88d4e3cea47c5a5d4cd3' if ansible_architecture == 'x86_64' else '1f5ac84c1cb25e385b49b94a04807d60bf73da217bc6c9fe2cbd1f0a61d33f63' }}"
+  when: ansible_distribution == 'Ubuntu' and ansible_distribution_major_version == '20'
+  
 - name: download wkthmltox Ubuntu 18
   get_url:
     url: https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.bionic_{{ "amd64" if ansible_architecture == "x86_64" else "i386"}}.deb

--- a/bench/playbooks/roles/wkhtmltopdf/tasks/main.yml
+++ b/bench/playbooks/roles/wkhtmltopdf/tasks/main.yml
@@ -24,7 +24,6 @@
   get_url:
     url: https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.focal_amd64.deb
     dest: /tmp/wkhtmltox.deb
-    checksum: "sha256:{{ 'db48fa1a043309c4bfe8c8e0e38dc06c183f821599dd88d4e3cea47c5a5d4cd3' if ansible_architecture == 'x86_64' else '1f5ac84c1cb25e385b49b94a04807d60bf73da217bc6c9fe2cbd1f0a61d33f63' }}"
   when: ansible_distribution == 'Ubuntu' and ansible_distribution_major_version == '20'
     
 - name: download wkthmltox Ubuntu 18

--- a/bench/playbooks/roles/wkhtmltopdf/tasks/main.yml
+++ b/bench/playbooks/roles/wkhtmltopdf/tasks/main.yml
@@ -19,6 +19,7 @@
     state: present
     force: yes
   when: ansible_os_family == 'Debian'
+  
 
 - name: download wkthmltox Ubuntu 20
   get_url:
@@ -26,7 +27,7 @@
     dest: /tmp/wkhtmltox.deb
     checksum: "sha256:{{ 'db48fa1a043309c4bfe8c8e0e38dc06c183f821599dd88d4e3cea47c5a5d4cd3' if ansible_architecture == 'x86_64' else '1f5ac84c1cb25e385b49b94a04807d60bf73da217bc6c9fe2cbd1f0a61d33f63' }}"
   when: ansible_distribution == 'Ubuntu' and ansible_distribution_major_version == '20'
-  
+    
 - name: download wkthmltox Ubuntu 18
   get_url:
     url: https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.bionic_{{ "amd64" if ansible_architecture == "x86_64" else "i386"}}.deb


### PR DESCRIPTION
https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.focal_amd64.deb

Updating file to support Ubuntu20.04 LTS