### PR TITLE
feat: Setup Requirements for specific apps

### DIFF
--- a/bench/app.py
+++ b/bench/app.py
@@ -173,7 +173,7 @@ class App(AppMeta):
 		shutil.move(active_app_path, archived_app_path)
 
 	@step(title="Installing App {repo}", success="App {repo} Installed")
-	def install(self, skip_assets=False, verbose=False):
+	def install(self, skip_assets=False, verbose=False, restart_bench=True):
 		import bench.cli
 		from bench.utils.app import get_app_name
 
@@ -190,7 +190,11 @@ class App(AppMeta):
 		)
 
 		install_app(
-			app=app_name, bench_path=self.bench.name, verbose=verbose, skip_assets=skip_assets,
+			app=app_name,
+			bench_path=self.bench.name,
+			verbose=verbose,
+			skip_assets=skip_assets,
+			restart_bench=restart_bench
 		)
 
 	@step(title="Uninstalling App {repo}", success="App {repo} Uninstalled")

--- a/bench/bench.py
+++ b/bench/bench.py
@@ -339,7 +339,7 @@ class BenchSetup(Base):
 		print(f"Installing {len(apps)} applications...")
 
 		for app in apps:
-			App(app, bench=self.bench, to_clone=False).install()
+			App(app, bench=self.bench, to_clone=False).install( skip_assets=True, restart_bench=False)
 
 	def python(self, apps=None):
 		"""Install and upgrade Python dependencies for installed apps on given Bench if app not specified

--- a/bench/bench.py
+++ b/bench/bench.py
@@ -326,12 +326,13 @@ class BenchSetup(Base):
 		return apps
 
 	@job(title="Setting Up Bench Dependencies", success="Bench Dependencies Set Up")
-	def requirements(self):
-		"""Install and upgrade all installed apps on given Bench
+	def requirements(self, apps=None):
+		"""Install and upgrade all installed apps on given Bench if apps not specified
 		"""
 		from bench.app import App
 
-		apps = self.__get_installed_apps()
+		if not apps:
+			apps = self.__get_installed_apps()
 
 		self.pip()
 
@@ -340,12 +341,13 @@ class BenchSetup(Base):
 		for app in apps:
 			App(app, bench=self.bench, to_clone=False).install()
 
-	def python(self):
-		"""Install and upgrade Python dependencies for installed apps on given Bench
+	def python(self, apps=None):
+		"""Install and upgrade Python dependencies for installed apps on given Bench if app not specified
 		"""
 		import bench.cli
 
-		apps = self.__get_installed_apps()
+		if not apps:
+			apps = self.__get_installed_apps()
 
 		quiet_flag = "" if bench.cli.verbose else "--quiet"
 
@@ -356,12 +358,12 @@ class BenchSetup(Base):
 			log(f"\nInstalling python dependencies for {app}", level=3, no_log=True)
 			self.run(f"{self.bench.python} -m pip install {quiet_flag} --upgrade -e {app_path}")
 
-	def node(self):
-		"""Install and upgrade Node dependencies for all apps on given Bench
+	def node(self, apps=None):
+		"""Install and upgrade Node dependencies for all apps on given Bench if app not specified
 		"""
 		from bench.utils.bench import update_node_packages
 
-		return update_node_packages(bench_path=self.bench.name)
+		return update_node_packages(bench_path=self.bench.name, apps=apps)
 
 
 class BenchTearDown:

--- a/bench/commands/setup.py
+++ b/bench/commands/setup.py
@@ -131,17 +131,20 @@ def setup_procfile():
 def setup_socketio():
 	return
 
-@click.command("requirements", help="Setup Python and Node dependencies")
+@click.command("requirements")
 @click.option("--node", help="Update only Node packages", default=False, is_flag=True)
 @click.option("--python", help="Update only Python packages", default=False, is_flag=True)
 @click.option("--dev", help="Install optional python development dependencies", default=False, is_flag=True)
-@click.option("--app", help="Setup requirements for a specific app")
-def setup_requirements(node=False, python=False, dev=False, app=None):
+@click.argument("apps", nargs=-1)
+def setup_requirements(node=False, python=False, dev=False, apps=None):
+	"""
+	Setup Python and Node dependencies.
+
+	You can optionally specify one or more apps to specify dependencies for.
+	"""
 	from bench.bench import Bench
 
 	bench = Bench(".")
