### PR TITLE
fix: Handle no args passed in CLI

### DIFF
--- a/bench/cli.py
+++ b/bench/cli.py
@@ -30,11 +30,10 @@ def cli():
 	logger = setup_logging() or logging.getLogger(bench.PROJECT_NAME)
 	logger.info(command)
 
-	if sys.argv[1] not in ("src", ):
+	if len(sys.argv) > 1 and sys.argv[1] not in ("src", ):
 		check_uid()
 		change_uid()
-
-	change_dir()
+		change_dir()
 
 	if is_dist_editable(bench.PROJECT_NAME) and len(sys.argv) > 1 and sys.argv[1] != "src" and not get_config(".").get("developer_mode"):
 		log("bench is installed in editable mode!\n\nThis is not the recommended mode of installation for production. Instead, install the package from PyPI with: `pip install frappe-bench`\n", level=3)

--- a/bench/tests/test_init.py
+++ b/bench/tests/test_init.py
@@ -9,6 +9,7 @@ import git
 
 # imports - module imports
 import bench
+import bench.cli
 import bench.utils
 from bench.release import get_bumped_version
 from bench.tests.test_base import FRAPPE_BRANCH, TestBenchBase

--- a/bench/tests/test_init.py
+++ b/bench/tests/test_init.py
@@ -27,6 +27,11 @@ class TestBenchInit(TestBenchBase):
 		self.assertEqual( get_bumped_version('11.0.5-beta.22', 'prerelease'), '11.0.5-beta.23' )
 
 
+	def test_utils(self):
+		self.assertEqual(subprocess.call("bench"), 0)
+		self.assertEqual(os.path.dirname(bench.cli.src), subprocess.check_output(["bench", "src"], cwd=".").decode('utf8'))
+
+
 	def test_init(self, bench_name="test-bench", **kwargs):
 		self.init_bench(bench_name, **kwargs)
 		self.assert_folders(bench_name)

--- a/bench/tests/test_init.py
+++ b/bench/tests/test_init.py
@@ -30,7 +30,6 @@ class TestBenchInit(TestBenchBase):
 
 	def test_utils(self):
 		self.assertEqual(subprocess.call("bench"), 0)
-		self.assertEqual(os.path.dirname(bench.cli.src), subprocess.check_output(["bench", "src"], cwd=".").decode('utf8'))
 
 
 	def test_init(self, bench_name="test-bench", **kwargs):


### PR DESCRIPTION
When no args given the command breaks, works fine with commands like
bench --version, bench init etc


![](https://frappe.io/files/YVDmsot.png)
