### PR TITLE
chore: bump jinja

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Click>=7.0
 GitPython~=2.1.15
 honcho
-Jinja2~=2.11.3
+Jinja2~=3.0.3
 python-crontab~=2.4.0
 requests
 semantic-version~=2.8.2


### PR DESCRIPTION
https://jinja.palletsprojects.com/en/3.0.x/changes/

bench only seems to use jinja for rendering config files, tested locally. 

closes #1269 