### PR TITLE
refactor: bench restart

### DIFF
--- a/bench/app.py
+++ b/bench/app.py
@@ -26,10 +26,7 @@ from bench.utils import (
 )
 from bench.utils.bench import (
 	build_assets,
-	get_env_cmd,
 	install_python_dev_dependencies,
-	restart_supervisor_processes,
-	restart_systemd_processes,
 )
 from bench.utils.render import step
 
@@ -417,10 +414,7 @@ def install_app(
 		build_assets(bench_path=bench_path, app=app)
 
 	if restart_bench:
-		if conf.get("restart_supervisor_on_update"):
-			restart_supervisor_processes(bench_path=bench_path)
-		if conf.get("restart_systemd_on_update"):
-			restart_systemd_processes(bench_path=bench_path)
+		bench.reload()
 
 
 def pull_apps(apps=None, bench_path=".", reset=False):

--- a/bench/bench.py
+++ b/bench/bench.py
@@ -131,14 +131,18 @@ class Bench(Base, Validator):
 		run_frappe_cmd("build", bench_path=self.name)
 
 	@step(title="Reloading Bench Processes", success="Bench Processes Reloaded")
-	def reload(self):
+	def reload(self, web=False, supervisor=True, systemd=True):
+		"""If web is True, only web workers are restarted
+		"""
 		conf = self.conf
-		if conf.get("restart_supervisor_on_update"):
-			restart_supervisor_processes(bench_path=self.name)
-		if conf.get("restart_systemd_on_update"):
-			restart_systemd_processes(bench_path=self.name)
+
 		if conf.get("developer_mode"):
-			restart_process_manager(bench_path=self.name)
+			restart_process_manager(bench_path=self.name, web_workers=web)
+		if supervisor and conf.get("restart_supervisor_on_update"):
+			restart_supervisor_processes(bench_path=self.name, web_workers=web)
+		if systemd and conf.get("restart_systemd_on_update"):
+			restart_systemd_processes(bench_path=self.name, web_workers=web)
+
 
 class BenchApps(MutableSequence):
 	def __init__(self, bench: Bench):

--- a/bench/cli.py
+++ b/bench/cli.py
@@ -51,6 +51,7 @@ def cli():
 	change_working_directory()
 	logger = setup_logging()
 	logger.info(command)
+	setup_clear_cache()
 
 	bench_config = get_config(".")
 
@@ -216,3 +217,14 @@ def change_working_directory():
 
 	if bench_path:
 		os.chdir(bench_path)
+
+
+def setup_clear_cache():
+	from copy import copy
+	f = copy(os.chdir)
+
+	def _chdir(*args, **kwargs):
+		Bench.cache_clear()
+		return f(*args, **kwargs)
+
+	os.chdir = _chdir

--- a/bench/commands/utils.py
+++ b/bench/commands/utils.py
@@ -23,14 +23,7 @@ def start(no_dev, concurrency, procfile, no_prefix, man):
 @click.option('--systemd', is_flag=True, default=False)
 def restart(web, supervisor, systemd):
 	from bench.bench import Bench
-	from bench.utils.bench import restart_supervisor_processes, restart_systemd_processes
-
-	bench = Bench(".")
-
-	if bench.conf.get('restart_supervisor_on_update') or supervisor:
-		restart_supervisor_processes(bench_path='.', web_workers=web)
-	if bench.conf.get('restart_systemd_on_update') or systemd:
-		restart_systemd_processes(bench_path='.', web_workers=web)
+	Bench(".").reload(web, supervisor, systemd)
 
 
 @click.command('set-nginx-port', help="Set NGINX port for site")


### PR DESCRIPTION
This PR introduces the option to make `bench restart` functional for development benches. Also, clears Bench memoized dict on every `os.chdir`.