### PR TITLE
feat: changed Multiprocessing to Threading to improve speed for i/o tasks

### DIFF
--- a/bench/utils.py
+++ b/bench/utils.py
@@ -822,15 +822,15 @@ def update_translations_p(args):
 
 
 def download_translations_p():
-	import multiprocessing
+	from concurrent.futures import ThreadPoolExecutor
 
-	pool = multiprocessing.Pool(multiprocessing.cpu_count())
+	executor = ThreadPoolExecutor()
 
 	langs = get_langs()
 	apps = ('frappe', 'erpnext')
 	args = list(itertools.product(apps, langs))
 
-	pool.map(update_translations_p, args)
+	executor.map(update_translations_p, args)
 
 
 def download_translations():


### PR DESCRIPTION
Modified function download_translations_p in bench/utils.py to use threading instead of multiprocessing as the given task is I/0 bound and not CPU intensive and it would take longer to spin up a process when compared to using threads.