### PR TITLE
fix: process SSH git URLs

### DIFF
--- a/bench/app.py
+++ b/bench/app.py
@@ -84,6 +84,8 @@ class AppMeta:
 
 		# fetch meta for repo from remote git server - traditional get-app url
 		elif is_git_url(self.name):
+			if self.name.startswith("git@") or self.name.startswith("ssh://"):
+				self.use_ssh = True
 			self._setup_details_from_git_url()
 
 		# fetch meta from new styled name tags & first party apps on github


### PR DESCRIPTION
Trying to run the following command: `bench get-app git@github.com:org/repo.git` would result in the URL being transformed to `https://github.com/git@github.com:org/repo.git`, which errors out and `get-app` fails.

**Alternatives:**
This isn't the best way to handle this, and we could use something like [giturlparse](https://github.com/nephila/giturlparse). But I didn't want to add a dependency right now without getting some feedback.