### PR TITLE
chore(readme): Remove PyPI unsupported picture tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 <div align="center">
-	<picture>
-		<source media="(prefers-color-scheme: dark)" srcset="https://github.com/frappe/design/raw/master/logos/png/bench-logo-dark.png">
-		<img src="https://github.com/frappe/design/raw/master/logos/png/bench-logo.png" height="128">
-	</picture>
+	<img src="https://github.com/frappe/design/raw/master/logos/png/bench-logo.png" height="128">
 	<h2>Bench</h2>
 </div>
 


### PR DESCRIPTION
Getting rid of the picture tag on v5.x branch which publishes to PyPI while leaving it on develop which is Bench's landing page on GitHub which supports it (via #1341)

![image](https://user-images.githubusercontent.com/36654812/182792409-2b474996-3acf-4e96-a45d-ea57a8a46947.png)

ref: https://pypi.org/project/frappe-bench/5.13.3/