### PR TITLE
fix: use remote_addr instead of user-defined header ip

### DIFF
--- a/bench/config/templates/nginx.conf
+++ b/bench/config/templates/nginx.conf
@@ -85,7 +85,7 @@ server {
 	}
 
 	location @webserver {
-		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+		proxy_set_header X-Forwarded-For $remote_addr;
 		proxy_set_header X-Forwarded-Proto $scheme;
 		proxy_set_header X-Frappe-Site-Name {{ site_name }};
 		proxy_set_header Host $host;


### PR DESCRIPTION
`$proxy_add_x_forwarded_for` sets the user defined ip in the request. changing it to `$remote_addr` ensures that nginx sets the remote ip itself, disregarding user-specified ip from the request.