### PR TITLE
feat: Redis ACL config is added to conf templates

### DIFF
--- a/bench/config/common_site_config.py
+++ b/bench/config/common_site_config.py
@@ -12,7 +12,8 @@ default_config = {
 	'rebase_on_pull': False,
 	'frappe_user': getpass.getuser(),
 	'shallow_clone': True,
-	'background_workers': 1
+	'background_workers': 1,
+	'use_redis_auth': False
 }
 
 def make_config(bench_path):

--- a/bench/config/redis.py
+++ b/bench/config/redis.py
@@ -12,6 +12,7 @@ def generate_config(bench_path):
 	from urllib.parse import urlparse
 
 	config = get_config(bench_path)
+	redis_version = get_redis_version()
 
 	ports = {}
 	for key in ('redis_cache', 'redis_queue', 'redis_socketio'):
@@ -22,6 +23,7 @@ def generate_config(bench_path):
 		context={
 			"port": ports['redis_queue'],
 			"bench_path": os.path.abspath(bench_path),
+			"redis_version": redis_version
 		},
 		bench_path=bench_path
 	)
@@ -30,6 +32,7 @@ def generate_config(bench_path):
 		template_name='redis_socketio.conf',
 		context={
 			"port": ports['redis_socketio'],
+			"redis_version": redis_version
 		},
 		bench_path=bench_path
 	)
@@ -39,7 +42,7 @@ def generate_config(bench_path):
 		context={
 			"maxmemory": config.get('cache_maxmemory', get_max_redis_memory()),
 			"port": ports['redis_cache'],
-			"redis_version": get_redis_version(),
+			"redis_version": redis_version
 		},
 		bench_path=bench_path
 	)
@@ -49,11 +52,26 @@ def generate_config(bench_path):
 	if not os.path.exists(pid_path):
 		os.makedirs(pid_path)
 
+	# ACL feature is introduced in Redis 6.0
+	if redis_version < 6.0:
+		return
+
+	# make ACL files
+	acl_rq_path = os.path.join(bench_path, "config", "redis_queue.acl")
+	acl_redis_cache_path = os.path.join(bench_path, "config", "redis_cache.acl")
+	acl_redis_socketio_path = os.path.join(bench_path, "config", "redis_socketio.acl")
+	open(acl_rq_path, 'a').close()
+	open(acl_redis_cache_path, 'a').close()
+	open(acl_redis_socketio_path, 'a').close()
+
 def write_redis_config(template_name, context, bench_path):
 	template = bench.config.env().get_template(template_name)
 
+	if "config_path" not in context:
+		context["config_path"] = os.path.abspath(os.path.join(bench_path, "config"))
+
 	if "pid_path" not in context:
-		context["pid_path"] = os.path.abspath(os.path.join(bench_path, "config", "pids"))
+		context["pid_path"] = os.path.join(context["config_path"], "pids")
 
 	with open(os.path.join(bench_path, 'config', template_name), 'w') as f:
 		f.write(template.render(**context))

--- a/bench/config/templates/redis_cache.conf
+++ b/bench/config/templates/redis_cache.conf
@@ -9,3 +9,6 @@ appendonly no
 {% if redis_version and redis_version >= 2.2 %}
 save ""
 {% endif %}
+{% if redis_version and redis_version >= 6.0 %}
+aclfile {{ config_path }}/redis_cache.acl
+{% endif %}

--- a/bench/config/templates/redis_queue.conf
+++ b/bench/config/templates/redis_queue.conf
@@ -3,3 +3,6 @@ dir {{ pid_path }}
 pidfile {{ pid_path }}/redis_queue.pid
 bind 127.0.0.1
 port {{ port }}
+{% if redis_version and redis_version >= 6.0 %}
+aclfile {{ config_path }}/redis_queue.acl
+{% endif %}

--- a/bench/config/templates/redis_socketio.conf
+++ b/bench/config/templates/redis_socketio.conf
@@ -3,3 +3,6 @@ dir {{ pid_path }}
 pidfile {{ pid_path }}/redis_socketio.pid
 bind 127.0.0.1
 port {{ port }}
+{% if redis_version and redis_version >= 6.0 %}
+aclfile {{ config_path }}/redis_socketio.acl
+{% endif %}


### PR DESCRIPTION
Redis 6.0 introduced Access control list features that allows certain connections to be limited in terms of the commands that can be executed and the keys that can be accessed. 

Modified  Redis configuration templates to support ACL users in this PR. Along with Redis configuration files, `bench init` generates `redis_queue.acl`, `redis_cache.acl`, `redis_socketio.acl` files if Redis version is 6.0 or above and adds `aclfile` variable to all Redis config files.

What type of a PR is this?
- Changes to Existing Features

