### PR TITLE
fix(nginx)!: set `proxy_http_version` to `1.1`

### DIFF
--- a/bench/config/templates/nginx.conf
+++ b/bench/config/templates/nginx.conf
@@ -91,6 +91,7 @@ server {
 	}
 
 	location @webserver {
+		proxy_http_version 1.1;
 		proxy_set_header X-Forwarded-For $remote_addr;
 		proxy_set_header X-Forwarded-Proto $scheme;
 		proxy_set_header X-Frappe-Site-Name {{ site_name }};


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. Update necessary Documentation
 4. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/bench/blob/master/docs/contribution_guidelines.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

What type of a PR is this?

- [ ] Changes to Existing Features
- [ ] New Feature Submissions
- [x] Bug Fix
- [ ] Breaking Change (include change in API behaviours, etc.)

---

> Please provide enough information so that others can review your pull request:

This sets the `proxy_http_version` to `1.1` within the `@webserver` block.

---

> Explain the **details** for making this change. What existing problem does the pull request solve? The following checklist could help

The reason this change should be implemented is that when this is deployed in a Kubernetes environment with Istio, the proxy request fails with HTTP error 426 as the HTTP version is too low for envoy to handle. Setting it to `1.1` will solve the issue.

---

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

![image](https://user-images.githubusercontent.com/48422312/180673156-ad5291bc-3d02-4486-9b82-e7ea5f9e214e.png)


<!-- Add images/recordings to better visualize the change: expected/current behviour -->