### PR TITLE
fix: PosixPath object has no attribute 'rstrip'

### DIFF
--- a/bench/patches/v5/update_archived_sites.py
+++ b/bench/patches/v5/update_archived_sites.py
@@ -40,7 +40,7 @@ def execute(bench_path):
 		os.makedirs(new_directory)
 
 	for archived_site_path in old_directory.glob("*"):
-		shutil.move(str(archived_site_path), str(new_directory))
+		archived_site_path.rename(new_directory)
 
 	click.secho(f"Archived sites are now stored under {new_directory}")
 

--- a/bench/patches/v5/update_archived_sites.py
+++ b/bench/patches/v5/update_archived_sites.py
@@ -9,7 +9,6 @@ patch and try again later.
 Corresponding changes in frappe/frappe via https://github.com/frappe/frappe/pull/15060
 """
 import os
-import shutil
 from pathlib import Path
 
 import click

--- a/bench/patches/v5/update_archived_sites.py
+++ b/bench/patches/v5/update_archived_sites.py
@@ -40,7 +40,7 @@ def execute(bench_path):
 		os.makedirs(new_directory)
 
 	for archived_site_path in old_directory.glob("*"):
-		shutil.move(archived_site_path, new_directory)
+		shutil.move(str(archived_site_path), str(new_directory))
 
 	click.secho(f"Archived sites are now stored under {new_directory}")
 


### PR DESCRIPTION
~Convert paths to strings before passing them to `shutil.move()`.~
Drop `shutil` and use `Path.rename` instead.
Closes #1234

