### PR TITLE
fix: Install gunicorn for production setup

### DIFF
--- a/bench/config/production_setup.py
+++ b/bench/config/production_setup.py
@@ -17,9 +17,11 @@ logger = logging.getLogger(bench.PROJECT_NAME)
 
 
 def setup_production_prerequisites():
-	"""Installs ansible, fail2banc, NGINX and supervisor"""
+	"""Installs ansible, gunicorn, fail2banc, NGINX and supervisor"""
 	if not which("ansible"):
 		exec_cmd(f"sudo {sys.executable} -m pip install ansible")
+	if not which("gunicorn"):
+		exec_cmd(f"bench pip install gunicorn")
 	if not which("fail2ban-client"):
 		exec_cmd("bench setup role fail2ban")
 	if not which("nginx"):


### PR DESCRIPTION
Related to https://github.com/frappe/frappe/pull/17482

Currently, gunicorn is added as a dependency for frappe. However gunicorn is not needed for non-production(dev, testing, CI etc) setups. 

Moving gunicorn installation to `bench setup production`.