### PR TITLE
fix: setup all apps is empty list is supplied

### DIFF
--- a/bench/utils/bench.py
+++ b/bench/utils/bench.py
@@ -74,7 +74,7 @@ def install_python_dev_dependencies(bench_path=".", apps=None, verbose=False):
 
 	if isinstance(apps, str):
 		apps = [apps]
-	elif apps is None:
+	elif not apps:
 		apps = bench.get_installed_apps()
 
 	for app in apps:


### PR DESCRIPTION
`bench setup requirements --dev` doesn't do anything because `apps` is `()`

caused by https://github.com/frappe/bench/pull/1265 which changes apps from `None` to `()`