### PR TITLE
chore: Add logo for Dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 <div align="center">
-	<img src="https://github.com/frappe/design/raw/master/logos/png/bench-logo.png" height="128">
+	<picture>
+		<source media="(prefers-color-scheme: dark)" srcset="https://github.com/frappe/design/raw/master/logos/png/bench-logo-dark.png">
+		<img src="https://github.com/frappe/design/raw/master/logos/png/bench-logo.png" height="128">
+	</picture>
 	<h2>Bench</h2>
 </div>
 


### PR DESCRIPTION
Until now we had only a bright mode theme in the README, although @marination and I had made more (ref: https://github.com/frappe/bench/issues/1219). Thanks to https://www.stefanjudis.com/notes/how-to-define-dark-light-mode-images-in-github-markdown/ and @ankush telling me this was possible 😄. Switching your theme switches the logo too!

### Light theme:

![image](https://user-images.githubusercontent.com/36654812/181613970-faab2b0b-0348-485c-820d-9086290dd51c.png)

### Dark theme:

![image](https://user-images.githubusercontent.com/36654812/181614044-51ad5e63-525b-4b98-aa2c-2fe139fdbe52.png)

---

Committed the logo to https://github.com/frappe/design/commit/daf2190f55cf6fea90f7f17086148fe30ce57ed2