### PR TITLE
feat: Keep repos shallow if --reset and shallow_clone are specified in bench update --pull

### DIFF
--- a/bench/app.py
+++ b/bench/app.py
@@ -228,7 +228,7 @@ def pull_apps(apps=None, bench_path='.', reset=False):
 	rebase = '--rebase' if get_config(bench_path).get('rebase_on_pull') else ''
 
 	apps = apps or get_apps(bench_path=bench_path)
-	# chech for local changes
+	# check for local changes
 	if not reset:
 		for app in apps:
 			excluded_apps = get_excluded_apps()
@@ -271,9 +271,10 @@ Here are your choices:
 				reset_cmd = "git reset --hard {remote}/{branch}".format(
 					remote=remote, branch=get_current_branch(app,bench_path=bench_path))
 				if get_config(bench_path).get('shallow_clone'):
-					exec_cmd("git fetch --depth 1 --no-tags", cwd=app_dir)
+					exec_cmd("git fetch --depth=1 --no-tags", cwd=app_dir)
 					exec_cmd(reset_cmd, cwd=app_dir)
-					exec_cmd("git clean -dfx", cwd=app_dir)
+					exec_cmd("git reflog expire --all", cwd=app_dir)
+					exec_cmd("git gc --prune=all", cwd=app_dir)
 				else:
 					exec_cmd("git fetch --all", cwd=app_dir)
 					exec_cmd(reset_cmd, cwd=app_dir)
@@ -284,20 +285,15 @@ Here are your choices:
 
 
 def is_version_upgrade(app='frappe', bench_path='.', branch=None):
-	try:
-		fetch_upstream(app, bench_path=bench_path)
-	except CommandFailedError:
-		raise InvalidRemoteException("No remote named upstream for {0}".format(app))
-
 	upstream_version = get_upstream_version(app=app, branch=branch, bench_path=bench_path)
 
 	if not upstream_version:
-		raise InvalidBranchException("Specified branch of app {0} is not in upstream".format(app))
+		raise InvalidBranchException('Specified branch of app {0} is not in upstream remote'.format(app))
 
 	local_version = get_major_version(get_current_version(app, bench_path=bench_path))
 	upstream_version = get_major_version(upstream_version)
 
-	if upstream_version - local_version > 0:
+	if upstream_version > local_version:
 		return (True, local_version, upstream_version)
 
 	return (False, local_version, upstream_version)
@@ -330,10 +326,6 @@ def use_rq(bench_path):
 	celery_app = os.path.join(bench_path, 'apps', 'frappe', 'frappe', 'celery_app.py')
 	return not os.path.exists(celery_app)
 
-def fetch_upstream(app, bench_path='.'):
-	repo_dir = get_repo_dir(app, bench_path=bench_path)
-	return subprocess.call(["git", "fetch", "upstream"], cwd=repo_dir)
-
 def get_current_version(app, bench_path='.'):
 	repo_dir = get_repo_dir(app, bench_path=bench_path)
 	try:
@@ -352,10 +344,16 @@ def get_develop_version(app, bench_path='.'):
 
 def get_upstream_version(app, branch=None, bench_path='.'):
 	repo_dir = get_repo_dir(app, bench_path=bench_path)
+	try:
+		subprocess.call('git fetch --depth=1 --no-tags upstream', shell=True, cwd=repo_dir)
+	except CommandFailedError:
+		raise InvalidRemoteException('Failed to fetch from remote named upstream for {0}'.format(app))
+
 	if not branch:
 		branch = get_current_branch(app, bench_path=bench_path)
 	try:
-		contents = subprocess.check_output(['git', 'show', 'upstream/{branch}:{app}/__init__.py'.format(branch=branch, app=app)], cwd=repo_dir, stderr=subprocess.STDOUT)
+		contents = subprocess.check_output('git show upstream/{branch}:{app}/__init__.py'.format(branch=branch, app=app),
+			shell=True, cwd=repo_dir, stderr=subprocess.STDOUT)
 		contents = contents.decode('utf-8')
 	except subprocess.CalledProcessError as e:
 		if b"Invalid object" in e.output:

--- a/bench/app.py
+++ b/bench/app.py
@@ -109,7 +109,8 @@ def get_app(git_url, branch=None, bench_path='.', skip_assets=False, verbose=Fal
 		shallow_clone = '--depth 1' if check_git_for_shallow_clone() else ''
 		branch = '--branch {branch}'.format(branch=branch) if branch else ''
 	else:
-		repo_name = git_url.split(os.sep)[-1]
+		git_url = os.path.abspath(git_url)
+		_, repo_name = os.path.split(git_url)
 		shallow_clone = ''
 		branch = '--branch {branch}'.format(branch=branch) if branch else ''
 

--- a/bench/app.py
+++ b/bench/app.py
@@ -345,13 +345,14 @@ def get_develop_version(app, bench_path='.'):
 
 def get_upstream_version(app, branch=None, bench_path='.'):
 	repo_dir = get_repo_dir(app, bench_path=bench_path)
+	if not branch:
+		branch = get_current_branch(app, bench_path=bench_path)
+
 	try:
-		subprocess.call('git fetch --depth=1 --no-tags upstream', shell=True, cwd=repo_dir)
+		subprocess.call('git fetch --depth=1 --no-tags upstream {branch}'.format(branch=branch), shell=True, cwd=repo_dir)
 	except CommandFailedError:
 		raise InvalidRemoteException('Failed to fetch from remote named upstream for {0}'.format(app))
 
-	if not branch:
-		branch = get_current_branch(app, bench_path=bench_path)
 	try:
 		contents = subprocess.check_output('git show upstream/{branch}:{app}/__init__.py'.format(branch=branch, app=app),
 			shell=True, cwd=repo_dir, stderr=subprocess.STDOUT)

--- a/bench/app.py
+++ b/bench/app.py
@@ -237,7 +237,7 @@ def pull_apps(apps=None, bench_path='.', reset=False):
 				continue
 			app_dir = get_repo_dir(app, bench_path=bench_path)
 			if os.path.exists(os.path.join(app_dir, '.git')):
-				out = subprocess.check_output(["git", "status"], cwd=app_dir)
+				out = subprocess.check_output('git status', shell=True, cwd=app_dir)
 				out = out.decode('utf-8')
 				if not re.search(r'nothing to commit, working (directory|tree) clean', out):
 					print('''
@@ -266,12 +266,13 @@ Here are your choices:
 				add_to_excluded_apps_txt(app, bench_path=bench_path)
 				print("Skipping pull for app {}, since remote doesn't exist, and adding it to excluded apps".format(app))
 				continue
+			branch = get_current_branch(app, bench_path=bench_path)
 			logger.log('pulling {0}'.format(app))
 			if reset:
-				reset_cmd = "git reset --hard {remote}/{branch}".format(
-					remote=remote, branch=get_current_branch(app,bench_path=bench_path))
+				reset_cmd = "git reset --hard {remote}/{branch}".format(remote=remote, branch=branch)
 				if get_config(bench_path).get('shallow_clone'):
-					exec_cmd("git fetch --depth=1 --no-tags", cwd=app_dir)
+					exec_cmd("git fetch --depth=1 --no-tags {remote} {branch}".format(remote=remote, branch=branch),
+						cwd=app_dir)
 					exec_cmd(reset_cmd, cwd=app_dir)
 					exec_cmd("git reflog expire --all", cwd=app_dir)
 					exec_cmd("git gc --prune=all", cwd=app_dir)
@@ -280,7 +281,7 @@ Here are your choices:
 					exec_cmd(reset_cmd, cwd=app_dir)
 			else:
 				exec_cmd("git pull {rebase} {remote} {branch}".format(rebase=rebase,
-					remote=remote, branch=get_current_branch(app, bench_path=bench_path)), cwd=app_dir)
+					remote=remote, branch=branch), cwd=app_dir)
 			exec_cmd('find . -name "*.pyc" -delete', cwd=app_dir)
 
 

--- a/bench/app.py
+++ b/bench/app.py
@@ -268,9 +268,15 @@ Here are your choices:
 				continue
 			logger.log('pulling {0}'.format(app))
 			if reset:
-				exec_cmd("git fetch --all", cwd=app_dir)
-				exec_cmd("git reset --hard {remote}/{branch}".format(
-					remote=remote, branch=get_current_branch(app,bench_path=bench_path)), cwd=app_dir)
+				reset_cmd = "git reset --hard {remote}/{branch}".format(
+					remote=remote, branch=get_current_branch(app,bench_path=bench_path))
+				if get_config(bench_path).get('shallow_clone'):
+					exec_cmd("git fetch --depth 1 --no-tags", cwd=app_dir)
+					exec_cmd(reset_cmd, cwd=app_dir)
+					exec_cmd("git clean -dfx", cwd=app_dir)
+				else:
+					exec_cmd("git fetch --all", cwd=app_dir)
+					exec_cmd(reset_cmd, cwd=app_dir)
 			else:
 				exec_cmd("git pull {rebase} {remote} {branch}".format(rebase=rebase,
 					remote=remote, branch=get_current_branch(app, bench_path=bench_path)), cwd=app_dir)


### PR DESCRIPTION
What type of a PR is this?

- [x] Changes to Existing Features

Saves disk space on production machines

---

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [x] Have you successfully run tests with your changes locally?
- [x] Does your commit message have an explanation for your changes and why you'd like us to include them?

---

> $ bench update --apps frappe --reset --pull
```
remote: Total 0 (delta 0), reused 0 (delta 0), pack-reused 0
From https://github.com/frappe/frappe
 * branch            develop    -> FETCH_HEAD
Backing up sites...
...
$ git fetch --depth=1 --no-tags upstream develop
remote: Total 0 (delta 0), reused 0 (delta 0), pack-reused 0
From https://github.com/frappe/frappe
 * branch            develop    -> FETCH_HEAD
$ git reset --hard upstream/develop
HEAD is now at a342ca2 fix: Get file name from path (#12437)
$ git reflog expire --all
$ git gc --prune=all
Counting objects: 3285, done.
Compressing objects: 100% (2627/2627), done.
Writing objects: 100% (3285/3285), done.
Total 3285 (delta 586), reused 3285 (delta 586)
$ find . -name "*.pyc" -delete

```