-
-	apps = [app] if app else None
 
 	if not (node or python or dev):
 		bench.setup.requirements(apps=apps)

--- a/bench/commands/setup.py
+++ b/bench/commands/setup.py
@@ -135,23 +135,26 @@ def setup_socketio():
 @click.option("--node", help="Update only Node packages", default=False, is_flag=True)
 @click.option("--python", help="Update only Python packages", default=False, is_flag=True)
 @click.option("--dev", help="Install optional python development dependencies", default=False, is_flag=True)
-def setup_requirements(node=False, python=False, dev=False):
+@click.option("--app", help="setup requirements for a specific app")
+def setup_requirements(node=False, python=False, dev=False, app=None):
 	from bench.bench import Bench
 
 	bench = Bench(".")
 
+	apps = [app] if app else None
+
 	if not (node or python or dev):
-		bench.setup.requirements()
+		bench.setup.requirements(apps=apps)
 
 	elif not node and not dev:
-		bench.setup.python()
+		bench.setup.python(apps=apps)
 
 	elif not python and not dev:
-		bench.setup.node()
+		bench.setup.node(apps=apps)
 
 	else:
 		from bench.utils.bench import install_python_dev_dependencies
-		install_python_dev_dependencies()
+		install_python_dev_dependencies(apps=apps)
 
 		if node:
 			click.secho("--dev flag only supports python dependencies. All node development dependencies are installed by default.", fg="yellow")

--- a/bench/commands/setup.py
+++ b/bench/commands/setup.py
@@ -135,7 +135,7 @@ def setup_socketio():
 @click.option("--node", help="Update only Node packages", default=False, is_flag=True)
 @click.option("--python", help="Update only Python packages", default=False, is_flag=True)
 @click.option("--dev", help="Install optional python development dependencies", default=False, is_flag=True)
-@click.option("--app", help="setup requirements for a specific app")
+@click.option("--app", help="Setup requirements for a specific app")
 def setup_requirements(node=False, python=False, dev=False, app=None):
 	from bench.bench import Bench
 

--- a/bench/utils/bench.py
+++ b/bench/utils/bench.py
@@ -48,7 +48,7 @@ def get_venv_path():
 	return venv or log("virtualenv cannot be found", level=2)
 
 
-def update_node_packages(bench_path="."):
+def update_node_packages(bench_path=".", apps=None):
 	print("Updating node packages...")
 	from bench.utils.app import get_develop_version
 	from distutils.version import LooseVersion
@@ -58,9 +58,9 @@ def update_node_packages(bench_path="."):
 	# After rollup was merged, frappe_version = 10.1
 	# if develop_verion is 11 and up, only then install yarn
 	if v < LooseVersion("11.x.x-develop"):
-		update_npm_packages(bench_path)
+		update_npm_packages(bench_path, apps=apps)
 	else:
-		update_yarn_packages(bench_path)
+		update_yarn_packages(bench_path, apps=apps)
 
 
 def install_python_dev_dependencies(bench_path=".", apps=None, verbose=False):
@@ -86,11 +86,14 @@ def install_python_dev_dependencies(bench_path=".", apps=None, verbose=False):
 			bench.run(f"{bench.python} -m pip install {quiet_flag} --upgrade -r {dev_requirements_path}")
 
 
-def update_yarn_packages(bench_path="."):
+def update_yarn_packages(bench_path=".", apps=None):
 	from bench.bench import Bench
 
 	bench = Bench(bench_path)
-	apps = [app for app in bench.apps if app not in bench.excluded_apps]
+
+	if not apps:
+		apps = [app for app in bench.apps if app not in bench.excluded_apps]
+
 	apps_dir = os.path.join(bench.name, "apps")
 
 	# TODO: Check for stuff like this early on only??
@@ -106,11 +109,14 @@ def update_yarn_packages(bench_path="."):
 			bench.run("yarn install", cwd=app_path)
 
 
-def update_npm_packages(bench_path="."):
+def update_npm_packages(bench_path=".", apps=None):
 	apps_dir = os.path.join(bench_path, "apps")
 	package_json = {}
 
-	for app in os.listdir(apps_dir):
+	if not apps:
+		apps = os.listdir(apps_dir)
+
+	for app in apps:
 		package_json_path = os.path.join(apps_dir, app, "package.json")
 
 		if os.path.exists(package_json_path):

