### PR TITLE
fix: git unrelated histories

### DIFF
--- a/bench/app.py
+++ b/bench/app.py
@@ -287,7 +287,7 @@ Here are your choices:
 					exec_cmd(reset_cmd, cwd=app_dir)
 			else:
 				exec_cmd("git pull {rebase} {remote} {branch}".format(rebase=rebase,
-					remote=remote, branch=branch), cwd=app_dir)
+					remote=remote, branch=branch), cwd=app_dir, fail_on_non_zero_return=True)
 			exec_cmd('find . -name "*.pyc" -delete', cwd=app_dir)
 
 

--- a/bench/app.py
+++ b/bench/app.py
@@ -277,7 +277,7 @@ Here are your choices:
 			if reset:
 				reset_cmd = "git reset --hard {remote}/{branch}".format(remote=remote, branch=branch)
 				if get_config(bench_path).get('shallow_clone'):
-					exec_cmd("git fetch --depth=1 --no-tags {remote} {branch}".format(remote=remote, branch=branch),
+					exec_cmd("git fetch {remote} {branch}".format(remote=remote, branch=branch),
 						cwd=app_dir)
 					exec_cmd(reset_cmd, cwd=app_dir)
 					exec_cmd("git reflog expire --all", cwd=app_dir)

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -300,14 +300,19 @@ def clone_apps_from(bench_path, clone_from, update_app=True):
 		setup_app(app)
 
 
-def exec_cmd(cmd, cwd='.'):
+def exec_cmd(cmd, cwd='.', fail_on_non_zero_return=False):
 	import shlex
 	print("{0}$ {1}{2}".format(color.silver, cmd, color.nc))
 	cwd_info = "cd {0} && ".format(cwd) if cwd != "." else ""
 	cmd_log = "{0}{1}".format(cwd_info, cmd)
 	logger.debug(cmd_log)
 	cmd = shlex.split(cmd)
-	return_code = subprocess.call(cmd, cwd=cwd, universal_newlines=True)
+
+	if fail_on_non_zero_return:
+		return_code = subprocess.check_call(cmd, cwd=cwd, universal_newlines=True)
+	else:
+		return_code = subprocess.call(cmd, cwd=cwd, universal_newlines=True)
+
 	if return_code:
 		logger.warning("{0} executed with exit code {1}".format(cmd_log, return_code))
 


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. Update necessary Documentation
 4. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/bench/blob/master/docs/contribution_guidelines.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

What type of a PR is this?

- [ ] Changes to Existing Features
- [ ] New Feature Submissions
- [X] Bug Fix
- [ ] Breaking Change (include change in API behaviours, etc.)

---

Problem:

After updating bench to the latest version few users started getting "refusing to merge unrelated histories"

![image](https://user-images.githubusercontent.com/9079960/117617689-8763cd00-b18a-11eb-9a3d-316c2cf9fd69.png)

Root cause:
A recent change to allow keeping repo shallow after the update is fetching with `depth=1`, this will make `FETCH_HEAD` have just 1 latest commit, so git refuses to merge it with a previous full tree.

E.g. if a user does `bench update` it will trigger two git commands:
1. `git fetch --depth=1 upstream branch` (to check version update)
2. `git pull upstream branch`

here `git pull` tries to merge using shallow fetch and fails. 


![image](https://user-images.githubusercontent.com/9079960/117618109-1a046c00-b18b-11eb-913e-fe025aaf9b8a.png)

reference: https://github.com/frappe/bench/pull/1130/files#diff-3722f4ad716221f5c6d162bf82efd37d96c6367678903aba4e51725dd57ee75bR353

Solution:
- Firstly, this should fail the update process and not proceed silently which can have unexpected side effects.
- don't use `depth=1` while fetching branch for checking version check. 