### PR TITLE
fix: Misc fixes

### DIFF
--- a/bench/app.py
+++ b/bench/app.py
@@ -488,6 +488,13 @@ def new_app(app, no_git=None, bench_path="."):
 
 	# For backwards compatibility
 	app = app.lower().replace(" ", "_").replace("-", "_")
+	if app[0].isdigit() or "." in app:
+		click.secho(
+			"App names cannot start with numbers(digits) or have dot(.) in them",
+			fg="red"
+		)
+		return
+
 	apps = os.path.abspath(os.path.join(bench_path, "apps"))
 	args = ["make-app", apps, app]
 	if no_git:

--- a/bench/utils/__init__.py
+++ b/bench/utils/__init__.py
@@ -53,8 +53,7 @@ def is_frappe_app(directory: str) -> bool:
 def is_valid_frappe_branch(frappe_path:str, frappe_branch:str):
 	""" Check if a branch exists in a repo. Throws InvalidRemoteException if branch is not found
 
-	Uses github's api without auth to query branch.
-	If rate limited by gitapi, requests are sent to github.com
+	Uses native git command to check for branches on a remote.
 
 	:param frappe_path: git url
 	:type frappe_path: str
@@ -62,28 +61,25 @@ def is_valid_frappe_branch(frappe_path:str, frappe_branch:str):
 	:type frappe_branch: str
 	:raises InvalidRemoteException: branch for this repo doesn't exist
 	"""
-	if "http" in frappe_path and frappe_branch:
-		frappe_path = frappe_path.replace(".git", "")
+	import subprocess
 
+	message = f"Invalid branch {frappe_branch} for remote {frappe_path}"
+	if frappe_branch:
 		try:
-			owner, repo = frappe_path.split("/")[3], frappe_path.split("/")[4]
-		except IndexError:
-			raise InvalidRemoteException("Invalid git url")
-
-		git_api_req = f"https://api.github.com/repos/{owner}/{repo}/branches/{frappe_branch}"
-		res = requests.get(git_api_req)
-
-		if res.status_code == 403:
-			# slower alternative with no rate limit
-			github_req = f'https://github.com/{owner}/{repo}/tree/{frappe_branch}'
-			if requests.get(github_req).status_code != 200:
-				raise InvalidRemoteException("Invalid git url")
-
-		elif res.status_code == 404:
-			raise InvalidRemoteException("Frappe branch does not exist")
-
-		elif res.status_code == 301:
-			raise InvalidRemoteException("Frappe branch has been moved to another location")
+			ret = subprocess.check_output(
+				(
+					"git",
+					"ls-remote",
+					"--heads",
+					frappe_path,
+					frappe_branch,
+				),
+				encoding="UTF-8",
+			)
+			if not ret:
+				raise InvalidRemoteException(message)
+		except subprocess.CalledProcessError:
+			raise InvalidRemoteException(message)
 
 
 def log(message, level=0, no_log=False):

--- a/bench/utils/__init__.py
+++ b/bench/utils/__init__.py
@@ -51,7 +51,7 @@ def is_frappe_app(directory: str) -> bool:
 
 
 def is_valid_frappe_branch(frappe_path:str, frappe_branch:str):
-	""" Check if a branch exists in a repo. Throws InvalidRemoteException if branch is not found
+	"""Check if a branch exists in a repo. Throws InvalidRemoteException if branch is not found
 
 	Uses native git command to check for branches on a remote.
 
@@ -63,7 +63,6 @@ def is_valid_frappe_branch(frappe_path:str, frappe_branch:str):
 	"""
 	import subprocess
 
-	message = f"Invalid branch {frappe_branch} for remote {frappe_path}"
 	if frappe_branch:
 		try:
 			ret = subprocess.check_output(
@@ -77,9 +76,11 @@ def is_valid_frappe_branch(frappe_path:str, frappe_branch:str):
 				encoding="UTF-8",
 			)
 			if not ret:
-				raise InvalidRemoteException(message)
+				raise InvalidRemoteException(
+					f"Invalid {frappe_branch} for the remote {frappe_path}"
+				)
 		except subprocess.CalledProcessError:
-			raise InvalidRemoteException(message)
+			raise InvalidRemoteException(f"Invalid frappe path {frappe_path}")
 
 
 def log(message, level=0, no_log=False):

--- a/bench/utils/__init__.py
+++ b/bench/utils/__init__.py
@@ -71,7 +71,7 @@ def is_valid_frappe_branch(frappe_path:str, frappe_branch:str):
 			raise InvalidRemoteException("Invalid git url")
 
 		git_api_req = f"https://api.github.com/repos/{owner}/{repo}/branches/{frappe_branch}"
-		res = requests.get(git_api_req).json()
+		res = requests.get(git_api_req)
 
 		if res.status_code == 403:
 			# slower alternative with no rate limit

--- a/bench/utils/__init__.py
+++ b/bench/utils/__init__.py
@@ -64,21 +64,26 @@ def is_valid_frappe_branch(frappe_path:str, frappe_branch:str):
 	"""
 	if "http" in frappe_path and frappe_branch:
 		frappe_path = frappe_path.replace(".git", "")
+
 		try:
 			owner, repo = frappe_path.split("/")[3], frappe_path.split("/")[4]
 		except IndexError:
 			raise InvalidRemoteException("Invalid git url")
-		git_api_req = f"https://api.github.com/repos/{owner}/{repo}/branches"
+
+		git_api_req = f"https://api.github.com/repos/{owner}/{repo}/branches/{frappe_branch}"
 		res = requests.get(git_api_req).json()
 
-		if "message" in res:
+		if res.status_code == 403:
 			# slower alternative with no rate limit
 			github_req = f'https://github.com/{owner}/{repo}/tree/{frappe_branch}'
 			if requests.get(github_req).status_code != 200:
 				raise InvalidRemoteException("Invalid git url")
 
-		elif frappe_branch not in [x["name"] for x in res]:
+		elif res.status_code == 404:
 			raise InvalidRemoteException("Frappe branch does not exist")
+
+		elif res.status_code == 301:
+			raise InvalidRemoteException("Frappe branch has been moved to another location")
 
 
 def log(message, level=0, no_log=False):


### PR DESCRIPTION
Changes:
- use git's `ls-remote` command for validating frappe branch
- don't allow creating apps with names which start with int and/or have `.` in them


closes: https://github.com/frappe/bench/issues/1292, 
closes: https://github.com/frappe/bench/issues/1283, 
closes: https://github.com/frappe/frappe/issues/16524, 
closes: https://github.com/frappe/bench/issues/1298