### PR TITLE
fix: dont use glob pattern for `python` exec

### DIFF
--- a/bench/bench.py
+++ b/bench/bench.py
@@ -70,7 +70,7 @@ class Bench(Base, Validator):
 
 	@property
 	def python(self) -> str:
-		return get_env_cmd("python*", bench_path=self.name)
+		return get_env_cmd("python", bench_path=self.name)
 
 	@property
 	def shallow_clone(self) -> bool:

--- a/bench/cli.py
+++ b/bench/cli.py
@@ -188,13 +188,13 @@ def change_uid():
 
 
 def app_cmd(bench_path="."):
-	f = get_env_cmd("python*", bench_path=bench_path)
+	f = get_env_cmd("python", bench_path=bench_path)
 	os.chdir(os.path.join(bench_path, "sites"))
 	os.execv(f, [f] + ["-m", "frappe.utils.bench_helper"] + sys.argv[1:])
 
 
 def frappe_cmd(bench_path="."):
-	f = get_env_cmd("python*", bench_path=bench_path)
+	f = get_env_cmd("python", bench_path=bench_path)
 	os.chdir(os.path.join(bench_path, "sites"))
 	os.execv(f, [f] + ["-m", "frappe.utils.bench_helper", "frappe"] + sys.argv[1:])
 
@@ -207,7 +207,7 @@ def get_frappe_commands():
 
 
 def get_frappe_help(bench_path="."):
-	python = get_env_cmd("python*", bench_path=bench_path)
+	python = get_env_cmd("python", bench_path=bench_path)
 	sites_path = os.path.join(bench_path, "sites")
 	try:
 		out = get_cmd_output(

--- a/bench/commands/make.py
+++ b/bench/commands/make.py
@@ -227,5 +227,5 @@ def pip(ctx, args):
 
 	from bench.utils.bench import get_env_cmd
 
-	env_py = get_env_cmd("python*")
+	env_py = get_env_cmd("python")
 	os.execv(env_py, (env_py, "-m", "pip") + args)

--- a/bench/utils/__init__.py
+++ b/bench/utils/__init__.py
@@ -231,7 +231,7 @@ def run_frappe_cmd(*args, **kwargs):
 	from bench.utils.bench import get_env_cmd
 
 	bench_path = kwargs.get("bench_path", ".")
-	f = get_env_cmd("python*", bench_path=bench_path)
+	f = get_env_cmd("python", bench_path=bench_path)
 	sites_dir = os.path.join(bench_path, "sites")
 
 	is_async = not from_command_line
@@ -386,7 +386,7 @@ def get_env_frappe_commands(bench_path=".") -> List:
 	"""
 	from bench.utils.bench import get_env_cmd
 
-	python = get_env_cmd("python*", bench_path=bench_path)
+	python = get_env_cmd("python", bench_path=bench_path)
 	sites_path = os.path.join(bench_path, "sites")
 
 	try:


### PR DESCRIPTION
This causes executables like `python-barcode` to get detected 😄 

I printed `existing_python_bins` in `get_env_cmd`:
```
['./env/bin/python-barcode', './env/bin/python3', './env/bin/python', './env/bin/python3.10']
```

It doesn't help that the incorrect bin is the first one..

Refer:
https://discuss.erpnext.com/t/python-barcode-error-while-installing-with-erpnext-v14/92981/7

I think having an executable called `python` is a fair expectation for a virtual environment. Existence of "local" should still get respected.