--- a/bench/utils/bench.py
+++ b/bench/utils/bench.py
@@ -75,7 +75,7 @@ def install_python_dev_dependencies(bench_path=".", apps=None, verbose=False):
 	if isinstance(apps, str):
 		apps = [apps]
 	elif apps is None:
-		apps = [app for app in bench.apps if app not in bench.excluded_apps]
+		apps = bench.get_installed_apps()
 
 	for app in apps:
 		app_path = os.path.join(bench_path, "apps", app)
@@ -92,7 +92,7 @@ def update_yarn_packages(bench_path=".", apps=None):
 	bench = Bench(bench_path)
 
 	if not apps:
-		apps = [app for app in bench.apps if app not in bench.excluded_apps]
+		apps = bench.get_installed_apps()
 
 	apps_dir = os.path.join(bench.name, "apps")
 


### PR DESCRIPTION
Added `apps` argument to run setup requirements for a specific app(s)

## Usage

Specify multiple space-separated apps. Similar to how `bench switch-to-branch` works.
**CAVEAT**: apps must be specified in the end.
```bash
bench setup requirements [OPTIONS] [APPS]
```

## Other Changes
- Don't restart bench or build assets while setting up dependencies (original behavior). Restart and build should be separately executed. Restart fails for developer setups anyway:

```
ERROR: Command 'supervisorctl status' returned non-zero exit status 127.
Traceback (most recent call last):
  File "/usr/local/bin/bench", line 33, in <module>
    sys.exit(load_entry_point('frappe-bench', 'console_scripts', 'bench')())
  File "/home/snv/Work/.bench/bench/cli.py", line 121, in cli
    raise e
  File "/home/snv/Work/.bench/bench/cli.py", line 111, in cli
    bench_command()
  File "/home/snv/.local/lib/python3.8/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/home/snv/.local/lib/python3.8/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/home/snv/.local/lib/python3.8/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/snv/.local/lib/python3.8/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/snv/.local/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/snv/.local/lib/python3.8/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/home/snv/Work/.bench/bench/commands/setup.py", line 150, in setup_requirements
    bench.setup.requirements(apps=apps)
  File "/home/snv/Work/.bench/bench/utils/render.py", line 95, in wrapper_fn
    return fn(*args, **kwargs)
  File "/home/snv/Work/.bench/bench/bench.py", line 342, in requirements
    App(app, bench=self.bench, to_clone=False).install()
  File "/home/snv/Work/.bench/bench/utils/render.py", line 110, in wrapper_fn
    return fn(*args, **kwargs)
  File "/home/snv/Work/.bench/bench/app.py", line 192, in install
    install_app(
  File "/home/snv/Work/.bench/bench/app.py", line 426, in install_app
    bench.reload()
  File "/home/snv/Work/.bench/bench/utils/render.py", line 110, in wrapper_fn
    return fn(*args, **kwargs)
  File "/home/snv/Work/.bench/bench/bench.py", line 142, in reload
    restart_supervisor_processes(bench_path=self.name, web_workers=web)
  File "/home/snv/Work/.bench/bench/utils/bench.py", line 257, in restart_supervisor_processes
    supervisor_status = get_cmd_output("supervisorctl status", cwd=bench_path)
  File "/home/snv/Work/.bench/bench/utils/__init__.py", line 185, in get_cmd_output
    output = subprocess.check_output(
  File "/usr/lib/python3.8/subprocess.py", line 415, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/lib/python3.8/subprocess.py", line 516, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command 'supervisorctl status' returned non-zero exit status 127.
```

## Screenshots

### Help

![image](https://user-images.githubusercontent.com/16315650/154639363-86405c52-b41e-48ec-90e6-f464e45b625b.png)

### One App

![image](https://user-images.githubusercontent.com/16315650/154640302-11a20e79-3b5a-4e9b-b4ff-1b92b244a3b8.png)


### Multiple Apps

![image](https://user-images.githubusercontent.com/16315650/154640382-75e31f20-7a22-4878-880f-8f47532da835.png)

### No Apps (truncated)

![image](https://user-images.githubusercontent.com/16315650/154640464-89eba582-03a4-41b9-970b-c10e1d2a85d5.png)

### Multiple apps, node

![image](https://user-images.githubusercontent.com/16315650/154640558-debb1e1e-0c04-49cf-94db-2fed9cbf1be8.png)
