### PR TITLE
ci: use frappe13 in py 3.7

### DIFF
--- a/bench/tests/test_base.py
+++ b/bench/tests/test_base.py
@@ -14,10 +14,14 @@ from bench.utils import paths_in_bench, exec_cmd
 from bench.utils.system import init
 from bench.bench import Bench
 
-if sys.version_info.major == 2:
-	FRAPPE_BRANCH = "version-12"
-else:
-	FRAPPE_BRANCH = "develop"
+PYTHON_VER = sys.version_info
+
+FRAPPE_BRANCH = "version-12"
+if PYTHON_VER.major == 3:
+	if PYTHON_VER.minor in [6, 7]:
+		FRAPPE_BRANCH = "version-13"
+	else:
+		FRAPPE_BRANCH = "develop"
 
 class TestBenchBase(unittest.TestCase):
 	def setUp(self):

--- a/bench/tests/test_init.py
+++ b/bench/tests/test_init.py
@@ -151,15 +151,21 @@ class TestBenchInit(TestBenchBase):
 		bench_path = os.path.join(self.benches_path, "test-bench")
 		app_path = os.path.join(bench_path, "apps", "frappe")
 
-		successful_switch = not exec_cmd("bench switch-to-branch version-13 frappe --upgrade", cwd=bench_path)
+		# * chore: change to 14 when avalible
+		prevoius_branch = "version-13"
+		if FRAPPE_BRANCH != "develop":
+			# assuming we follow `version-#`
+			prevoius_branch = f"version-{int(FRAPPE_BRANCH.split('-')[1]) - 1}"
+
+		successful_switch = not exec_cmd(f"bench switch-to-branch {prevoius_branch} frappe --upgrade", cwd=bench_path)
 		app_branch_after_switch = str(git.Repo(path=app_path).active_branch)
 		if successful_switch:
-			self.assertEqual("version-13", app_branch_after_switch)
+			self.assertEqual(prevoius_branch, app_branch_after_switch)
 
-		successful_switch = not exec_cmd("bench switch-to-branch develop frappe --upgrade", cwd=bench_path)
+		successful_switch = not exec_cmd(f"bench switch-to-branch {FRAPPE_BRANCH} frappe --upgrade", cwd=bench_path)
 		app_branch_after_second_switch = str(git.Repo(path=app_path).active_branch)
 		if successful_switch:
-			self.assertEqual("develop", app_branch_after_second_switch)
+			self.assertEqual(FRAPPE_BRANCH, app_branch_after_second_switch)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# Changes
- Modify bench tests to get the correct version of frappe depending on the version of python
- Change `test_switch_to_branch()` to switch to a lower branch (in test) than the current one instead of defaulting to v13

As develop requires python >=3.8 now (https://github.com/frappe/frappe/commit/3d474b592721fac37bb06ce4a520a65fa828f9bb)