### PR TITLE
fix: run backups every 6 hours, rather than every minute per 6 hours

### DIFF
--- a/bench/patches/patches.txt
+++ b/bench/patches/patches.txt
@@ -5,3 +5,4 @@ bench.patches.v4.update_node
 bench.patches.v4.update_socketio
 bench.patches.v4.install_yarn #2
 bench.patches.v5.fix_user_permissions
+bench.patches.v5.fix_backup_cronjob

--- a/bench/patches/v5/fix_backup_cronjob.py
+++ b/bench/patches/v5/fix_backup_cronjob.py
@@ -1,0 +1,15 @@
+from bench.config.common_site_config import get_config
+from crontab import CronTab
+
+
+def execute(bench_path):
+	"""
+		This patch fixes a cron job that would backup sites every minute per 6 hours
+	"""
+
+	user = get_config(bench_path=bench_path).get('frappe_user')
+	user_crontab = CronTab(user=user)
+
+	for job in user_crontab.find_comment("bench auto backups set for every 6 hours"):
+		job.every(6).hours()
+		user_crontab.write()

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -400,7 +400,7 @@ def setup_backups(bench_path='.'):
 
 	if job_command not in str(system_crontab):
 		job = system_crontab.new(command=job_command, comment="bench auto backups set for every 6 hours")
-		job.hour.every(6)
+		job.every(6).hours()
 		system_crontab.write()
 
 


### PR DESCRIPTION
What type of a PR is this?

- [ ] Changes to Existing Features
- [ ] New Feature Submissions
- [x] Bug Fix
- [ ] Breaking Change (include change in API behaviours, etc.)

---

> Explain the **details** for making this change. What existing problem does the pull request solve? The following checklist could help

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [x] Have you lint your code locally prior to submission?
- [ ] Have you successfully run tests with your changes locally?
- [x] Does your commit message have an explanation for your changes and why you'd like us to include them?
- [ ] Docs have been added / updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Did you modify the existing test cases? If yes, why?

---

**Problem:**

For newer benches, the crontab would be set to generate backups every _minute_ per 6 hours, as opposed to running it every 6 hours.

**Solution:**

Fix the crontab generation accordingly

**Reference:**

From the [`python-crontab`](https://pypi.org/project/python-crontab/) package documentation:

> Proceeding Unit Confusion

> It is sometimes logical to think that job.hour.every(2) will set all proceeding units to ‘0’ and thus result in “0 */2 * * *”. Instead you are controlling only the hours units and the minute column is unaffected. The real result would be “* */2 * * *” and maybe unexpected to those unfamiliar with crontabs.

> There is a special ‘every’ method on a job to clear the job’s existing schedule and replace it with a simple single unit:

> ```
> job.every(4).hours()  == '0 */4 * * *'
> job.every().dom()     == '0 0 * * *'
> job.every().month()   == '0 0 0 * *'
> job.every(2).dows()   == '0 0 * * */2'
> ```

> This is a convenience method only, it does normal things with the existing api.