### PR TITLE
feat(config): Add IPv6 listener to nginx site configuration

### DIFF
--- a/bench/config/templates/nginx.conf
+++ b/bench/config/templates/nginx.conf
@@ -14,8 +14,10 @@ map {{ from_variable }} {{ to_variable }} {
 server {
 	{% if ssl_certificate and ssl_certificate_key %}
 	listen {{ port }} ssl;
+	listen [::]:{{ port }} ssl;
 	{% else %}
 	listen {{ port }};
+	listen [::]:{{ port }};
 	{% endif %}
 
 	server_name


### PR DESCRIPTION
closes #814 

What type of a PR is this?

- [X] Changes to Existing Features

---

- [X] Have you followed the guidelines in our Contributing document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [X] Have you lint your code locally prior to submission?
- [X] Have you successfully run tests with your changes locally?
- [X] Does your commit message have an explanation for your changes and why you'd like us to include them?
- [N/A] Docs have been added / updated
- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Did you modify the existing test cases? If yes, why?

---

This PR adds an IPv6 listener to nginx configuration files.
With RHEL 8, localhost TCP calls are done via IPv6 if available.
Thus, even when configuring `/etc/hosts` file to resolve a bench site name to 127.0.0.1 and ::1, a command like `curl localhost` will read nginx default site instead of the frappe configured site.
This also resolves an issue where `wkhtmltodpf` misses CSS and images since it will try to load assets on the default nginx site.