### PR TITLE
fix: get-app on existing apps

### DIFF
--- a/bench/app.py
+++ b/bench/app.py
@@ -209,6 +209,9 @@ class App(AppMeta):
 			shutil.move(active_app_path, archived_app_path)
 			log(f"App moved from {active_app_path} to {archived_app_path}")
 
+		self.from_apps = False
+		self.on_disk = False
+
 	@step(title="Installing App {repo}", success="App {repo} Installed")
 	def install(
 		self,
@@ -419,7 +422,7 @@ def get_app(
 			"Do you want to continue and overwrite it?"
 		)
 	):
-		shutil.rmtree(cloned_path)
+		app.remove()
 		to_clone = True
 
 	if to_clone:


### PR DESCRIPTION
get-app to replace existing folder would fail due to bad url generation.

Changes
* Archive old repo instead of overwritting
* Resetting flags in App instance

---

Traceback:

```bash
 % bench get-app payments
A directory for the application 'payments' already exists. Do you want to continue and overwrite it? [y/N]: y
Getting payments
$ git clone payments --branch develop  --origin upstream
fatal: repository 'payments' does not exist
ERROR: 
Traceback (most recent call last):
  File "/home/frappe/.local/bin/bench", line 33, in <module>
    sys.exit(load_entry_point('frappe-bench', 'console_scripts', 'bench')())
  File "/home/frappe/bench/bench/cli.py", line 121, in cli
    raise e
  File "/home/frappe/bench/bench/cli.py", line 111, in cli
    bench_command()
  File "/home/frappe/.local/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/home/frappe/.local/lib/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/home/frappe/.local/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/.local/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/frappe/.local/lib/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/home/frappe/bench/bench/commands/make.py", line 156, in get_app
    get_app(
  File "/home/frappe/bench/bench/app.py", line 426, in get_app
    app.get()
  File "/home/frappe/bench/bench/utils/render.py", line 110, in wrapper_fn
    return fn(*args, **kwargs)
  File "/home/frappe/bench/bench/app.py", line 192, in get
    self.bench.run(
  File "/home/frappe/bench/bench/bench.py", line 47, in run
    return exec_cmd(cmd, cwd=cwd or self.cwd)
  File "/home/frappe/bench/bench/utils/__init__.py", line 153, in exec_cmd
    raise CommandFailedError
bench.exceptions.CommandFailedError
```