### PR TITLE
feat: get-app support soft link as alternative to git clone

### DIFF
--- a/bench/app.py
+++ b/bench/app.py
@@ -13,6 +13,8 @@ from datetime import date
 from urllib.parse import urlparse
 import os
 
+from markupsafe import soft_str
+
 # imports - third party imports
 import click
 from git import Repo
@@ -158,8 +160,9 @@ class AppMeta:
 
 @functools.lru_cache(maxsize=None)
 class App(AppMeta):
-	def __init__(self, name: str, branch: str = None, bench: "Bench" = None, *args, **kwargs):
+	def __init__(self, name: str, branch: str = None, bench: "Bench" = None, soft_link : bool = False, *args, **kwargs):
 		self.bench = bench
+		self.soft_link = soft_link
 		self.required_by = None
 		self.local_resolution = []
 		super().__init__(name, branch, *args, **kwargs)
@@ -169,12 +172,19 @@ class App(AppMeta):
 		branch = f"--branch {self.tag}" if self.tag else ""
 		shallow = "--depth 1" if self.bench.shallow_clone else ""
 
+		if not self.soft_link:
+			cmd = "git clone"
+			args = f"{self.url} {branch} {shallow} --origin upstream"
+		else:
+			cmd = "ln -s"
+			args = f"{self.name}"
+
 		fetch_txt = f"Getting {self.repo}"
 		click.secho(fetch_txt, fg="yellow")
 		logger.log(fetch_txt)
 
 		self.bench.run(
-			f"git clone {self.url} {branch} {shallow} --origin upstream",
+			f"{cmd} {args}",
 			cwd=os.path.join(self.bench.name, "apps"),
 		)
 
@@ -338,6 +348,7 @@ def get_app(
 	skip_assets=False,
 	verbose=False,
 	overwrite=False,
+	soft_link=False,
 	init_bench=False,
 	resolve_deps=False,
 ):
@@ -354,7 +365,7 @@ def get_app(
 	from bench.utils.app import check_existing_dir
 
 	bench = Bench(bench_path)
-	app = App(git_url, branch=branch, bench=bench)
+	app = App(git_url, branch=branch, bench=bench, soft_link=soft_link)
 	git_url = app.url
 	repo_name = app.repo
 	branch = app.tag

--- a/bench/commands/make.py
+++ b/bench/commands/make.py
@@ -130,6 +130,7 @@ def drop(path):
 @click.option("--branch", default=None, help="branch to checkout")
 @click.option("--overwrite", is_flag=True, default=False)
 @click.option("--skip-assets", is_flag=True, default=False, help="Do not build assets")
+@click.option("--soft-link", is_flag=True, default=False, help="Create a soft link to git repo instead of clone.")
 @click.option(
 	"--init-bench", is_flag=True, default=False, help="Initialize Bench if not in one"
 )
@@ -145,6 +146,7 @@ def get_app(
 	name=None,
 	overwrite=False,
 	skip_assets=False,
+	soft_link=False,
 	init_bench=False,
 	resolve_deps=False,
 ):
@@ -156,6 +158,7 @@ def get_app(
 		branch=branch,
 		skip_assets=skip_assets,
 		overwrite=overwrite,
+		soft_link=soft_link,
 		init_bench=init_bench,
 		resolve_deps=resolve_deps,
 	)


### PR DESCRIPTION
# Use Case
I'm experimenting with GitHub Codespaces (Only been using it for a couple of hours) So maybe I'm taking the wrong approach to this.

Let's say I'm working on `erpnext`, I'll create a code space for my fork `dj12djdjs/erpnext` which will put my working directory at `/workspaces/erpnext`. I can't test my code just like this. I need frappe and bench utilities to actual use ERPnext. so in the parent directory of workspaces I'll create `/frappe-bench` with frappe and the python environment. 

If I want to test my code, I'll have to commit to the github repo -> push -> then pull in the /frappe-bench/apps/erpnext

It would be much better if the changes I made in `/workspaces/erpnext` directly reflect to `/frappe-bench/apps/erpnext`

# Proposed Solution
Introduce the `--soft-link` flag to `get-app` command, altering the way bench will get the app into the apps directory. Instead of `git clone`,  it will `ln -s` if the `--soft-link` flag is provided.
![get app ln-s](https://user-images.githubusercontent.com/29856401/171788756-5aa9546e-15f7-479d-bbc1-d1dce015bb40.gif)


**Note:** I just through this together to test it, It broke some things like `bench remove-app` and maybe some others. I just wanted to get some feedback if others might find this a useful addition.
