### PR TITLE
fix(install): Show Debian 10 is supported, update MariaDB defaults

### DIFF
--- a/install.py
+++ b/install.py
@@ -79,7 +79,7 @@ def check_distribution_compatibility():
 	supported_dists = {
 		'macos': [10.9, 10.10, 10.11, 10.12],
 		'ubuntu': [14, 15, 16, 18, 19],
-		'debian': [8, 9],
+		'debian': [8, 9, 10],
 		'centos': [7]
 	}
 
@@ -396,7 +396,7 @@ def parse_commandline_args():
 	parser.add_argument('--overwrite', dest='overwrite', action='store_true', default=False, help='Whether to overwrite an existing bench')
 	# set passwords
 	parser.add_argument('--mysql-root-password', dest='mysql_root_password', help='Set mysql root password')
-	parser.add_argument('--mariadb-version', dest='mariadb_version', default='10.2', help='Specify mariadb version')
+	parser.add_argument('--mariadb-version', dest='mariadb_version', default='10.4', help='Specify mariadb version')
 	parser.add_argument('--admin-password', dest='admin_password', help='Set admin password')
 	parser.add_argument('--bench-name', dest='bench_name', help='Create bench with specified name. Default name is frappe-bench')
 	# Python interpreter to be used


### PR DESCRIPTION
- Fix faulty Debian 10 unsupported statement
- Change MariaDB default version installed to `10.4`

Fixes https://github.com/frappe/bench/issues/1045