### PR TITLE
fix: Remove virtualenv dependency

### DIFF
--- a/bench/bench.py
+++ b/bench/bench.py
@@ -29,6 +29,7 @@ from bench.utils.bench import (
 	restart_process_manager,
 	remove_backups_crontab,
 	get_venv_path,
+	get_virtualenv_path,
 	get_env_cmd,
 )
 from bench.utils.render import job, step
@@ -347,14 +348,20 @@ class BenchSetup(Base):
 		import bench.cli
 		import click
 
+		verbose = bench.cli.verbose
+
 		click.secho("Setting Up Environment", fg="yellow")
 
 		frappe = os.path.join(self.bench.name, "apps", "frappe")
-		virtualenv = get_venv_path()
-		quiet_flag = "" if bench.cli.verbose else "--quiet"
+		virtualenv = get_virtualenv_path(verbose=verbose)
+		quiet_flag = "" if verbose else "--quiet"
 
 		if not os.path.exists(self.bench.python):
-			self.run(f"{virtualenv} {quiet_flag} env -p {python}")
+			if virtualenv:
+				self.run(f"{virtualenv} {quiet_flag} env -p {python}")
+			else:
+				venv = get_venv_path(verbose=verbose)
+				self.run(f"{venv} env")
 
 		self.pip()
 

--- a/bench/utils/bench.py
+++ b/bench/utils/bench.py
@@ -33,19 +33,25 @@ def get_env_cmd(cmd, bench_path="."):
 	return os.path.abspath(os.path.join(bench_path, "env", "bin", cmd))
 
 
-def get_venv_path():
-	venv = which("virtualenv")
+def get_virtualenv_path(verbose=False):
+	virtualenv_path = which("virtualenv")
 
-	if not venv:
-		current_python = sys.executable
-		with open(os.devnull, "wb") as devnull:
-			is_venv_installed = not subprocess.call(
-				[current_python, "-m", "venv", "--help"], stdout=devnull
-			)
-		if is_venv_installed:
-			venv = f"{current_python} -m venv"
+	if not virtualenv_path and verbose:
+		log("virtualenv cannot be found", level=2)
 
-	return venv or log("virtualenv cannot be found", level=2)
+	return virtualenv_path
+
+
+def get_venv_path(verbose=False):
+	current_python = sys.executable
+	with open(os.devnull, "wb") as devnull:
+		is_venv_installed = not subprocess.call(
+			[current_python, "-m", "venv", "--help"], stdout=devnull
+		)
+	if is_venv_installed:
+		return f"{current_python} -m venv"
+	else:
+		log("virtualenv cannot be found", level=2)
 
 
 def update_node_packages(bench_path=".", apps=None):

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ python-crontab~=2.4.0
 requests
 semantic-version~=2.8.2
 setuptools
-virtualenv


### PR DESCRIPTION
Use virtualenv cli only if found in PATH. Else use venv package of the invoker's Python installation. venv was added in the std lib since PY33.

ref: https://docs.python.org/3/library/venv.html

Re of #828, #1313 