### PR TITLE
fix: Don't show logs in stdout if command run outside bench directory

### DIFF
--- a/bench/cli.py
+++ b/bench/cli.py
@@ -27,7 +27,7 @@ def cli():
 	command = " ".join(sys.argv)
 
 	change_working_directory()
-	logger = setup_logging() or logging.getLogger(bench.PROJECT_NAME)
+	logger = setup_logging()
 	logger.info(command)
 	check_uid()
 	change_dir()

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -443,15 +443,18 @@ def setup_logging(bench_path='.'):
 	logging.Logger.log = logv
 
 	if os.path.exists(os.path.join(bench_path, 'logs')):
-		logger = logging.getLogger(bench.PROJECT_NAME)
 		log_file = os.path.join(bench_path, 'logs', 'bench.log')
-		formatter = logging.Formatter('%(asctime)s %(levelname)s %(message)s')
-		hdlr = logging.FileHandler(log_file)
-		hdlr.setFormatter(formatter)
-		logger.addHandler(hdlr)
-		logger.setLevel(logging.DEBUG)
+	else:
+		log_file = os.path.join(os.path.expanduser("~"), 'bench.log')
 
-		return logger
+	logger = logging.getLogger(bench.PROJECT_NAME)
+	formatter = logging.Formatter('%(asctime)s %(levelname)s %(message)s')
+	hdlr = logging.FileHandler(log_file)
+	hdlr.setFormatter(formatter)
+	logger.addHandler(hdlr)
+	logger.setLevel(logging.DEBUG)
+
+	return logger
 
 
 def get_process_manager():

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -444,12 +444,12 @@ def setup_logging(bench_path='.'):
 
 	if os.path.exists(os.path.join(bench_path, 'logs')):
 		log_file = os.path.join(bench_path, 'logs', 'bench.log')
+		hdlr = logging.FileHandler(log_file)
 	else:
-		log_file = os.path.join(os.path.expanduser("~"), 'bench.log')
+		hdlr = logging.NullHandler()
 
 	logger = logging.getLogger(bench.PROJECT_NAME)
 	formatter = logging.Formatter('%(asctime)s %(levelname)s %(message)s')
-	hdlr = logging.FileHandler(log_file)
 	hdlr.setFormatter(formatter)
 	logger.addHandler(hdlr)
 	logger.setLevel(logging.DEBUG)


### PR DESCRIPTION
![Screenshot 2020-09-10 at 10 17 13 AM](https://user-images.githubusercontent.com/36654812/92682790-d5e86f80-f34e-11ea-8f83-89e6e49f84df.png)

if bench commands are executed under the bench directory, they get populated under `./logs/bench.log`. In case of commands executed outside the bench directories, this PR adds a `NullHandler` to the existing bench logger.

Fixes #1057 