### PR TITLE
fix!: Remove backup command

### DIFF
--- a/bench/commands/__init__.py
+++ b/bench/commands/__init__.py
@@ -73,7 +73,6 @@ bench_command.add_command(switch_to_develop)
 
 from bench.commands.utils import (
 	backup_all_sites,
-	backup_site,
 	bench_src,
 	clear_command_cache,
 	disable_production,
@@ -105,7 +104,6 @@ bench_command.add_command(set_redis_cache_host)
 bench_command.add_command(set_redis_queue_host)
 bench_command.add_command(set_redis_socketio_host)
 bench_command.add_command(download_translations)
-bench_command.add_command(backup_site)
 bench_command.add_command(backup_all_sites)
 bench_command.add_command(renew_lets_encrypt)
 bench_command.add_command(disable_production)

--- a/bench/commands/utils.py
+++ b/bench/commands/utils.py
@@ -1,6 +1,5 @@
 # imports - standard imports
 import os
-import sys
 
 # imports - third party imports
 import click
@@ -133,18 +132,6 @@ def renew_lets_encrypt():
 	from bench.config.lets_encrypt import renew_certs
 
 	renew_certs()
-
-
-@click.command("backup", help="Backup single site")
-@click.argument("site")
-def backup_site(site):
-	from bench.bench import Bench
-	from bench.utils.system import backup_site
-
-	if site not in Bench(".").sites:
-		print(f"Site `{site}` not found")
-		sys.exit(1)
-	backup_site(site, bench_path=".")
 
 
 @click.command("backup-all-sites", help="Backup all sites in current bench")


### PR DESCRIPTION
bench's backup command is redundant and acts as a wrapper over Frappe's
backup command. This caused a conflict with Frappe's CLI after the
resolution correction introduced via a6f196440ad8c9b65a5bbc31a88d8c80f2ba2ded

ref: https://github.com/frappe/frappe/runs/7592331617?check_suite_focus=true