### PR TITLE
Revert "fix: Use execve and set envvars instead of execv"

### DIFF
--- a/bench/cli.py
+++ b/bench/cli.py
@@ -109,19 +109,19 @@ def change_uid():
 def old_frappe_cli(bench_path='.'):
 	f = get_frappe(bench_path=bench_path)
 	os.chdir(os.path.join(bench_path, 'sites'))
-	os.execve(f, [f] + sys.argv[2:], {})
+	os.execv(f, [f] + sys.argv[2:])
 
 
 def app_cmd(bench_path='.'):
 	f = get_env_cmd('python', bench_path=bench_path)
 	os.chdir(os.path.join(bench_path, 'sites'))
-	os.execve(f, [f] + ['-m', 'frappe.utils.bench_helper'] + sys.argv[1:], {})
+	os.execv(f, [f] + ['-m', 'frappe.utils.bench_helper'] + sys.argv[1:])
 
 
 def frappe_cmd(bench_path='.'):
 	f = get_env_cmd('python', bench_path=bench_path)
 	os.chdir(os.path.join(bench_path, 'sites'))
-	os.execve(f, [f] + ['-m', 'frappe.utils.bench_helper', 'frappe'] + sys.argv[1:], {})
+	os.execv(f, [f] + ['-m', 'frappe.utils.bench_helper', 'frappe'] + sys.argv[1:])
 
 
 def get_frappe_commands():

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -453,15 +453,12 @@ def get_process_manager():
 
 
 def start(no_dev=False, concurrency=None, procfile=None, no_prefix=False):
-	env = os.environ
 	program = get_process_manager()
-
 	if not program:
 		raise Exception("No process manager found")
-
-	env['PYTHONUNBUFFERED'] = "true"
+	os.environ['PYTHONUNBUFFERED'] = "true"
 	if not no_dev:
-		env['DEV_SERVER'] = "true"
+		os.environ['DEV_SERVER'] = "true"
 
 	command = [program, 'start']
 	if concurrency:
@@ -473,7 +470,7 @@ def start(no_dev=False, concurrency=None, procfile=None, no_prefix=False):
 	if no_prefix:
 		command.extend(['--no-prefix'])
 
-	os.execve(program, command, env=env)
+	os.execv(program, command)
 
 
 def get_git_version():


### PR DESCRIPTION
This reverts commit 530a980ef74fd20a9de289284fde16875256b49b.

Related Issue: https://discuss.erpnext.com/t/development-docker-version13-yarn-not-found/74558