### PR TITLE
feat: add `live_reload` to default `common_site_config`

### DIFF
--- a/bench/config/common_site_config.py
+++ b/bench/config/common_site_config.py
@@ -13,7 +13,8 @@ default_config = {
 	'frappe_user': getpass.getuser(),
 	'shallow_clone': True,
 	'background_workers': 1,
-	'use_redis_auth': False
+	'use_redis_auth': False,
+	'live_reload': True
 }
 
 def make_config(bench_path):

--- a/bench/patches/patches.txt
+++ b/bench/patches/patches.txt
@@ -6,3 +6,4 @@ bench.patches.v4.update_socketio
 bench.patches.v4.install_yarn #2
 bench.patches.v5.fix_user_permissions
 bench.patches.v5.fix_backup_cronjob
+bench.patches.v5.set_live_reload_config

--- a/bench/patches/v5/set_live_reload_config.py
+++ b/bench/patches/v5/set_live_reload_config.py
@@ -1,0 +1,5 @@
+from bench.config.common_site_config import update_config
+
+
+def execute(bench_path):
+	update_config({'live_reload': True}, bench_path)

--- a/patches.txt
+++ b/patches.txt
@@ -1,1 +1,0 @@
-bench.patches.v3.deprecate_old_config

--- a/patches.txt
+++ b/patches.txt
@@ -1,1 +1,2 @@
 bench.patches.v3.deprecate_old_config
+bench.patches.v5.set_live_reload_config

--- a/patches.txt
+++ b/patches.txt
@@ -1,2 +1,1 @@
 bench.patches.v3.deprecate_old_config
-bench.patches.v5.set_live_reload_config


### PR DESCRIPTION
## Changes Made
 - add `live_reload` to default_config
 - add patch to set `live_reload` for existing bench instances

---
**Related PR:** https://github.com/frappe/frappe/pull/14238