### PR TITLE
fix: Merge v5.x into develop to get good version number

### DIFF
--- a/bench/__init__.py
+++ b/bench/__init__.py
@@ -1,4 +1,4 @@
-VERSION = "5.2.1"
+VERSION = "5.3.0"
 PROJECT_NAME = "frappe-bench"
 FRAPPE_VERSION = None
 


### PR DESCRIPTION
Into docker develop deployment get rig of the anoying message "upgrade bench to 5.3"