### PR TITLE
fix: case-insensitive matching

### DIFF
--- a/bench/config/templates/nginx.conf
+++ b/bench/config/templates/nginx.conf
@@ -80,7 +80,7 @@ server {
   		rewrite ^(.+)/index\.html$ $1 permanent;
   		rewrite ^(.+)\.html$ $1 permanent;
 
-		location ~ ^/files/.*.(htm|html|svg|xml) {
+		location ~* ^/files/.*.(htm|html|svg|xml) {
 			add_header Content-disposition "attachment";
 			try_files /{{ site_name }}/public/$uri @webserver;
 		}


### PR DESCRIPTION
Currently, files with uppercase extensions do not get matched. For example, `file.HTML` would be served as a normal web page instead of being downloaded as attachment. This PR makes matching case-**in**sensitive.

Thanks @ankush for pointing out this fix.