### PR TITLE
feat(nginx): Allow logging settings as site/combined/none

### DIFF
--- a/bench/commands/setup.py
+++ b/bench/commands/setup.py
@@ -7,6 +7,7 @@ import click
 
 # imports - module imports
 from bench.utils import exec_cmd, run_playbook, which
+from bench.utils.cli import SugaredOption
 
 
 @click.group(help="Setup command group for enabling setting up a Frappe environment")
@@ -29,12 +30,19 @@ def setup_sudoers(user):
 	"--logging", default="combined", type=click.Choice(["none", "site", "combined"])
 )
 @click.option(
+	"--log_format",
+	help="Specify the log_format for nginx. Use none or '' to not set a value.",
+	only_if_set=["logging"],
+	cls=SugaredOption,
+	default="main",
+)
+@click.option(
 	"--yes", help="Yes to regeneration of nginx config file", default=False, is_flag=True
 )
-def setup_nginx(yes=False, logging="combined"):
+def setup_nginx(yes=False, logging="combined", log_format=None):
 	from bench.config.nginx import make_nginx_conf
 
-	make_nginx_conf(bench_path=".", yes=yes, logging=logging)
+	make_nginx_conf(bench_path=".", yes=yes, logging=logging, log_format=log_format)
 
 
 @click.command("reload-nginx", help="Checks NGINX config file and reloads service")

--- a/bench/commands/setup.py
+++ b/bench/commands/setup.py
@@ -26,12 +26,15 @@ def setup_sudoers(user):
 
 @click.command("nginx", help="Generate configuration files for NGINX")
 @click.option(
+	"--logging", default="combined", type=click.Choice(["none", "site", "combined"])
+)
+@click.option(
 	"--yes", help="Yes to regeneration of nginx config file", default=False, is_flag=True
 )
-def setup_nginx(yes=False):
+def setup_nginx(yes=False, logging="combined"):
 	from bench.config.nginx import make_nginx_conf
 
-	make_nginx_conf(bench_path=".", yes=yes)
+	make_nginx_conf(bench_path=".", yes=yes, logging=logging)
 
 
 @click.command("reload-nginx", help="Checks NGINX config file and reloads service")

--- a/bench/config/nginx.py
+++ b/bench/config/nginx.py
@@ -9,11 +9,12 @@ import click
 
 # imports - module imports
 import bench
+import bench.config
 from bench.bench import Bench
 from bench.utils import get_bench_name
 
 
-def make_nginx_conf(bench_path, yes=False, logging=None):
+def make_nginx_conf(bench_path, yes=False, logging=None, log_format=None):
 	conf_path = os.path.join(bench_path, "config", "nginx.conf")
 
 	if not yes and os.path.exists(conf_path):
@@ -43,8 +44,13 @@ def make_nginx_conf(bench_path, yes=False, logging=None):
 		"allow_rate_limiting": allow_rate_limiting,
 		# for nginx map variable
 		"random_string": "".join(random.choice(string.ascii_lowercase) for i in range(7)),
-		"logging": logging,
 	}
+
+	if logging and logging != "none":
+		_log_format = ""
+		if log_format and log_format != "none":
+			_log_format = log_format
+		template_vars["logging"] = {"level": logging, "log_format": _log_format}
 
 	if allow_rate_limiting:
 		template_vars.update(
@@ -281,8 +287,6 @@ def use_wildcard_certificate(bench_path, ret):
 
 
 def get_error_pages():
-	import bench
-
 	bench_app_path = os.path.abspath(bench.__path__[0])
 	templates = os.path.join(bench_app_path, "config", "templates")
 

--- a/bench/config/nginx.py
+++ b/bench/config/nginx.py
@@ -13,7 +13,7 @@ from bench.bench import Bench
 from bench.utils import get_bench_name
 
 
-def make_nginx_conf(bench_path, yes=False):
+def make_nginx_conf(bench_path, yes=False, logging=None):
 	conf_path = os.path.join(bench_path, "config", "nginx.conf")
 
 	if not yes and os.path.exists(conf_path):
@@ -43,6 +43,7 @@ def make_nginx_conf(bench_path, yes=False):
 		"allow_rate_limiting": allow_rate_limiting,
 		# for nginx map variable
 		"random_string": "".join(random.choice(string.ascii_lowercase) for i in range(7)),
+		"logging": logging,
 	}
 
 	if allow_rate_limiting:

--- a/bench/config/templates/nginx.conf
+++ b/bench/config/templates/nginx.conf
@@ -114,11 +114,18 @@ server {
 
 	{% endfor -%}
 
-	# logs in var
+	{%- if logging == "site" -%}
+
 	access_log  /var/log/nginx/{{ site_name }}_access.log  main;
 	error_log  /var/log/nginx/{{ site_name }}_error.log;
 
-	
+	{%- elif logging == "combined" -%}
+
+	access_log  /var/log/nginx/access.log  main;
+	error_log  /var/log/nginx/error.log;
+
+	{%- endif %}
+
 	# optimizations
 	sendfile on;
 	keepalive_timeout 15;

--- a/bench/config/templates/nginx.conf
+++ b/bench/config/templates/nginx.conf
@@ -31,7 +31,7 @@ server {
 	{% if allow_rate_limiting %}
 	limit_conn per_host_{{ bench_name_hash }} 8;
 	{% endif %}
-	
+
 	proxy_buffer_size 128k;
 	proxy_buffers 4 256k;
 	proxy_busy_buffers_size 256k;
@@ -114,16 +114,18 @@ server {
 
 	{% endfor -%}
 
-	{%- if logging == "site" -%}
+	{% if logging %}
+	{%- if logging.level == "site" -%}
 
-	access_log  /var/log/nginx/{{ site_name }}_access.log  main;
+	access_log  /var/log/nginx/{{ site_name }}_access.log  {{ logging.log_format }};
 	error_log  /var/log/nginx/{{ site_name }}_error.log;
 
-	{%- elif logging == "combined" -%}
+	{%- elif logging.level == "combined" -%}
 
-	access_log  /var/log/nginx/access.log  main;
+	access_log  /var/log/nginx/access.log {{ logging.log_format }};
 	error_log  /var/log/nginx/error.log;
 
+	{%- endif %}
 	{%- endif %}
 
 	# optimizations


### PR DESCRIPTION
Defaults to NGINX access + error logs combined for all sites. Site level granularity in log generation is optional, and so is not logging at all.

NGINX Guides: https://docs.nginx.com/nginx/admin-guide/monitoring/logging/

> Note: If you haven't installed NGINX via `bench install nginx`, then run `bench setup nginx --log_format ''` to set no log_format

Closes https://github.com/frappe/bench/issues/1351 caused by https://github.com/frappe/bench/pull/1308
