### PR TITLE
fix: Bump Nodejs v8 => v12

### DIFF
--- a/bench/playbooks/roles/nodejs/defaults/main.yml
+++ b/bench/playbooks/roles/nodejs/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
-node_version: 8
+node_version: 12
 ...


### PR DESCRIPTION
Well, because this should've happened a long time ago.