### PR TITLE
fix: Show correct src of bench source

### DIFF
--- a/bench/cli.py
+++ b/bench/cli.py
@@ -18,6 +18,7 @@ from bench.utils import PatchError, bench_cache_file, check_latest_version, drop
 
 from_command_line = False
 change_uid_msg = "You should not run this command as root"
+src = os.path.dirname(__file__)
 
 
 def cli():

--- a/bench/commands/utils.py
+++ b/bench/commands/utils.py
@@ -164,8 +164,8 @@ def disable_production():
 
 @click.command('src', help="Prints bench source folder path, which can be used as: cd `bench src`")
 def bench_src():
-	import bench
-	print(os.path.dirname(bench.__path__[0]))
+	from bench.cli import src
+	print(os.path.dirname(src))
 
 
 @click.command('find', help="Finds benches recursively from location")


### PR DESCRIPTION
Depending on which `bench` module Python gets while importing bench, `bench src` may give wrong results. In case the package of an older version is cached and gets imported first, the values may be different. This may even come up through some inconsistencies in the virtual environments you've set up.