### PR TITLE
fix(DX): make warnings go to stderr

### DIFF
--- a/bench/cli.py
+++ b/bench/cli.py
@@ -123,7 +123,7 @@ def cli():
 		bench_command()
 
 	if cmd_from_sys in bench_command.commands:
-		with execute_cmd(check_for_update=not is_cli_command, command=command, logger=logger):
+		with execute_cmd(check_for_update=is_cli_command, command=command, logger=logger):
 			bench_command()
 
 	if in_bench:

--- a/bench/utils/__init__.py
+++ b/bench/utils/__init__.py
@@ -79,7 +79,7 @@ def is_valid_frappe_branch(frappe_path: str, frappe_branch: str):
 			raise InvalidRemoteException(f"Invalid frappe path: {frappe_path}") from e
 
 
-def log(message, level=0, no_log=False):
+def log(message, level=0, no_log=False, stderr=False):
 	import bench
 	import bench.cli
 
@@ -96,13 +96,13 @@ def log(message, level=0, no_log=False):
 		bench.LOG_BUFFER.append({"prefix": prefix, "message": message, "color": color})
 
 	if no_log:
-		click.secho(message, fg=color)
+		click.secho(message, fg=color, err=stderr)
 	else:
 		loggers = {2: logger.error, 3: logger.warning}
 		level_logger = loggers.get(level, logger.info)
 
 		level_logger(message)
-		click.secho(f"{prefix}: {message}", fg=color)
+		click.secho(f"{prefix}: {message}", fg=color, err=stderr)
 
 
 def check_latest_version():
@@ -125,7 +125,7 @@ def check_latest_version():
 		local_version = Version(VERSION)
 
 		if pypi_version > local_version:
-			log(f"A newer version of bench is available: {local_version} → {pypi_version}")
+			log(f"A newer version of bench is available: {local_version} → {pypi_version}", stderr=True)
 
 
 def pause_exec(seconds=10):


### PR DESCRIPTION
This doesn't fix all the warnings that clobber stdout but adds an arg to make logs got to stderr instead of stdout. 
If you find more similar warnings feel free to send PR. 


ref: https://discuss.erpnext.com/t/bench-update-notification-message/93126/3 