### PR TITLE
fix: Bump Nodejs v12 => v14

### DIFF
--- a/bench/playbooks/roles/nodejs/defaults/main.yml
+++ b/bench/playbooks/roles/nodejs/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
-node_version: 12
+node_version: 14
 ...


### PR DESCRIPTION
v13 requires Nodejs v14