### PR TITLE
chore: Remove `set-default-site` command

### DIFF
--- a/bench/commands/__init__.py
+++ b/bench/commands/__init__.py
@@ -35,7 +35,7 @@ bench_command.add_command(switch_to_develop)
 
 
 from bench.commands.utils import (start, restart, set_nginx_port, set_ssl_certificate, set_ssl_certificate_key, set_url_root,
-	set_mariadb_host, set_default_site, download_translations, backup_site, backup_all_sites, release, renew_lets_encrypt,
+	set_mariadb_host, download_translations, backup_site, backup_all_sites, release, renew_lets_encrypt,
 	disable_production, bench_src, prepare_beta_release, set_redis_cache_host, set_redis_queue_host, set_redis_socketio_host, find_benches, migrate_env,
 	generate_command_cache, clear_command_cache)
 bench_command.add_command(start)
@@ -48,7 +48,6 @@ bench_command.add_command(set_mariadb_host)
 bench_command.add_command(set_redis_cache_host)
 bench_command.add_command(set_redis_queue_host)
 bench_command.add_command(set_redis_socketio_host)
-bench_command.add_command(set_default_site)
 bench_command.add_command(download_translations)
 bench_command.add_command(backup_site)
 bench_command.add_command(backup_all_sites)

--- a/bench/commands/utils.py
+++ b/bench/commands/utils.py
@@ -98,12 +98,6 @@ def set_redis_socketio_host(host):
 	set_redis_socketio_host(host)
 
 
-@click.command('set-default-site', help="Set default site for bench")
-@click.argument('site')
-def set_default_site(site):
-	from bench.utils import set_default_site
-	set_default_site(site)
-
 
 @click.command('download-translations', help="Download latest translations")
 def download_translations():

--- a/docs/bench_usage.md
+++ b/docs/bench_usage.md
@@ -101,7 +101,7 @@ These commands belong directly to the bench group so they can be invoked directl
  - **set-redis-cache-host**: Set Redis cache host for bench
  - **set-redis-queue-host**: Set Redis queue host for bench
  - **set-redis-socketio-host**: Set Redis socketio host for bench
- - **set-default-site**: Set default site for bench
+ - **use**: Set default site for bench
  - **download-translations**: Download latest translations
 
 


### PR DESCRIPTION
1. Remove `set-default-site` command. 
2. Update usage docs.

The `set-default-site` no longer works as expected and prints some output like (although `frappe` is installed correctly):

```
frappe app is not installed. Run the following command to install frappe
bench get-app https://github.com/frappe/frappe.git
...
```

`bench use <site-name>` should be used instead.

PR to update Frappe Docs: https://github.com/frappe/frappe_docs/pull/125