### PR TITLE
feature: Added http2 to SSL site and push preload

### DIFF
--- a/bench/config/templates/nginx.conf
+++ b/bench/config/templates/nginx.conf
@@ -13,7 +13,7 @@ map {{ from_variable }} {{ to_variable }} {
 {%- macro server_block(bench_name, port, server_names, site_name, sites_path, ssl_certificate, ssl_certificate_key) %}
 server {
 	{% if ssl_certificate and ssl_certificate_key %}
-	listen {{ port }} ssl;
+	listen {{ port }} ssl http2;
 	{% else %}
 	listen {{ port }};
 	{% endif %}
@@ -25,6 +25,9 @@ server {
 		;
 
 	root {{ sites_path }};
+	{% if ssl_certificate and ssl_certificate_key %}
+	http2_push_preload on;
+	{% endif %}
 
 	{% if allow_rate_limiting %}
 	limit_conn per_host_{{ bench_name_hash }} 8;
@@ -60,6 +63,7 @@ server {
 	}
 
 	location /socket.io {
+
 		proxy_http_version 1.1;
 		proxy_set_header Upgrade $http_upgrade;
 		proxy_set_header Connection "upgrade";


### PR DESCRIPTION
Hi dev folks,
I noticed that bench in production, using Nginx, it's not configured to use http2 when Frappe or ERPNext are served over SSL connection.

With a tiny modification, I have added `http2` features to nginx.conf configuration
I have also added `http2_push_preload on` to nginx.conf to preload the push of files to clients

adding http2 has these goals:

- Create a negotiation mechanism that allows clients and servers to elect to use HTTP 1.1, 2.0, or potentially other non-HTTP protocols.

- Maintain high-level compatibility with HTTP 1.1 (for example with methods, status codes, URIs, and most header fields).

- Decrease latency to improve page load speed in web browsers

- data compression of HTTP headers

- HTTP/2 Server Push

- pipelining of requests

- fixing the head-of-line blocking problem in HTTP 1.x

- multiplexing 

- multiple requests over a single TCP connection

Everything it's explained more in detail in these pages:

- [https://medium.com/@mena.meseha/http-2-server-push-tutorial-d8714154ef9a](https://medium.com/@mena.meseha/http-2-server-push-tutorial-d8714154ef9a)

- [https://en.wikipedia.org/wiki/HTTP/2](https://en.wikipedia.org/wiki/HTTP/2)

- [https://www.nginx.com/blog/nginx-1-13-9-http2-server-push](https://www.nginx.com/blog/nginx-1-13-9-http2-server-push)

I hope this feat request could be approved and it will be ported also to version 11 and 12

Waiting for your comments