### PR TITLE
fix: Run compileall in bench after update

### DIFF
--- a/bench/commands/update.py
+++ b/bench/commands/update.py
@@ -15,11 +15,12 @@ from bench.utils import post_upgrade, patch_sites, build_assets
 @click.option('--restart-supervisor', is_flag=True, help="Restart supervisor processes after update")
 @click.option('--restart-systemd', is_flag=True, help="Restart systemd units after update")
 @click.option('--no-backup', is_flag=True, help="If this flag is set, sites won't be backed up prior to updates. Note: This is not recommended in production.")
+@click.option('--no-compile', is_flag=True, help="If set, Python bytecode won't be compiled before restarting the processes")
 @click.option('--force', is_flag=True, help="Forces major version upgrades")
 @click.option('--reset', is_flag=True, help="Hard resets git branch's to their new states overriding any changes and overriding rebase on pull")
-def update(pull, apps, patch, build, requirements, restart_supervisor, restart_systemd, no_backup, force, reset):
+def update(pull, apps, patch, build, requirements, restart_supervisor, restart_systemd, no_backup, no_compile, force, reset):
 	from bench.utils import update
-	update(pull=pull, apps=apps, patch=patch, build=build, requirements=requirements, restart_supervisor=restart_supervisor, restart_systemd=restart_systemd, backup=not no_backup, force=force, reset=reset)
+	update(pull=pull, apps=apps, patch=patch, build=build, requirements=requirements, restart_supervisor=restart_supervisor, restart_systemd=restart_systemd, backup=not no_backup, compile=not no_compile, force=force, reset=reset)
 
 
 @click.command('retry-upgrade', help="Retry a failed upgrade")

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # imports - standard imports
+import compileall
 import errno
 import glob
 import grp
@@ -183,8 +184,8 @@ def init(path, apps_path=None, no_procfile=False, no_backups=False,
 	copy_patches_txt(path)
 
 
-def update(pull=False, apps=None, patch=False, build=False, requirements=False, backup=True, force=False, reset=False,
-	restart_supervisor=False, restart_systemd=False):
+def update(pull=False, apps=None, patch=False, build=False, requirements=False, backup=True, compile=True,
+	force=False, reset=False, restart_supervisor=False, restart_systemd=False):
 	"""command: bench update"""
 	from bench import patches
 	from bench.app import is_version_upgrade, pull_apps, validate_branch
@@ -218,7 +219,6 @@ def update(pull=False, apps=None, patch=False, build=False, requirements=False, 
 
 	if version_upgrade[0] or (not version_upgrade[0] and force):
 		validate_upgrade(version_upgrade[1], version_upgrade[2], bench_path=bench_path)
-
 	conf.update({ "maintenance_mode": 1, "pause_scheduler": 1 })
 	update_config(conf, bench_path=bench_path)
 
@@ -245,6 +245,10 @@ def update(pull=False, apps=None, patch=False, build=False, requirements=False, 
 
 	if version_upgrade[0] or (not version_upgrade[0] and force):
 		post_upgrade(version_upgrade[1], version_upgrade[2], bench_path=bench_path)
+
+	if pull and compile:
+		print("Compiling Python files...")
+		compileall.compile_dir('../apps', quiet=1, rx=re.compile('.*node_modules.*'))
 
 	if restart_supervisor or conf.get('restart_supervisor_on_update'):
 		restart_supervisor_processes(bench_path=bench_path)
@@ -481,7 +485,7 @@ def start(no_dev=False, concurrency=None, procfile=None, no_prefix=False):
 
 	if no_prefix:
 		command.extend(['--no-prefix'])
-		
+
 	os.execv(program, command)
 
 


### PR DESCRIPTION
Move `compileall. compile_dir` after a pull updates.