### PR TITLE
feat: Add full (deep) clone option to bench init

### DIFF
--- a/bench/app.py
+++ b/bench/app.py
@@ -109,7 +109,7 @@ def get_app(git_url, branch=None, bench_path='.', skip_assets=False, verbose=Fal
 
 		# Gets repo name from URL
 		repo_name = git_url.rstrip('/').rsplit('/', 1)[1].rsplit('.', 1)[0]
-		shallow_clone = '--depth 1' if check_git_for_shallow_clone() else ''
+		shallow_clone = '--depth 1' if check_git_for_shallow_clone(bench_path) else ''
 		branch = '--branch {branch}'.format(branch=branch) if branch else ''
 	else:
 		repo_name = git_url.split(os.sep)[-1]

--- a/bench/commands/make.py
+++ b/bench/commands/make.py
@@ -11,13 +11,13 @@ import click
 @click.option('--frappe-branch', default=None, help="Clone a particular branch of frappe")
 @click.option('--clone-from', default=None, help="copy repos from path")
 @click.option('--clone-without-update', is_flag=True, help="copy repos from path without update")
-@click.option('--clone-full', is_flag=True, help="make a full (deep) clone of the repositories")
+@click.option('--deep-clone', is_flag=True, help="Make a deep clone of the app repositories")
 @click.option('--no-procfile', is_flag=True, help="Do not create a Procfile")
 @click.option('--no-backups',is_flag=True, help="Do not set up automatic periodic backups for all sites on this bench")
 @click.option('--skip-redis-config-generation', is_flag=True, help="Skip redis config generation if already specifying the common-site-config file")
 @click.option('--skip-assets',is_flag=True, default=False, help="Do not build assets")
 @click.option('--verbose',is_flag=True, help="Verbose output during install")
-def init(path, apps_path, frappe_path, frappe_branch, no_procfile, no_backups, clone_from, verbose, skip_redis_config_generation, clone_without_update, clone_full, ignore_exist=False, skip_assets=False, python='python3'):
+def init(path, apps_path, frappe_path, frappe_branch, no_procfile, no_backups, clone_from, verbose, skip_redis_config_generation, clone_without_update, deep_clone=False, ignore_exist=False, skip_assets=False, python='python3'):
 	from bench.utils import init, log
 
 	try:
@@ -32,7 +32,7 @@ def init(path, apps_path, frappe_path, frappe_branch, no_procfile, no_backups, c
 			clone_from=clone_from,
 			skip_redis_config_generation=skip_redis_config_generation,
 			clone_without_update=clone_without_update,
-			clone_full=clone_full,
+			deep_clone=deep_clone,
 			ignore_exist=ignore_exist,
 			skip_assets=skip_assets,
 			python=python,

--- a/bench/commands/make.py
+++ b/bench/commands/make.py
@@ -11,12 +11,13 @@ import click
 @click.option('--frappe-branch', default=None, help="path to frappe repo")
 @click.option('--clone-from', default=None, help="copy repos from path")
 @click.option('--clone-without-update', is_flag=True, help="copy repos from path without update")
+@click.option('--clone-full', is_flag=True, help="make a full (deep) clone of the repositories")
 @click.option('--no-procfile', is_flag=True, help="Do not create a Procfile")
 @click.option('--no-backups',is_flag=True, help="Do not set up automatic periodic backups for all sites on this bench")
 @click.option('--skip-redis-config-generation', is_flag=True, help="Skip redis config generation if already specifying the common-site-config file")
 @click.option('--skip-assets',is_flag=True, default=False, help="Do not build assets")
 @click.option('--verbose',is_flag=True, help="Verbose output during install")
-def init(path, apps_path, frappe_path, frappe_branch, no_procfile, no_backups, clone_from, verbose, skip_redis_config_generation, clone_without_update, ignore_exist=False, skip_assets=False, python='python3'):
+def init(path, apps_path, frappe_path, frappe_branch, no_procfile, no_backups, clone_from, verbose, skip_redis_config_generation, clone_without_update, clone_full, ignore_exist=False, skip_assets=False, python='python3'):
 	from bench.utils import init, log
 
 	try:
@@ -31,6 +32,7 @@ def init(path, apps_path, frappe_path, frappe_branch, no_procfile, no_backups, c
 			clone_from=clone_from,
 			skip_redis_config_generation=skip_redis_config_generation,
 			clone_without_update=clone_without_update,
+			clone_full=clone_full,
 			ignore_exist=ignore_exist,
 			skip_assets=skip_assets,
 			python=python,

--- a/bench/config/common_site_config.py
+++ b/bench/config/common_site_config.py
@@ -19,12 +19,15 @@ default_config = {
 	'background_workers': 1
 }
 
-def make_config(bench_path):
+def make_config(bench_path, extra_config=None):
 	make_pid_folder(bench_path)
 	bench_config = get_config(bench_path)
 	bench_config.update(default_config)
 	bench_config.update(get_gunicorn_workers())
 	update_config_for_frappe(bench_config, bench_path)
+
+	if extra_config:
+		bench_config.update(extra_config)
 
 	put_config(bench_config, bench_path)
 

--- a/bench/config/common_site_config.py
+++ b/bench/config/common_site_config.py
@@ -19,7 +19,7 @@ default_config = {
 	'background_workers': 1
 }
 
-def make_config(bench_path, extra_config=None):
+def make_config(bench_path, **extra_config):
 	make_pid_folder(bench_path)
 	bench_config = get_config(bench_path)
 	bench_config.update(default_config)

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -123,7 +123,8 @@ def get_env_cmd(cmd, bench_path='.'):
 
 def init(path, apps_path=None, no_procfile=False, no_backups=False,
 		frappe_path=None, frappe_branch=None, verbose=False, clone_from=None,
-		skip_redis_config_generation=False, clone_without_update=False, ignore_exist=False, skip_assets=False,
+		skip_redis_config_generation=False, clone_without_update=False, clone_full=False,
+		ignore_exist=False, skip_assets=False,
 		python='python3'):
 	"""Initialize a new bench directory"""
 	from bench.app import get_app, install_apps_from_path
@@ -150,7 +151,13 @@ def init(path, apps_path=None, no_procfile=False, no_backups=False,
 
 	setup_env(bench_path=path, python=python)
 
-	make_config(path)
+	extra_config = None
+	if clone_full:
+		extra_config = {
+			'shallow_clone': False
+		}
+
+	make_config(path, extra_config)
 
 	if clone_from:
 		clone_apps_from(bench_path=path, clone_from=clone_from, update_app=not clone_without_update)
@@ -499,9 +506,9 @@ def get_git_version():
 	return float(version)
 
 
-def check_git_for_shallow_clone():
+def check_git_for_shallow_clone(bench_path='.'):
 	from .config.common_site_config import get_config
-	config = get_config('.')
+	config = get_config(bench_path)
 
 	if config:
 		if config.get('release_bench'):

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -151,13 +151,7 @@ def init(path, apps_path=None, no_procfile=False, no_backups=False,
 
 	setup_env(bench_path=path, python=python)
 
-	extra_config = None
-	if clone_full:
-		extra_config = {
-			'shallow_clone': False
-		}
-
-	make_config(path, extra_config)
+	make_config(path, shallow_clone=not clone_full)
 
 	if clone_from:
 		clone_apps_from(bench_path=path, clone_from=clone_from, update_app=not clone_without_update)

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -114,7 +114,7 @@ def get_env_cmd(cmd, bench_path='.'):
 
 def init(path, apps_path=None, no_procfile=False, no_backups=False,
 		frappe_path=None, frappe_branch=None, verbose=False, clone_from=None,
-		skip_redis_config_generation=False, clone_without_update=False, clone_full=False,
+		skip_redis_config_generation=False, clone_without_update=False, deep_clone=False,
 		ignore_exist=False, skip_assets=False,
 		python='python3'):
 	"""Initialize a new bench directory"""
@@ -144,7 +144,7 @@ def init(path, apps_path=None, no_procfile=False, no_backups=False,
 
 	setup_env(bench_path=path, python=python)
 
-	make_config(path, shallow_clone=not clone_full)
+	make_config(path, shallow_clone=not deep_clone)
 
 	if clone_from:
 		clone_apps_from(bench_path=path, clone_from=clone_from, update_app=not clone_without_update)


### PR DESCRIPTION
Add a new --clone-full option to the bench init command to request a full clone of frappe and any other installed apps.

This change should make it easier to create a development setup using bench init.
