### PR TITLE
fix: get-app command should be able to clone from any git server

### DIFF
--- a/bench/app.py
+++ b/bench/app.py
@@ -19,10 +19,10 @@ from bench.exceptions import NotInBenchDirectoryError
 from bench.utils import (
 	fetch_details_from_partial_url,
 	get_available_folder_name,
+	get_parsed_giturl,
 	is_bench_directory,
 	log,
-	parse_git_url,
-	run_frappe_cmd,
+	run_frappe_cmd
 )
 from bench.utils.bench import (
 	build_assets,
@@ -76,7 +76,7 @@ class AppMeta:
 		self.setup_details()
 
 	def setup_details(self):
-		parsed_git_obj = parse_git_url(self.name)
+		parsed_git_obj = get_parsed_giturl(self.name)
 
 		# fetch meta from installed apps
 		if (

--- a/bench/app.py
+++ b/bench/app.py
@@ -45,8 +45,9 @@ class AppMeta:
 			1. https://github.com/frappe/healthcare.git
 			2. git@github.com:frappe/healthcare.git
 			3. frappe/healthcare@develop
-			4. healthcare
-			5. healthcare@develop, healthcare@v13.12.1
+			4. frappe/healthcare
+			5. healthcare
+			6. healthcare@develop, healthcare@v13.12.1
 
 		References for Version Identifiers:
 		 * https://www.python.org/dev/peps/pep-0440/#version-specifiers
@@ -67,16 +68,10 @@ class AppMeta:
 		self.setup_details()
 
 	def setup_details(self):
-
-		# fetch meta for repo from git url - traditional get-app url
 		parsed_git_obj = parse_git_url(self.name)
-		if parsed_git_obj:
-			self.tag = self.branch
-			self.org = parsed_git_obj.owner
-			self.repo = parsed_git_obj.name
 
 		# fetch meta from installed apps
-		elif (
+		if (
 			not self.to_clone
 			and hasattr(self, "bench")
 			and os.path.exists(os.path.join(self.bench.name, "apps", self.name))
@@ -88,6 +83,13 @@ class AppMeta:
 		elif os.path.exists(self.name):
 			self.on_disk = True
 			self._setup_details_from_mounted_disk()
+
+		# fetch meta for repo from git url - traditional get-app url
+		# NOTE: Adding a check for owner here for making `organisation/repoository` format work
+		elif parsed_git_obj and parsed_git_obj.owner:
+			self.tag = self.branch
+			self.org = parsed_git_obj.owner
+			self.repo = parsed_git_obj.name
 
 		# fetch meta from new styled name tags & first party apps on github
 		else:

--- a/bench/commands/make.py
+++ b/bench/commands/make.py
@@ -133,8 +133,24 @@ def drop(path):
 @click.option(
 	"--init-bench", is_flag=True, default=False, help="Initialize Bench if not in one"
 )
+@click.option(
+	"--use-ssh", is_flag=True, default=False, help="Use SSH for cloning (to be used with partial url format)"
+)
+@click.option(
+	"--git-host",
+	type=click.Choice(["github", "gitlab"], case_sensitive=False),
+	default="github",
+	help="Remote git host from where to fetch the app (to be used with partial url format)"
+)
 def get_app(
-	git_url, branch, name=None, overwrite=False, skip_assets=False, init_bench=False
+	git_url,
+	branch,
+	name=None,
+	git_host=None,
+	overwrite=False,
+	skip_assets=False,
+	init_bench=False,
+	use_ssh=False,
 ):
 	"clone an app from the internet and set it up in your bench"
 	from bench.app import get_app
@@ -145,6 +161,8 @@ def get_app(
 		skip_assets=skip_assets,
 		overwrite=overwrite,
 		init_bench=init_bench,
+		git_host=git_host,
+		use_ssh=use_ssh
 	)
 
 

--- a/bench/commands/make.py
+++ b/bench/commands/make.py
@@ -136,17 +136,10 @@ def drop(path):
 @click.option(
 	"--use-ssh", is_flag=True, default=False, help="Use SSH for cloning (to be used with partial url format)"
 )
-@click.option(
-	"--git-host",
-	type=click.Choice(["github", "gitlab"], case_sensitive=False),
-	default="github",
-	help="Remote git host from where to fetch the app (to be used with partial url format)"
-)
 def get_app(
 	git_url,
 	branch,
 	name=None,
-	git_host=None,
 	overwrite=False,
 	skip_assets=False,
 	init_bench=False,
@@ -161,7 +154,6 @@ def get_app(
 		skip_assets=skip_assets,
 		overwrite=overwrite,
 		init_bench=init_bench,
-		git_host=git_host,
 		use_ssh=use_ssh
 	)
 

--- a/bench/utils/__init__.py
+++ b/bench/utils/__init__.py
@@ -405,7 +405,16 @@ def fetch_details_from_partial_url(partial_url: str) -> Tuple[str, str, str]:
 	if not partial_url:
 		raise Exception("Partial url is not provided")
 
-	app_tag = partial_url.split("@")
+	splitted_partial_url = partial_url.split(":")
+	git_host = splitted_partial_url[0]
+
+	try:
+		app_tag = splitted_partial_url[1].split("@")
+	except IndexError:
+		# githost is not available in partial url
+		app_tag = git_host.split("@")
+		git_host = "github"
+
 	org_repo = app_tag[0].split("/")
 
 	try:
@@ -416,9 +425,12 @@ def fetch_details_from_partial_url(partial_url: str) -> Tuple[str, str, str]:
 	try:
 		org, repo = org_repo
 	except Exception:
-		org, repo = find_org(org_repo)
+		if git_host == "github":
+			org, repo = find_org(org_repo)
+		else:
+			raise Exception("Git Host provided is Invalid")
 
-	return org, repo, tag
+	return git_host, org, repo, tag
 
 
 def parse_git_url(url: str):

--- a/bench/utils/__init__.py
+++ b/bench/utils/__init__.py
@@ -11,6 +11,7 @@ from typing import List, Tuple
 
 # imports - third party imports
 import click
+import giturlparse
 
 # imports - module imports
 from bench import PROJECT_NAME, VERSION
@@ -420,10 +421,14 @@ def fetch_details_from_tag(_tag: str) -> Tuple[str, str, str]:
 	return org, repo, tag
 
 
-def is_git_url(url: str) -> bool:
-	# modified to allow without the tailing .git from https://github.com/jonschlinkert/is-git-url.git
-	pattern = r"(?:git|ssh|https?|\w*@[-\w.]+):(\/\/)?(.*?)(\.git)?(\/?|\#[-\d\w._]+?)$"
-	return bool(re.match(pattern, url))
+def parse_git_url(url: str):
+	try:
+		parsed_obj = giturlparse.parse(url)
+	except Exception:
+		# the git url is not parsable
+		return False
+
+	return parsed_obj
 
 
 def drop_privileges(uid_name="nobody", gid_name="nogroup"):

--- a/bench/utils/__init__.py
+++ b/bench/utils/__init__.py
@@ -433,12 +433,12 @@ def fetch_details_from_partial_url(partial_url: str) -> Tuple[str, str, str]:
 	return git_host, org, repo, tag
 
 
-def parse_git_url(url: str):
+def get_parsed_giturl(url: str):
 	try:
 		parsed_obj = giturlparse.parse(url)
 	except Exception:
 		# the git url is not parsable
-		return False
+		return None
 
 	return parsed_obj
 

--- a/bench/utils/__init__.py
+++ b/bench/utils/__init__.py
@@ -401,11 +401,11 @@ def find_org(org_repo):
 	raise InvalidRemoteException
 
 
-def fetch_details_from_tag(_tag: str) -> Tuple[str, str, str]:
-	if not _tag:
-		raise Exception("Tag is not provided")
+def fetch_details_from_partial_url(partial_url: str) -> Tuple[str, str, str]:
+	if not partial_url:
+		raise Exception("Partial url is not provided")
 
-	app_tag = _tag.split("@")
+	app_tag = partial_url.split("@")
 	org_repo = app_tag[0].split("/")
 
 	try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 Click
 GitPython~=2.1.15
+git-url-parse~=1.2.2
 honcho
 Jinja2~=2.11.3
 python-crontab~=2.4.0


### PR DESCRIPTION
Currently the git remote server is hardcoded to `github.com`.

Changes:
- get-app command now has 2 new options `--git-host` (for providing from which git host to get the app from - currently only supported for gitlab and github[default]) and `--use-ssh` - both of these options are to be used with partial url format (previously name tag format) i.e `org/repo@branch` or `org/repo` or `repo@branch` or just `repo` (the last 2 being for apps under frappe/erpnext org) 
- support for `org/repo` format in get-app (rest all partial url formats were already there)
- fix for get-app not being able to get app from anywhere but github - if the url provided is valid, we just use it as is for cloning
- added a new dependency [`git-url-parse`](https://github.com/coala/git-url-parse) - which we also use in frappe

closes: https://github.com/frappe/bench/issues/1228

![Screenshot 2021-12-08 at 8 01 26 PM](https://user-images.githubusercontent.com/32034600/145226086-39337180-cd05-4037-876d-1e8be4a74f7a.png)

![Screenshot 2021-12-10 at 2 49 55 PM](https://user-images.githubusercontent.com/32034600/145564767-486b92df-3e79-4b03-a0b0-78b95785e6a5.png)

![Screenshot 2021-12-10 at 2 49 03 PM](https://user-images.githubusercontent.com/32034600/145565993-4eba63b8-265c-414f-a0d6-5806d64601f0.png)

![Screenshot 2021-12-10 at 4 43 37 PM](https://user-images.githubusercontent.com/32034600/145566019-82606c4f-e1bb-47a6-85c7-fbf21775b0fd.png)

![Screenshot 2021-12-10 at 5 02 02 PM](https://user-images.githubusercontent.com/32034600/145567878-5e1ab9ad-458c-4eab-a285-3075b6bfc2b1.png)

