### PR TITLE
fix: allow bench init with git tags

### DIFF
--- a/bench/tests/test_utils.py
+++ b/bench/tests/test_utils.py
@@ -35,6 +35,7 @@ class TestUtils(unittest.TestCase):
 			is_valid_frappe_branch("https://github.com/random/random.git", frappe_branch="random-branch")
 
 		is_valid_frappe_branch("https://github.com/frappe/frappe.git", frappe_branch="develop")
+		is_valid_frappe_branch("https://github.com/frappe/frappe.git", frappe_branch="v13.29.0")
 
 	def test_app_states(self):
 		bench_dir = "./sandbox"

--- a/bench/utils/__init__.py
+++ b/bench/utils/__init__.py
@@ -61,35 +61,19 @@ def is_valid_frappe_branch(frappe_path:str, frappe_branch:str):
 	:type frappe_branch: str
 	:raises InvalidRemoteException: branch for this repo doesn't exist
 	"""
-	import subprocess
+	import git
+
+	g = git.cmd.Git()
 
 	if frappe_branch:
 		try:
-			ret = subprocess.check_output(
-				(
-					"git",
-					"ls-remote",
-					"--heads",
-					frappe_path,
-					frappe_branch,
-				),
-				encoding="UTF-8",
-			) or subprocess.check_output(
-				(
-					"git",
-					"ls-remote",
-					"--tags",
-					frappe_path,
-					frappe_branch,
-				),
-				encoding="UTF-8",
-			)
-			if not ret:
+			res = g.ls_remote("--heads", "--tags", frappe_path, frappe_branch)
+			if not res:
 				raise InvalidRemoteException(
-					f"Invalid {frappe_branch} for the remote {frappe_path}"
+					f"Invalid branch: {frappe_branch} for the remote {frappe_path}"
 				)
-		except subprocess.CalledProcessError:
-			raise InvalidRemoteException(f"Invalid frappe path {frappe_path}")
+		except git.exc.GitCommandError:
+			raise InvalidRemoteException(f"Invalid frappe path: {frappe_path}")
 
 
 def log(message, level=0, no_log=False):

--- a/bench/utils/__init__.py
+++ b/bench/utils/__init__.py
@@ -50,6 +50,7 @@ def is_frappe_app(directory: str) -> bool:
 	return bool(is_frappe_app)
 
 
+@lru_cache(maxsize=None)
 def is_valid_frappe_branch(frappe_path:str, frappe_branch:str):
 	"""Check if a branch exists in a repo. Throws InvalidRemoteException if branch is not found
 

--- a/bench/utils/__init__.py
+++ b/bench/utils/__init__.py
@@ -74,6 +74,15 @@ def is_valid_frappe_branch(frappe_path:str, frappe_branch:str):
 					frappe_branch,
 				),
 				encoding="UTF-8",
+			) or subprocess.check_output(
+				(
+					"git",
+					"ls-remote",
+					"--tags",
+					frappe_path,
+					frappe_branch,
+				),
+				encoding="UTF-8",
 			)
 			if not ret:
 				raise InvalidRemoteException(

--- a/bench/utils/__init__.py
+++ b/bench/utils/__init__.py
@@ -70,7 +70,7 @@ def is_valid_frappe_branch(frappe_path:str, frappe_branch:str):
 			res = g.ls_remote("--heads", "--tags", frappe_path, frappe_branch)
 			if not res:
 				raise InvalidRemoteException(
-					f"Invalid branch: {frappe_branch} for the remote {frappe_path}"
+					f"Invalid branch or tag: {frappe_branch} for the remote {frappe_path}"
 				)
 		except git.exc.GitCommandError:
 			raise InvalidRemoteException(f"Invalid frappe path: {frappe_path}")


### PR DESCRIPTION
```
bench init --skip-redis-config-generation --frappe-branch v13.14.1 frappe-bench
```

Results into:

```
bench.exceptions.InvalidRemoteException: Invalid v13.14.1 for the remote https://github.com/frappe/frappe.git
```

Fix allows git tags to be used for `--frappe-branch` during `bench init`