### PR TITLE
chore: change the default version to 13 of erpnext and frappe when installing using easyinstall

### DIFF
--- a/install.py
+++ b/install.py
@@ -251,16 +251,13 @@ def install_bench(args):
 	if args.production:
 		extra_vars.update(max_worker_connections=multiprocessing.cpu_count() * 1024)
 
-	frappe_branch = 'version-13'
-	erpnext_branch = 'version-13'
+	if args.version <= 10:
+		frappe_branch = "{0}.x.x".format(args.version)
+		erpnext_branch = "{0}.x.x".format(args.version)
+	else:
+		frappe_branch = "version-{0}".format(args.version)
+		erpnext_branch = "version-{0}".format(args.version)
 
-	if args.version:
-		if args.version <= 10:
-			frappe_branch = "{0}.x.x".format(args.version)
-			erpnext_branch = "{0}.x.x".format(args.version)
-		else:
-			frappe_branch = "version-{0}".format(args.version)
-			erpnext_branch = "version-{0}".format(args.version)
 	# Allow override of frappe_branch and erpnext_branch, regardless of args.version (which always has a default set)
 	if args.frappe_branch:
 		frappe_branch = args.frappe_branch
@@ -445,7 +442,7 @@ def parse_commandline_args():
 	parser.add_argument('--erpnext-branch', dest='erpnext_branch', action='store', help='Clone a particular branch of erpnext')
 	parser.add_argument('--without-erpnext', dest='without_erpnext', action='store_true', default=False, help='Prevent fetching ERPNext')
 	# direct provision to install versions
-	parser.add_argument('--version', dest='version', action='store', default='12', type=int, help='Clone particular version of frappe and erpnext')
+	parser.add_argument('--version', dest='version', action='store', default=13, type=int, help='Clone particular version of frappe and erpnext')
 	# To enable testing of script using Travis, this should skip the prompt
 	parser.add_argument('--run-travis', dest='run_travis', action='store_true', default=False, help=argparse.SUPPRESS)
 	parser.add_argument('--without-bench-setup', dest='without_bench_setup', action='store_true', default=False, help=argparse.SUPPRESS)


### PR DESCRIPTION
In a meet with @abhishekbalam - we got confused and figured out why easyinstall was installing frappe/erpnext v12 by default

This pr bumps the default version of frappe & erpnext to 13 when installing via easyinstall script

PS: I haven't tested this as i don't have ansible installed on my local machine
PPS: we should come up with some other way I think - as more versions get released we'll have to do this everytime to keep up with the releases [or maybe we can mention it in readme and/or [docs](https://frappeframework.com/docs/v13/user/en/production-setup) about the `--version` argument?]