### PR TITLE
fix: use specified python for venv

### DIFF
--- a/bench/bench.py
+++ b/bench/bench.py
@@ -354,7 +354,7 @@ class BenchSetup(Base):
 			if virtualenv:
 				self.run(f"{virtualenv} {quiet_flag} env -p {python}")
 			else:
-				venv = get_venv_path(verbose=verbose)
+				venv = get_venv_path(verbose=verbose, python=python)
 				self.run(f"{venv} env")
 
 		self.pip()

--- a/bench/utils/bench.py
+++ b/bench/utils/bench.py
@@ -32,14 +32,13 @@ def get_virtualenv_path(verbose=False):
 	return virtualenv_path
 
 
-def get_venv_path(verbose=False):
-	current_python = sys.executable
+def get_venv_path(verbose=False, python="python3"):
 	with open(os.devnull, "wb") as devnull:
 		is_venv_installed = not subprocess.call(
-			[current_python, "-m", "venv", "--help"], stdout=devnull
+			[python, "-m", "venv", "--help"], stdout=devnull
 		)
 	if is_venv_installed:
-		return f"{current_python} -m venv"
+		return f"{python} -m venv"
 	else:
 		log("virtualenv cannot be found", level=2)
 


### PR DESCRIPTION
We can provide the desired python executable to `bench init`. This usually uses `virtualenv` to create the environment with the desired python. If `virtualenv` is not available, it fell back to using the `venv` module of the **system python**, ignoring the desired python.

This PR makes `venv` use the desired python.

In case #1313 / #1327 get merged, this becomes obsolete. But I'd say we can merge this one before these bigger PRs.