### PR TITLE
fix(CLI): Traceback, Exit codes, logging management

### DIFF
--- a/bench/__init__.py
+++ b/bench/__init__.py
@@ -8,3 +8,12 @@ def set_frappe_version(bench_path='.'):
 	global FRAPPE_VERSION
 	if not FRAPPE_VERSION:
 		FRAPPE_VERSION = get_current_frappe_version(bench_path=bench_path)
+
+def get_traceback():
+	import sys
+	import traceback
+
+	exc_type, exc_value, exc_tb = sys.exc_info()
+	trace_list = traceback.format_exception(exc_type, exc_value, exc_tb)
+	body = "".join(cstr(t) for t in trace_list)
+	return body

--- a/bench/__init__.py
+++ b/bench/__init__.py
@@ -15,5 +15,6 @@ def get_traceback():
 
 	exc_type, exc_value, exc_tb = sys.exc_info()
 	trace_list = traceback.format_exception(exc_type, exc_value, exc_tb)
-	body = "".join(cstr(t) for t in trace_list)
+	body = "".join(str(t) for t in trace_list)
+
 	return body

--- a/bench/cli.py
+++ b/bench/cli.py
@@ -62,9 +62,10 @@ def cli():
 	try:
 		bench_command()
 	except BaseException as e:
+		log(e, level=2)
 		return_code = getattr(e, "code", 0)
 		if return_code:
-			logger.warning("{0} executed with exit code {1}".format(command, return_code))
+			logger.warning("{0} executed with exit code {1}: {2}".format(command, return_code, bench.get_traceback()))
 		sys.exit(return_code)
 
 

--- a/bench/cli.py
+++ b/bench/cli.py
@@ -62,15 +62,17 @@ def cli():
 	try:
 		bench_command()
 	except BaseException as e:
-		log(e, level=2)
 		traceback = bench.get_traceback()
-		return_code = getattr(e, "code", 0)
+		return_code = e or (1 if traceback else 0)
 
-		if "--verbose" in sys.argv:
-			print("Traceback: \n{}".format(traceback))
+		if traceback and return_code in (0, 1):
+			log(e, level=2)
+
+		if any([x for x in ["--verbose", "-v"] if x in sys.argv]):
+			print(traceback)
 
 		if return_code:
-			logger.warning("{0} executed with exit code {1}: {2}".format(command, return_code, traceback))
+			logger.error("{0} executed with exit code {1}: {2}".format(command, return_code, traceback))
 
 		sys.exit(return_code)
 

--- a/bench/cli.py
+++ b/bench/cli.py
@@ -63,9 +63,15 @@ def cli():
 		bench_command()
 	except BaseException as e:
 		log(e, level=2)
+		traceback = bench.get_traceback()
 		return_code = getattr(e, "code", 0)
+
+		if "--verbose" in sys.argv:
+			print("Traceback: \n{}".format(traceback))
+
 		if return_code:
-			logger.warning("{0} executed with exit code {1}: {2}".format(command, return_code, bench.get_traceback()))
+			logger.warning("{0} executed with exit code {1}: {2}".format(command, return_code, traceback))
+
 		sys.exit(return_code)
 
 

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -99,7 +99,7 @@ def check_latest_version():
 		# ignore checking on all Exceptions
 		return
 
-	if pypi_request.status_code == 200:
+	if pypi_request.ok:
 		pypi_version_str = pypi_request.json().get('info').get('version')
 		pypi_version = Version(pypi_version_str)
 		local_version = Version(bench.VERSION)
@@ -481,7 +481,7 @@ def start(no_dev=False, concurrency=None, procfile=None, no_prefix=False):
 
 	if no_prefix:
 		command.extend(['--no-prefix'])
-		
+
 	os.execv(program, command)
 
 

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -80,7 +80,7 @@ def log(message, level=0):
 	end_line = '\033[0m'
 
 	level_logger(message)
-	print(start_line + message + end_line)
+	print("{}{}{}".format(start_line, message, end_line))
 
 
 def safe_decode(string, encoding = 'utf-8'):


### PR DESCRIPTION
1. In case a command fails with an error, print the message and log the entire traceback in the bench log. 
1. If `--verbose` is a part of the bench command, print the traceback too
1. Pass down the appropriate exit code

Fixes https://github.com/frappe/bench/issues/1095