### PR TITLE
feat: bench start --no-prefix

### DIFF
--- a/bench/commands/utils.py
+++ b/bench/commands/utils.py
@@ -8,11 +8,12 @@ import click
 
 @click.command('start', help="Start Frappe development processes")
 @click.option('--no-dev', is_flag=True, default=False)
+@click.option('--no-prefix', is_flag=True, default=False)
 @click.option('--concurrency', '-c', type=str)
 @click.option('--procfile', '-p', type=str)
-def start(no_dev, concurrency, procfile):
+def start(no_dev, concurrency, procfile, no_prefix):
 	from bench.utils import start
-	start(no_dev=no_dev, concurrency=concurrency, procfile=procfile)
+	start(no_dev=no_dev, concurrency=concurrency, procfile=procfile, no_prefix=no_prefix)
 
 
 @click.command('restart', help="Restart supervisor processes or systemd units")

--- a/bench/commands/utils.py
+++ b/bench/commands/utils.py
@@ -8,7 +8,7 @@ import click
 
 @click.command('start', help="Start Frappe development processes")
 @click.option('--no-dev', is_flag=True, default=False)
-@click.option('--no-prefix', is_flag=True, default=False)
+@click.option('--no-prefix', is_flag=True, default=False, help="Hide process name from bench start log")
 @click.option('--concurrency', '-c', type=str)
 @click.option('--procfile', '-p', type=str)
 def start(no_dev, concurrency, procfile, no_prefix):

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -434,7 +434,7 @@ def get_process_manager():
 	return get_program(['foreman', 'forego', 'honcho'])
 
 
-def start(no_dev=False, concurrency=None, procfile=None):
+def start(no_dev=False, concurrency=None, procfile=None, no_prefix=False):
 	program = get_process_manager()
 	if not program:
 		raise Exception("No process manager found")
@@ -449,6 +449,9 @@ def start(no_dev=False, concurrency=None, procfile=None):
 	if procfile:
 		command.extend(['-f', procfile])
 
+	if no_prefix:
+		command.extend(['--no-prefix'])
+		
 	os.execv(program, command)
 
 


### PR DESCRIPTION
Is it not awesome if anyone is not interested in viewing the process prefixed with the log on the terminal window.

By adding this option `--no-prefix` while `bench start` we can achieve it.

I feel this will help in finding any error or any log more easily and you can copy also from the terminal window efficiently without the process prefixed.

![image](https://user-images.githubusercontent.com/44434910/89025314-3a71e100-d344-11ea-9f33-ce88623980c2.png)
