### PR TITLE
feat(config): Add RHEL 8 compatibility

### DIFF
--- a/bench/config/production_setup.py
+++ b/bench/config/production_setup.py
@@ -100,24 +100,24 @@ def disable_production(bench_path='.'):
 
 def service(service_name, service_option):
 	if os.path.basename(which('systemctl') or '') == 'systemctl' and is_running_systemd():
-		status = exec_cmd(f"sudo systemctl {service_option} {service_name}", _raise=False)
+		# Get current service status (
+		is_running = (exec_cmd(f"sudo systemctl {service_option} {service_name}", _raise=False)) == 0
 		if service_option == "status":
-			return status == 0
-		if service_option == "reload":
-			if status == 0:
-				exec_cmd(f"sudo systemctl {service_option} {service_name}")
-			else:
-				exec_cmd(f"sudo systemctl start {service_name}")
+			return is_running
+		if service_option == "reload" and not is_running:
+			exec_cmd(f"sudo systemctl start {service_name}")
+		else:
+			exec_cmd(f"sudo systemctl {service_option} {service_name}")
+			if is_running:
 
 	elif os.path.basename(which('service') or '') == 'service':
-		status = exec_cmd(f"sudo service {service_name} {service_option}", _raise=False)
+		is_running = (exec_cmd(f"sudo service {service_name} {service_option}", _raise=False)) == 0
 		if service_option == "status":
-			return status == 0
-		if service_option == "reload":
-			if status == 0:
-				exec_cmd(f"sudo service {service_name} {service_option}")
-			else:
-				exec_cmd(f"sudo service start {service_option}")
+			return is_running
+		if service_option == "reload" and not is_running:
+			exec_cmd(f"sudo service start {service_option}")
+		else:
+			exec_cmd(f"sudo service {service_name} {service_option}")				
 
 	else:
 		# look for 'service_manager' and 'service_manager_command' in environment

--- a/bench/config/supervisor.py
+++ b/bench/config/supervisor.py
@@ -125,4 +125,6 @@ def update_supervisord_config(user=None, yes=False):
 		logger.log(f"Updating supervisord.conf failed due to '{e}'")
 
 	# Reread supervisor configuration, reload supervisord and supervisorctl, restart services that were started
-	service('supervisor', 'reload')
+	# Let's defer importing reload_supervisor() here to avoid a circular import
+	from bench.config.production_setup import reload_supervisor
+	reload_supervisor()

--- a/bench/patches/v5/fix_user_permissions.py
+++ b/bench/patches/v5/fix_user_permissions.py
@@ -5,7 +5,7 @@ import subprocess
 
 # imports - module imports
 from bench.cli import change_uid_msg
-from bench.config.production_setup import get_supervisor_confdir, is_centos7, service
+from bench.config.production_setup import get_supervisor_confdir, is_centos7_or_newer, service
 from bench.config.common_site_config import get_config
 from bench.utils import exec_cmd, get_bench_name, get_cmd_output
 
@@ -33,7 +33,7 @@ def is_production_set(bench_path):
 	production_setup = False
 	bench_name = get_bench_name(bench_path)
 
-	supervisor_conf_extn = "ini" if is_centos7() else "conf"
+	supervisor_conf_extn = "ini" if is_centos7_or_newer() else "conf"
 	supervisor_conf_file_name = f'{bench_name}.{supervisor_conf_extn}'
 	supervisor_conf = os.path.join(get_supervisor_confdir(), supervisor_conf_file_name)
 


### PR DESCRIPTION
closes #1041

What type of a PR is this?

- [X] Bug Fix


---
This PR improves RHEL 8 and clones detection (was limited to CentOS 7).
Also fixes supervisord / nginx services cannot be reloaded unless already started, which would end up with an error stopping production setup.
Replaces `service('supervisor', 'reload')` with existing `supervisor_reload()` function which handles different service names (eg `supervisor` on debian likes and `supervisord` on RHEL likes).

- [X] Have you followed the guidelines in our Contributing document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [X] Have you lint your code locally prior to submission?
- [X] Have you successfully run tests with your changes locally?
- [X] Does your commit message have an explanation for your changes and why you'd like us to include them?
- [N/A] Docs have been added / updated
- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Did you modify the existing test cases? If yes, why?

---
