### PR TITLE
chore: remove support for older versions of frappe

### DIFF
--- a/bench/app.py
+++ b/bench/app.py
@@ -152,13 +152,7 @@ def new_app(app, bench_path='.'):
 	app = app.lower().replace(" ", "_").replace("-", "_")
 	logger.log('creating new app {}'.format(app))
 	apps = os.path.abspath(os.path.join(bench_path, 'apps'))
-	bench.set_frappe_version(bench_path=bench_path)
-
-	if bench.FRAPPE_VERSION == 4:
-		exec_cmd("{frappe} --make_app {apps} {app}".format(frappe=get_frappe(bench_path=bench_path),
-			apps=apps, app=app))
-	else:
-		run_frappe_cmd('make-app', apps, app, bench_path=bench_path)
+	run_frappe_cmd('make-app', apps, app, bench_path=bench_path)
 	install_app(app, bench_path=bench_path)
 
 

--- a/bench/config/supervisor.py
+++ b/bench/config/supervisor.py
@@ -5,7 +5,7 @@ import os
 
 # imports - module imports
 import bench
-from bench.app import get_current_frappe_version, use_rq
+from bench.app import use_rq
 from bench.utils import get_bench_name, find_executable
 from bench.config.common_site_config import get_config, update_config, get_gunicorn_workers
 
@@ -29,7 +29,6 @@ def generate_supervisor_config(bench_path, user=None, yes=False, skip_redis=Fals
 		"bench_dir": bench_dir,
 		"sites_dir": os.path.join(bench_dir, 'sites'),
 		"user": user,
-		"frappe_version": get_current_frappe_version(bench_path),
 		"use_rq": use_rq(bench_path),
 		"http_timeout": config.get("http_timeout", 120),
 		"redis_server": find_executable('redis-server'),

--- a/bench/config/systemd.py
+++ b/bench/config/systemd.py
@@ -7,7 +7,7 @@ import click
 
 # imports - module imports
 import bench
-from bench.app import get_current_frappe_version, use_rq
+from bench.app import use_rq
 from bench.config.common_site_config import get_config, get_gunicorn_workers, update_config
 from bench.utils import exec_cmd, find_executable, get_bench_name
 
@@ -51,7 +51,6 @@ def generate_systemd_config(bench_path, user=None, yes=False,
 		"bench_dir": bench_dir,
 		"sites_dir": os.path.join(bench_dir, 'sites'),
 		"user": user,
-		"frappe_version": get_current_frappe_version(bench_path),
 		"use_rq": use_rq(bench_path),
 		"http_timeout": config.get("http_timeout", 120),
 		"redis_server": find_executable('redis-server'),

--- a/bench/config/templates/supervisor.conf
+++ b/bench/config/templates/supervisor.conf
@@ -136,7 +136,6 @@ user={{ user }}
 directory={{ sites_dir }}
 {% endif %}
 
-{% if frappe_version > 5 %}
 {% if not skip_redis %}
 [program:{{ bench_name }}-redis-socketio]
 command={{ redis_server }} {{ redis_socketio_config }}
@@ -161,8 +160,6 @@ user={{ user }}
 directory={{ bench_dir }}
 {% endif %}
 
-{% endif %}
-
 [group:{{ bench_name }}-web]
 programs={{ bench_name }}-frappe-web {%- if node -%} ,{{ bench_name }}-node-socketio {%- endif%}
 
@@ -180,5 +177,5 @@ programs={{ bench_name }}-frappe-workerbeat,{{ bench_name }}-frappe-worker,{{ be
 
 {% if not skip_redis %}
 [group:{{ bench_name }}-redis]
-programs={{ bench_name }}-redis-cache,{{ bench_name }}-redis-queue {%- if frappe_version > 5 -%} ,{{ bench_name }}-redis-socketio {%- endif %}
+programs={{ bench_name }}-redis-cache,{{ bench_name }}-redis-queue,{{ bench_name }}-redis-socketio
 {% endif %}


### PR DESCRIPTION
- This PR removes support for versions 5 and lower of the Frappe Framework.
- Additionally removes unused functions and variables.