### PR TITLE
Get-app from port specific ssh git server

### DIFF
--- a/bench/app.py
+++ b/bench/app.py
@@ -116,7 +116,7 @@ class AppMeta:
 		name = url if url else self.name
 		if name.startswith("git@") or name.startswith("ssh://"):
 			self.use_ssh = True
-			_first_part, _second_part = name.split(":")
+			_first_part, _second_part = self.name.rsplit(":", 1)
 			self.remote_server = _first_part.split("@")[-1]
 			self.org, _repo = _second_part.rsplit("/", 1)
 		else:

--- a/bench/tests/test_utils.py
+++ b/bench/tests/test_utils.py
@@ -73,3 +73,7 @@ class TestUtils(unittest.TestCase):
 		self.assertEqual("11.0", fake_bench.apps.states["frappe"]["version"])
 
 		shutil.rmtree(bench_dir)
+
+	def test_ssh_ports(self):
+		app = App("git@github.com:22:frappe/frappe")
+		self.assertEqual((app.use_ssh, app.org, app.repo), (True, "frappe", "frappe"))


### PR DESCRIPTION
Current bench package fails to get an app from a private git server with a specific ssh port other than the normal 22.

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. Update necessary Documentation
 4. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/bench/blob/master/docs/contribution_guidelines.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

What type of a PR is this?

- [ ] Changes to Existing Features
- [ ] New Feature Submissions
- [x] Bug Fix
- [ ] Breaking Change (include change in API behaviours, etc.)

---

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

---

> Explain the **details** for making this change. What existing problem does the pull request solve? The following checklist could help

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [x] Have you lint your code locally prior to submission?
- [x] Have you successfully run tests with your changes locally?
- [x] Does your commit message have an explanation for your changes and why you'd like us to include them?
- [x] Docs have been added / updated
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Did you modify the existing test cases? If yes, why?

---

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->