### PR TITLE
feat: Dev Dependencies via pyproject.toml

### DIFF
--- a/bench/utils/bench.py
+++ b/bench/utils/bench.py
@@ -97,8 +97,7 @@ def update_yarn_packages(bench_path=".", apps=None):
 
 	bench = Bench(bench_path)
 
-	if not apps:
-		apps = bench.get_installed_apps()
+	apps = apps or bench.apps
 
 	apps_dir = os.path.join(bench.name, "apps")
 

--- a/bench/utils/bench.py
+++ b/bench/utils/bench.py
@@ -84,12 +84,36 @@ def install_python_dev_dependencies(bench_path=".", apps=None, verbose=False):
 		apps = bench.get_installed_apps()
 
 	for app in apps:
+		pyproject_deps = None
 		app_path = os.path.join(bench_path, "apps", app)
-
+		pyproject_path = os.path.join(app_path, "pyproject.toml")
 		dev_requirements_path = os.path.join(app_path, "dev-requirements.txt")
 
-		if os.path.exists(dev_requirements_path):
+		if os.path.exists(pyproject_path):
+			pyproject_deps = _generate_dev_deps_pattern(pyproject_path)
+			if pyproject_deps:
+				bench.run(f"{bench.python} -m pip install {quiet_flag} --upgrade {pyproject_deps}")
+
+		if not pyproject_deps and os.path.exists(dev_requirements_path):
 			bench.run(f"{bench.python} -m pip install {quiet_flag} --upgrade -r {dev_requirements_path}")
+
+
+def _generate_dev_deps_pattern(pyproject_path):
+	try:
+		from tomli import loads
+	except ImportError:
+		from tomllib import loads
+
+	requirements_pattern = ""
+	pyroject_config = loads(open(pyproject_path).read())
+
+	try:
+		for pkg, version in pyroject_config['tool']['bench']['dev-dependencies'].items():
+			op = "=" if "=" not in version else ""
+			requirements_pattern += f"{pkg}{op}{version} "
+	except KeyError:
+		pass
+	return requirements_pattern
 
 
 def update_yarn_packages(bench_path=".", apps=None):


### PR DESCRIPTION
### Changes

Since support for pyproject.toml exists, Frappe has gotten rid of `requirements.txt` file. However, `dev-requirements.txt` file still existed in Frappe & other apps. With this, we can get rid of the separate dev-reqs file as well and replace it by defining the deps in pyproject under **[tool.bench.dev-dependencies]**

Example:

For Frappe, this transition will look like moving the contents of `dev-requirements.txt` as follows:

### Old Usage

```txt
# dev-requirements.txt
coverage==5.5
Faker~=13.12.1
pyngrok~=5.0.5
unittest-xml-reporting~=3.0.4
```

### New Usage

```txt
# pyproject.toml
[tool.bench.dev-dependencies]
coverage = "==5.5"
Faker = "~=13.12.1"
pyngrok = "~=5.0.5"
unittest-xml-reporting = "~=3.0.4"
```

### In Action

I've defined dev-dependencies in pyproject.toml for Frappe alone - notice the commands executed via `bench setup requirements`:

![Screenshot from 2022-06-16 18-33-54](https://user-images.githubusercontent.com/36654812/174075888-b0be69f1-598e-4135-aad9-b31e78aee094.png)


_Note: If dev-dependencies are defined in `pyproject.toml`, and a `dev-dependencies.txt` file exists - the txt file will be ignored._

Ref: https://github.com/frappe/frappe/pull/17174#discussion_r897572917