### PR TITLE
feat: use nice with backup cron job

### DIFF
--- a/bench/patches/patches.txt
+++ b/bench/patches/patches.txt
@@ -6,3 +6,4 @@ bench.patches.v4.update_socketio
 bench.patches.v4.install_yarn #2
 bench.patches.v5.fix_user_permissions
 bench.patches.v5.fix_backup_cronjob
+bench.patches.v5.nice_backup_cronjob

--- a/bench/patches/v5/nice_backup_cronjob.py
+++ b/bench/patches/v5/nice_backup_cronjob.py
@@ -1,0 +1,22 @@
+from bench.config.common_site_config import get_config
+from bench.utils import which
+from crontab import CronTab
+
+
+def execute(bench_path):
+	"""
+		This patch gives the backup cron job a lower priority
+	"""
+
+	nice = which("nice")
+	if not nice:
+		return
+
+	user = get_config(bench_path=bench_path).get('frappe_user')
+	user_crontab = CronTab(user=user)
+
+	for job in user_crontab.find_comment("bench auto backups set for every 6 hours"):
+		if nice not in job.command:
+			job.command = job.command.replace("&& ", "&& {} ".format(nice))
+
+		user_crontab.write()

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -401,7 +401,11 @@ def setup_backups(bench_path='.'):
 	if bench.FRAPPE_VERSION == 4:
 		backup_command = "cd {sites_dir} && {frappe} --backup all".format(frappe=get_frappe(bench_path=bench_path),)
 	else:
-		backup_command = "cd {bench_dir} && {bench} --verbose --site all backup".format(bench_dir=bench_dir, bench=sys.argv[0])
+		backup_command = "cd {bench_dir} && {nice} {bench} --verbose --site all backup".format(
+			bench_dir=bench_dir,
+			bench=sys.argv[0],
+			nice = which("nice") or ""
+		)
 
 	job_command = "{backup_command} >> {logfile} 2>&1".format(backup_command=backup_command, logfile=logfile)
 


### PR DESCRIPTION
## Description

Over the time, the size of a site's database is bound to increase. When the backup command is being run in background, it consumes a lot of CPU. To give it a low priority, this PR proposes using `nice`.

**Patch tested locally.**

## Alternate solution

Use `nice` inside implementation of `bench backup` where the actual `dump` executables are being run. This way, it will also get less priority when the `bench backup` command is being run manually.

