### PR TITLE
fix: uri-path when initializing Apps 

### DIFF
--- a/bench/app.py
+++ b/bench/app.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 import typing
 from datetime import date
+from urllib.parse import urlparse
 
 # imports - third party imports
 import click
@@ -62,6 +63,9 @@ class AppMeta:
 		self.from_apps = False
 		self.is_url = False
 		self.branch = branch
+		self.mount_path = os.path.abspath(
+			os.path.join(urlparse(self.name).netloc, urlparse(self.name).path)
+		)
 		self.setup_details()
 
 	def setup_details(self):
@@ -75,7 +79,7 @@ class AppMeta:
 			self._setup_details_from_installed_apps()
 
 		# fetch meta for repo on mounted disk
-		elif os.path.exists(self.name):
+		elif os.path.exists(self.mount_path):
 			self.on_disk = True
 			self._setup_details_from_mounted_disk()
 
@@ -91,7 +95,9 @@ class AppMeta:
 			self._setup_details_from_name_tag()
 
 	def _setup_details_from_mounted_disk(self):
-		self.org, self.repo, self.tag = os.path.split(self.name)[-2:] + (self.branch,)
+		self.org, self.repo, self.tag = os.path.split(self.mount_path)[-2:] + (
+			self.branch,
+		)
 
 	def _setup_details_from_name_tag(self):
 		self.org, self.repo, self.tag = fetch_details_from_tag(self.name)
@@ -122,7 +128,7 @@ class AppMeta:
 			return os.path.abspath(os.path.join("apps", self.name))
 
 		if self.on_disk:
-			return os.path.abspath(self.name)
+			return self.mount_path
 
 		if self.is_url:
 			return self.name

--- a/bench/tests/test_init.py
+++ b/bench/tests/test_init.py
@@ -10,6 +10,7 @@ import git
 # imports - module imports
 from bench.utils import exec_cmd
 from bench.release import get_bumped_version
+from bench.app import App
 from bench.tests.test_base import FRAPPE_BRANCH, TestBenchBase
 
 
@@ -34,9 +35,10 @@ class TestBenchInit(TestBenchBase):
 	def test_utils(self):
 		self.assertEqual(subprocess.call("bench"), 0)
 
-
 	def test_init(self, bench_name="test-bench", **kwargs):
 		self.init_bench(bench_name, **kwargs)
+		app = App("file:///tmp/frappe")
+		self.assertEqual(app.url, "/tmp/frappe")
 		self.assert_folders(bench_name)
 		self.assert_virtual_env(bench_name)
 		self.assert_config(bench_name)


### PR DESCRIPTION
* Allowing URI paths to be passed when initializing new apps.

Fixes #1266 

* Before
![image](https://user-images.githubusercontent.com/67282231/155292309-53e25eb0-ddba-483b-8c87-50b91e71be6b.png)

* After

![image](https://user-images.githubusercontent.com/67282231/155292464-5f4b51d8-117d-419b-b47a-9fa74390e0e8.png)
