### PR TITLE
feat(remove-app): --no-backup, --force

### DIFF
--- a/bench/app.py
+++ b/bench/app.py
@@ -180,7 +180,7 @@ class App(AppMeta):
 
 	@step(title="Archiving App {repo}", success="App {repo} Archived")
 	def remove(self):
-		active_app_path = os.path.join("apps", self.repo)
+		active_app_path = os.path.join("apps", self.name)
 		archived_path = os.path.join("archived", "apps")
 		archived_name = get_available_folder_name(f"{self.repo}-{date.today()}", archived_path)
 		archived_app_path = os.path.join(archived_path, archived_name)
@@ -224,7 +224,7 @@ class App(AppMeta):
 
 	@step(title="Uninstalling App {repo}", success="App {repo} Uninstalled")
 	def uninstall(self):
-		self.bench.run(f"{self.bench.python} -m pip uninstall -y {self.repo}")
+		self.bench.run(f"{self.bench.python} -m pip uninstall -y {self.name}")
 
 	def _get_dependencies(self):
 		from bench.utils.app import get_required_deps, required_apps_from_hooks

--- a/bench/app.py
+++ b/bench/app.py
@@ -113,6 +113,10 @@ class AppMeta:
 				self.tag = self.branch = self.git_repo.active_branch.name
 		except IndexError:
 			self.org, self.repo, self.tag = os.path.split(self.mount_path)[-2:] + (self.branch,)
+		except TypeError:
+			# faced a "a detached symbolic reference as it points" in case you're in the middle of
+			# some git shenanigans
+			self.tag = self.branch = None
 
 	def _setup_details_from_name_tag(self):
 		self.org, self.repo, self.tag = fetch_details_from_tag(self.name)

--- a/bench/app.py
+++ b/bench/app.py
@@ -179,13 +179,19 @@ class App(AppMeta):
 		)
 
 	@step(title="Archiving App {repo}", success="App {repo} Archived")
-	def remove(self):
+	def remove(self, no_backup: bool = False):
 		active_app_path = os.path.join("apps", self.name)
-		archived_path = os.path.join("archived", "apps")
-		archived_name = get_available_folder_name(f"{self.repo}-{date.today()}", archived_path)
-		archived_app_path = os.path.join(archived_path, archived_name)
-		log(f"App moved from {active_app_path} to {archived_app_path}")
-		shutil.move(active_app_path, archived_app_path)
+
+		if no_backup:
+			shutil.rmtree(active_app_path)
+			log(f"App deleted from {active_app_path}")
+		else:
+			archived_path = os.path.join("archived", "apps")
+			archived_name = get_available_folder_name(f"{self.repo}-{date.today()}", archived_path)
+			archived_app_path = os.path.join(archived_path, archived_name)
+
+			shutil.move(active_app_path, archived_app_path)
+			log(f"App moved from {active_app_path} to {archived_app_path}")
 
 	@step(title="Installing App {repo}", success="App {repo} Installed")
 	def install(

--- a/bench/bench.py
+++ b/bench/bench.py
@@ -312,8 +312,7 @@ class BenchApps(MutableSequence):
 
 	def remove(self, app: "App", no_backup: bool = False):
 		app.uninstall()
-		if not no_backup:
-			app.remove()
+		app.remove(no_backup=no_backup)
 		super().remove(app.repo)
 
 	def append(self, app: "App"):

--- a/bench/commands/make.py
+++ b/bench/commands/make.py
@@ -180,12 +180,14 @@ def new_app(app_name, no_git=None):
 		"Completely remove app from bench and re-build assets if not installed on any site"
 	),
 )
+@click.option("--no-backup", is_flag=True, help="Do not backup app before removing")
+@click.option("--force", is_flag=True, help="Force remove app")
 @click.argument("app-name")
-def remove_app(app_name):
+def remove_app(app_name, no_backup=False, force=False):
 	from bench.bench import Bench
 
 	bench = Bench(".")
-	bench.uninstall(app_name)
+	bench.uninstall(app_name, no_backup=no_backup, force=force)
 
 
 @click.command("exclude-app", help="Exclude app from updating")

--- a/bench/exceptions.py
+++ b/bench/exceptions.py
@@ -21,8 +21,14 @@ class BenchNotFoundError(Exception):
 class ValidationError(Exception):
 	pass
 
+
+class AppNotInstalledError(ValidationError):
+	pass
+
+
 class CannotUpdateReleaseBench(ValidationError):
 	pass
+
 
 class FeatureDoesNotExistError(CommandFailedError):
 	pass

--- a/bench/utils/__init__.py
+++ b/bench/utils/__init__.py
@@ -17,7 +17,7 @@ import requests
 # imports - module imports
 from bench import PROJECT_NAME, VERSION
 
-from bench.exceptions import CommandFailedError, InvalidRemoteException, ValidationError
+from bench.exceptions import CommandFailedError, InvalidRemoteException, AppNotInstalledError
 
 
 logger = logging.getLogger(PROJECT_NAME)
@@ -294,7 +294,7 @@ def set_git_remote_url(git_url, bench_path="."):
 	app = git_url.rsplit("/", 1)[1].rsplit(".", 1)[0]
 
 	if app not in Bench(bench_path).apps:
-		raise ValidationError(f"No app named {app}")
+		raise AppNotInstalledError(f"No app named {app}")
 
 	app_dir = get_repo_dir(app, bench_path=bench_path)
 


### PR DESCRIPTION
Features:
* `--no-backup` option to not move app folder to archived, instead just delete it directly
* `--force` option to force uninstall, remove app folder without validations

Bug fixes:
* faced other issues in remove-app about `'App {} does not exist'` with another private app
* GitPython throws `TypeError` when repo is in a "dangling" state
* App.repo != App.name always for remove-app
