### PR TITLE
fix: don't show warning message in developer mode

### DIFF
--- a/bench/cli.py
+++ b/bench/cli.py
@@ -32,7 +32,7 @@ def cli():
 	change_dir()
 	change_uid()
 
-	if is_dist_editable(bench.PROJECT_NAME) and len(sys.argv) > 1 and sys.argv[1] != "src":
+	if is_dist_editable(bench.PROJECT_NAME) and len(sys.argv) > 1 and sys.argv[1] != "src" and not get_config(".").get("developer_mode"):
 		log("bench is installed in editable mode!\n\nThis is not the recommended mode of installation for production. Instead, install the package from PyPI with: `pip install frappe-bench`\n", level=3)
 
 	if not is_bench_directory() and not cmd_requires_root() and len(sys.argv) > 1 and sys.argv[1] not in ("init", "find", "src"):


### PR DESCRIPTION
**Before:**
![Screenshot 2020-07-03 at 4 19 30 PM](https://user-images.githubusercontent.com/36654812/86462313-0907f480-bd49-11ea-8cf2-a7a894e3b8f4.png)

**After:**
![Screenshot 2020-07-03 at 4 19 43 PM](https://user-images.githubusercontent.com/36654812/86462314-0ad1b800-bd49-11ea-83bc-2a0a26ad7c80.png)
