### PR TITLE
feat: skip redis config during supervisor setup

### DIFF
--- a/bench/commands/setup.py
+++ b/bench/commands/setup.py
@@ -42,9 +42,10 @@ def reload_nginx():
 @click.command("supervisor", help="Generate configuration for supervisor")
 @click.option("--user", help="optional user argument")
 @click.option("--yes", help="Yes to regeneration of supervisor config", is_flag=True, default=False)
-def setup_supervisor(user=None, yes=False):
+@click.option("--skip-redis", help="Skip redis configuration", is_flag=True, default=False)
+def setup_supervisor(user=None, yes=False, skip_redis=False):
 	bench.config.supervisor.update_supervisord_config(user=user, yes=yes)
-	bench.config.supervisor.generate_supervisor_config(bench_path=".", user=user, yes=yes)
+	bench.config.supervisor.generate_supervisor_config(bench_path=".", user=user, yes=yes, skip_redis=skip_redis)
 
 
 @click.command("redis", help="Generates configuration for Redis")

--- a/bench/config/supervisor.py
+++ b/bench/config/supervisor.py
@@ -17,7 +17,7 @@ from six.moves import configparser
 logger = logging.getLogger(bench.PROJECT_NAME)
 
 
-def generate_supervisor_config(bench_path, user=None, yes=False):
+def generate_supervisor_config(bench_path, user=None, yes=False, skip_redis=False):
 	"""Generate supervisor config for respective bench path"""
 	if not user:
 		user = getpass.getuser()
@@ -42,7 +42,8 @@ def generate_supervisor_config(bench_path, user=None, yes=False):
 		"gunicorn_workers": config.get('gunicorn_workers', get_gunicorn_workers()["gunicorn_workers"]),
 		"bench_name": get_bench_name(bench_path),
 		"background_workers": config.get('background_workers') or 1,
-		"bench_cmd": find_executable('bench')
+		"bench_cmd": find_executable('bench'),
+		"skip_redis": skip_redis,
 	})
 
 	conf_path = os.path.join(bench_path, 'config', 'supervisor.conf')

--- a/bench/config/templates/supervisor.conf
+++ b/bench/config/templates/supervisor.conf
@@ -114,6 +114,7 @@ killasgroup=true
 
 {% endif %}
 
+{% if not skip_redis %}
 [program:{{ bench_name }}-redis-cache]
 command={{ redis_server }} {{ redis_cache_config }}
 priority=1
@@ -133,8 +134,10 @@ stdout_logfile={{ bench_dir }}/logs/redis-queue.log
 stderr_logfile={{ bench_dir }}/logs/redis-queue.error.log
 user={{ user }}
 directory={{ sites_dir }}
+{% endif %}
 
 {% if frappe_version > 5 %}
+{% if not skip_redis %}
 [program:{{ bench_name }}-redis-socketio]
 command={{ redis_server }} {{ redis_socketio_config }}
 priority=1
@@ -144,6 +147,7 @@ stdout_logfile={{ bench_dir }}/logs/redis-socketio.log
 stderr_logfile={{ bench_dir }}/logs/redis-socketio.error.log
 user={{ user }}
 directory={{ sites_dir }}
+{% endif %}
 
 {% if node %}
 [program:{{ bench_name }}-node-socketio]
@@ -174,5 +178,7 @@ programs={{ bench_name }}-frappe-workerbeat,{{ bench_name }}-frappe-worker,{{ be
 
 {% endif %}
 
+{% if not skip_redis %}
 [group:{{ bench_name }}-redis]
 programs={{ bench_name }}-redis-cache,{{ bench_name }}-redis-queue {%- if frappe_version > 5 -%} ,{{ bench_name }}-redis-socketio {%- endif %}
+{% endif %}


### PR DESCRIPTION
skips redis configuration during `bench setup supervisor --skip-redis`
In case redis is not installed locally and used as a remote service it causes redis processes to fail with command not found.