### PR TITLE
fix: remove patches.txt as identifier for frappe app

### DIFF
--- a/bench/utils/__init__.py
+++ b/bench/utils/__init__.py
@@ -20,7 +20,7 @@ from bench.exceptions import CommandFailedError, InvalidRemoteException, Validat
 
 logger = logging.getLogger(PROJECT_NAME)
 bench_cache_file = ".bench.cmd"
-paths_in_app = ("hooks.py", "modules.txt", "patches.txt")
+paths_in_app = ("hooks.py", "modules.txt")
 paths_in_bench = ("apps", "sites", "config", "logs", "config/pids")
 sudoers_file = "/etc/sudoers.d/frappe"
 


### PR DESCRIPTION
patches.txt will likely be removed in future https://github.com/frappe/frappe/pull/15351

In meantime, it's best to not consider this as an identifier for frappe app directory.