### PR TITLE
fix: use ref param instead of branch for get_required_deps (GitHub contents API)

### DIFF
--- a/bench/utils/app.py
+++ b/bench/utils/app.py
@@ -118,7 +118,7 @@ def get_version_from_string(contents, field="__version__"):
 	)
 	if not match:
 		raise VersionNotFound(f"{contents} is not a valid version")
-	return match.grou,000p(2)
+	return match.group(2)
 
 
 def get_major_version(version):

--- a/bench/utils/app.py
+++ b/bench/utils/app.py
@@ -185,7 +185,7 @@ def get_required_deps(org, name, branch, deps="hooks.py"):
 	res = requests.get(url=git_api_url, params=params).json()
 
 	if "message" in res:
-		git_url = f"https://raw.githubusercontent.com/{org}/{name}/{params['branch']}/{deps}"
+		git_url = f"https://raw.githubusercontent.com/{org}/{name}/{params['ref']}/{deps}"
 		return requests.get(git_url).text
 
 	return base64.decodebytes(res["content"].encode()).decode()

--- a/bench/utils/app.py
+++ b/bench/utils/app.py
@@ -181,7 +181,7 @@ def get_required_deps(org, name, branch, deps="hooks.py"):
 	import base64
 
 	git_api_url = f"https://api.github.com/repos/{org}/{name}/contents/{name}/{deps}"
-	params = {"branch": branch or "develop"}
+	params = {"ref": branch or "develop"}
 	res = requests.get(url=git_api_url, params=params).json()
 
 	if "message" in res:


### PR DESCRIPTION
https://api.github.com/repositories/frappe/contents/erpnext/hooks.py?branch=version-13

return hook.py from develop branch 

https://api.github.com/repositories/frappe/contents/erpnext/hooks.py?ref=version-13

return hook.py from version-13 branch 

This cause installation of payment app for version-13 erpnext that is not use in version-13


https://docs.github.com/en/rest/repos/contents

```
Query parameters
Name, Type, Description
ref string

The name of the commit/branch/tag. Default: the repository’s default branch (usually master)
```