### PR TITLE
fix: Bench update no reset

### DIFF
--- a/bench/app.py
+++ b/bench/app.py
@@ -272,6 +272,14 @@ Here are your choices:
 				add_to_excluded_apps_txt(app, bench_path=bench_path)
 				print("Skipping pull for app {}, since remote doesn't exist, and adding it to excluded apps".format(app))
 				continue
+
+			if not get_config(bench_path).get('shallow_clone') or not reset:
+				is_shallow = os.path.exists(os.path.join(app_dir, ".git", "shallow"))
+				if is_shallow:
+					s = " to safely pull remote changes." if not reset else ""
+					print(f"Unshallowing {app}{s}")
+					exec_cmd(f"git fetch {remote} --unshallow", cwd=app_dir)
+
 			branch = get_current_branch(app, bench_path=bench_path)
 			logger.log('pulling {0}'.format(app))
 			if reset:

--- a/bench/config/common_site_config.py
+++ b/bench/config/common_site_config.py
@@ -8,7 +8,6 @@ import os
 default_config = {
 	'restart_supervisor_on_update': False,
 	'restart_systemd_on_update': False,
-	'auto_update': False,
 	'serve_default_site': True,
 	'rebase_on_pull': False,
 	'frappe_user': getpass.getuser(),

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -221,9 +221,11 @@ def update(pull=False, apps=None, patch=False, build=False, requirements=False, 
 		apps = [app.strip() for app in re.split(",| ", apps) if app]
 
 	if pull:
+		print('Updating apps source...')
 		pull_apps(apps=apps, bench_path=bench_path, reset=reset)
 
 	if requirements:
+		print('Setting up requirements...')
 		update_requirements(bench_path=bench_path)
 		update_node_packages(bench_path=bench_path)
 
@@ -232,6 +234,7 @@ def update(pull=False, apps=None, patch=False, build=False, requirements=False, 
 		patch_sites(bench_path=bench_path)
 
 	if build:
+		print('Building assets...')
 		build_assets(bench_path=bench_path)
 
 	if version_upgrade[0] or (not version_upgrade[0] and force):

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -112,6 +112,16 @@ def get_env_cmd(cmd, bench_path='.'):
 	return os.path.abspath(os.path.join(bench_path, 'env', 'bin', cmd))
 
 
+def pause_exec(seconds=10):
+	from time import sleep
+
+	for i in range(seconds, 0, -1):
+		print(f"Will continue execution in {i} seconds...", end="\r")
+		sleep(1)
+
+	print(" " * 40, end="\r")
+
+
 def init(path, apps_path=None, no_procfile=False, no_backups=False,
 		frappe_path=None, frappe_branch=None, verbose=False, clone_from=None,
 		skip_redis_config_generation=False, clone_without_update=False, ignore_exist=False, skip_assets=False,
@@ -207,6 +217,16 @@ def update(pull=False, apps=None, patch=False, build=False, requirements=False, 
 		else:
 			print("This update will cause a major version change in Frappe/ERPNext from {0} to {1}. \nThis would take significant time to migrate and might break custom apps.".format(*version_upgrade[1:]))
 			click.confirm('Do you want to continue?', abort=True)
+
+	if not reset and conf.get('shallow_clone'):
+		log("""shallow_clone is set in your bench config.
+However without passing the --reset flag, your repositories will be unshallowed.
+To avoid this, cancel this operation and run `bench update --reset`.
+
+Consider the consequences of `git reset --hard` on your apps before you run that.
+To avoid seeing this warning, set shallow_clone to false in your common_site_config.json
+		""", level=3)
+		pause_exec(seconds=10)
 
 	if version_upgrade[0] or (not version_upgrade[0] and force):
 		validate_upgrade(version_upgrade[1], version_upgrade[2], bench_path=bench_path)


### PR DESCRIPTION
Fixes issues faced while updating benches in https://discuss.erpnext.com/t/release-note-erpnext-and-frappe-version-13-2-0/

If an unshallow clone has to be updated, the only way to update it without a reset will require an unshallow. This is because there may be uncommitted or committed changes in any of the apps, although unfavoured should be handled safely. The only way to update such repos is via the user configured settings..or a ff only merge.

# Changes

If `bench update` is run for a bench with `shallow_update: true` set in it's `common_site_config.json`, you'll get the following:

![2021-05-10 16 37 52](https://user-images.githubusercontent.com/36654812/117651083-269abb80-b1af-11eb-8775-1728035c9132.gif)

If `bench update --reset` is run for a bench with `shallow_update: true` set in it's `common_site_config.json`, you'll get the following:

![2021-05-10 16 43 23](https://user-images.githubusercontent.com/36654812/117651068-200c4400-b1af-11eb-913c-20f9dc634089.gif)