### PR TITLE
feat: `bench setup requirements --dev`

### DIFF
--- a/bench/app.py
+++ b/bench/app.py
@@ -181,12 +181,16 @@ def install_app(app, bench_path=".", verbose=False, no_cache=False, restart_benc
 
 	add_to_appstxt(app, bench_path=bench_path)
 
+	conf = get_config(bench_path=bench_path)
+
+	if conf.get("developer_mode"):
+		from bench.utils import install_python_dev_dependencies
+		install_python_dev_dependencies(apps=app)
+
 	if not skip_assets:
 		build_assets(bench_path=bench_path, app=app)
 
 	if restart_bench:
-		conf = get_config(bench_path=bench_path)
-
 		if conf.get('restart_supervisor_on_update'):
 			restart_supervisor_processes(bench_path=bench_path)
 		if conf.get('restart_systemd_on_update'):

--- a/bench/commands/setup.py
+++ b/bench/commands/setup.py
@@ -135,7 +135,7 @@ def setup_socketio():
 @click.command("requirements", help="Setup Python and Node dependencies")
 @click.option("--node", help="Update only Node packages", default=False, is_flag=True)
 @click.option("--python", help="Update only Python packages", default=False, is_flag=True)
-@click.option("--dev", help="Install optional development dependencies", default=False, is_flag=True)
+@click.option("--dev", help="Install optional python development dependencies", default=False, is_flag=True)
 def setup_requirements(node=False, python=False, dev=False):
 	if not (node or python):
 		from bench.utils import update_requirements
@@ -152,6 +152,9 @@ def setup_requirements(node=False, python=False, dev=False):
 	if dev:
 		from bench.utils import install_python_dev_dependencies
 		install_python_dev_dependencies()
+
+		if node:
+			click.secho("--dev flag only supports python dependencies. All node development dependencies are installed by default.", fg="yellow")
 
 
 @click.command("manager", help="Setup bench-manager.local site with the bench_manager app installed on it")

--- a/bench/commands/setup.py
+++ b/bench/commands/setup.py
@@ -135,7 +135,8 @@ def setup_socketio():
 @click.command("requirements", help="Setup Python and Node dependencies")
 @click.option("--node", help="Update only Node packages", default=False, is_flag=True)
 @click.option("--python", help="Update only Python packages", default=False, is_flag=True)
-def setup_requirements(node=False, python=False):
+@click.option("--dev", help="Install optional development dependencies", default=False, is_flag=True)
+def setup_requirements(node=False, python=False, dev=False):
 	if not (node or python):
 		from bench.utils import update_requirements
 		update_requirements()
@@ -148,10 +149,9 @@ def setup_requirements(node=False, python=False):
 		from bench.utils import update_node_packages
 		update_node_packages()
 
-@click.command("dev-requirements", help="Setup optional development dependencies")
-def setup_dev_requirements():
-	from bench.utils import install_python_dev_dependencies
-	install_python_dev_dependencies()
+	if dev:
+		from bench.utils import install_python_dev_dependencies
+		install_python_dev_dependencies()
 
 
 @click.command("manager", help="Setup bench-manager.local site with the bench_manager app installed on it")
@@ -292,7 +292,6 @@ setup.add_command(setup_env)
 setup.add_command(setup_procfile)
 setup.add_command(setup_socketio)
 setup.add_command(setup_requirements)
-setup.add_command(setup_dev_requirements)
 setup.add_command(setup_manager)
 setup.add_command(setup_config)
 setup.add_command(setup_fonts)

--- a/bench/commands/setup.py
+++ b/bench/commands/setup.py
@@ -148,6 +148,11 @@ def setup_requirements(node=False, python=False):
 		from bench.utils import update_node_packages
 		update_node_packages()
 
+@click.command("dev-requirements", help="Setup optional development dependencies")
+def setup_dev_requirements():
+	from bench.utils import install_python_dev_dependencies
+	install_python_dev_dependencies()
+
 
 @click.command("manager", help="Setup bench-manager.local site with the bench_manager app installed on it")
 @click.option("--yes", help="Yes to regeneration of nginx config file", default=False, is_flag=True)
@@ -287,6 +292,7 @@ setup.add_command(setup_env)
 setup.add_command(setup_procfile)
 setup.add_command(setup_socketio)
 setup.add_command(setup_requirements)
+setup.add_command(setup_dev_requirements)
 setup.add_command(setup_manager)
 setup.add_command(setup_config)
 setup.add_command(setup_fonts)

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -631,7 +631,7 @@ def install_python_dev_dependencies(bench_path='.', apps=None):
 		dev_requirements_path = os.path.join(app_path, "dev-requirements.txt")
 
 		if os.path.exists(dev_requirements_path):
-			log(f'Installing development dependencies for {app}')
+			log(f'Installing python development dependencies for {app}')
 			exec_cmd(f"{env_py} -m pip install -q -r {dev_requirements_path}", cwd=bench_path)
 		else:
 			log(f'dev-requirements.txt not found in {app}', level=3)

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -617,13 +617,16 @@ def update_node_packages(bench_path='.'):
 		update_yarn_packages(bench_path)
 
 
-def install_python_dev_dependencies(bench_path='.'):
+def install_python_dev_dependencies(bench_path='.', apps=None):
 	from bench.app import get_apps
 
-	log("Installing development dependencies")
+	if isinstance(apps, str):
+		apps = [apps]
+	elif apps is None:
+		apps = get_apps()
 
 	env_py = get_env_cmd("python")
-	for app in get_apps():
+	for app in apps:
 		app_path = os.path.join(bench_path, "apps", app)
 		dev_requirements_path = os.path.join(app_path, "dev-requirements.txt")
 

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -577,7 +577,7 @@ def set_default_site(site, bench_path='.'):
 
 
 def update_env_pip(bench_path):
-	env_py = os.path.join(bench_path, 'env', 'bin', 'python')
+	env_py = _get_venv_python(bench_path)
 	exec_cmd(f"{env_py} -m pip install -q -U pip")
 
 
@@ -593,7 +593,7 @@ def update_requirements(bench_path='.'):
 
 def update_python_packages(bench_path='.'):
 	from bench.app import get_apps
-	env_py = os.path.join(bench_path, "env", "bin", "python")
+	env_py = _get_venv_python(bench_path)
 	print('Updating Python libraries...')
 
 	update_env_pip(bench_path)
@@ -616,6 +616,26 @@ def update_node_packages(bench_path='.'):
 	else:
 		update_yarn_packages(bench_path)
 
+
+def install_python_dev_dependencies(bench_path='.'):
+	from bench.app import get_apps
+
+	print("Installing development dependencies")
+
+	env_py = _get_venv_python(bench_path)
+	for app in get_apps():
+		app_path = os.path.join(bench_path, "apps", app)
+		dev_requirements_path = os.path.join(app_path, "dev-requirements.txt")
+
+		if os.path.exists(dev_requirements_path):
+			print(f'\n{color.yellow}Installing development dependencies for {app}{color.nc}')
+			exec_cmd(f"{env_py} -m pip install -q -r {dev_requirements_path}", cwd=bench_path)
+		else:
+			print(f'\n{color.red} dev-requirements.txt not found in {app}{color.nc}')
+
+
+def _get_venv_python(bench_path="."):
+	return os.path.join(bench_path, "env", "bin", "python")
 
 def update_yarn_packages(bench_path='.'):
 	apps_dir = os.path.join(bench_path, 'apps')

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -577,7 +577,7 @@ def set_default_site(site, bench_path='.'):
 
 
 def update_env_pip(bench_path):
-	env_py = _get_venv_python(bench_path)
+	env_py = get_env_cmd("python")
 	exec_cmd(f"{env_py} -m pip install -q -U pip")
 
 
@@ -593,7 +593,7 @@ def update_requirements(bench_path='.'):
 
 def update_python_packages(bench_path='.'):
 	from bench.app import get_apps
-	env_py = _get_venv_python(bench_path)
+	env_py = get_env_cmd("python")
 	print('Updating Python libraries...')
 
 	update_env_pip(bench_path)
@@ -622,7 +622,7 @@ def install_python_dev_dependencies(bench_path='.'):
 
 	print("Installing development dependencies")
 
-	env_py = _get_venv_python(bench_path)
+	env_py = get_env_cmd("python")
 	for app in get_apps():
 		app_path = os.path.join(bench_path, "apps", app)
 		dev_requirements_path = os.path.join(app_path, "dev-requirements.txt")
@@ -633,9 +633,6 @@ def install_python_dev_dependencies(bench_path='.'):
 		else:
 			print(f'\n{color.red} dev-requirements.txt not found in {app}{color.nc}')
 
-
-def _get_venv_python(bench_path="."):
-	return os.path.join(bench_path, "env", "bin", "python")
 
 def update_yarn_packages(bench_path='.'):
 	apps_dir = os.path.join(bench_path, 'apps')

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -620,7 +620,7 @@ def update_node_packages(bench_path='.'):
 def install_python_dev_dependencies(bench_path='.'):
 	from bench.app import get_apps
 
-	print("Installing development dependencies")
+	log("Installing development dependencies")
 
 	env_py = get_env_cmd("python")
 	for app in get_apps():
@@ -628,10 +628,10 @@ def install_python_dev_dependencies(bench_path='.'):
 		dev_requirements_path = os.path.join(app_path, "dev-requirements.txt")
 
 		if os.path.exists(dev_requirements_path):
-			print(f'\n{color.yellow}Installing development dependencies for {app}{color.nc}')
+			log(f'Installing development dependencies for {app}')
 			exec_cmd(f"{env_py} -m pip install -q -r {dev_requirements_path}", cwd=bench_path)
 		else:
-			print(f'\n{color.red} dev-requirements.txt not found in {app}{color.nc}')
+			log(f'dev-requirements.txt not found in {app}', level=3)
 
 
 def update_yarn_packages(bench_path='.'):

--- a/docs/bench_custom_cmd.md
+++ b/docs/bench_custom_cmd.md
@@ -7,7 +7,7 @@ bench utilizes `frappe.utils.bench_manager` to get the framework's as well as th
 
 Along with the framework commands, Frappe's `bench_manager` module also searches for any commands in your custom applications. Thereby, bench communicates with the respective bench's Frappe which in turn checks for available commands in all of the applications.
 
-To make your custom command available to bench, just create a `commands` module under your parent module and write the command with a click wrapper and a variable commands which contains a list of click functions, which are your own commands. The directory strcuture may be visualized as:
+To make your custom command available to bench, just create a `commands` module under your parent module and write the command with a click wrapper and a variable commands which contains a list of click functions, which are your own commands. The directory structure may be visualized as:
 
 ```
 frappe-bench

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('requirements.txt') as f:
 
 setup(
 	name=PROJECT_NAME,
-	description='Metadata driven, full-stack web framework',
+	description='CLI to manage Multi-tenant deployments for Frappe apps',
 	author='Frappe Technologies',
 	author_email='info@frappe.io',
 	version=VERSION,


### PR DESCRIPTION
Often applications have development or test specific requirements which are not required in production.

Changes:
- Add new flag `bench setup requirements --dev`
- installs all `dev-requirements.txt` in root folder of apps.
- While doing `bench get-app` if dev mode is enabled in common_site_config then dev requirements are also installed. 


Documentation: https://github.com/frappe/frappe_docs/pull/196