### PR TITLE
Allow git url with custom username

### DIFF
--- a/bench/app.py
+++ b/bench/app.py
@@ -53,7 +53,7 @@ def write_appstxt(apps, bench_path='.'):
 
 def is_git_url(url):
 	# modified to allow without the tailing .git from https://github.com/jonschlinkert/is-git-url.git
-	pattern = r"(?:git|ssh|https?|git@[-\w.]+):(\/\/)?(.*?)(\.git)?(\/?|\#[-\d\w._]+?)$"
+	pattern = r"(?:git|ssh|https?|\w*@[-\w.]+):(\/\/)?(.*?)(\.git)?(\/?|\#[-\d\w._]+?)$"
 	return bool(re.match(pattern, url))
 
 def get_excluded_apps(bench_path='.'):


### PR DESCRIPTION
Allow git url with custom user, and not just the git user.

What type of a PR is this?

- [ ] Changes to Existing Features
- [ ] New Feature Submissions
- [x] Bug Fix
- [ ] Breaking Change (include change in API behaviours, etc.)

---

> Please provide enough information so that others can review your pull request:

This fixes bench to work with git repository from azure devops with the following url address
git clone git@ssh.dev.azure.com:v3/fabrikam-fiber/FabrikamFiber/FabrikamFiber

You can see this example in the official doc here
https://docs.microsoft.com/en-us/azure/devops/repos/git/use-ssh-keys-to-authenticate?view=azure-devops

This is allowed, because git clone not not support just git@host but any username.
section taken from the manual : https://man.archlinux.org/man/extra/git/git-clone.1.en

```
The ssh and git protocols additionally support ~username expansion:
•ssh://[user@]host.xz[:port]/~[user]/path/to/repo.git/
•git://host.xz[:port]/~[user]/path/to/repo.git/
•[user@]host.xz:/~[user]/path/to/repo.git/
```

I haven't verified in details which character are allowed and which are not, but I suppose [a-zA-Z] should be good enough for now. 

---

> Explain the **details** for making this change. What existing problem does the pull request solve? The following checklist could help

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [ ] Have you lint your code locally prior to submission?
- [ ] Have you successfully run tests with your changes locally?
- [ x ] Does your commit message have an explanation for your changes and why you'd like us to include them?
- [ ] Docs have been added / updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Did you modify the existing test cases? If yes, why?

No tests exists for this feature, so I did not add any new. 
---
