### PR TITLE
fix: bench must have same dependencies as frappe

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 ]
 dependencies = [
     "Click>=7.0",
-    "GitPython~=2.1.15",
+    "GitPython~=3.1.14",
     "honcho",
     "Jinja2~=3.0.3",
     "python-crontab~=2.6.0",


### PR DESCRIPTION
```
frappe@XXXXXXX:~/bench-13$ bench pip install --upgrade frappe-bench
Collecting frappe-bench
  Downloading frappe_bench-5.14.3-py3-none-any.whl (145 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 145.4/145.4 kB 9.1 MB/s eta 0:00:00
Requirement already satisfied: click>=7.0 in ./env/lib/python3.8/site-packages (from frappe-bench) (7.1.2)
Requirement already satisfied: setuptools>40.9.0 in ./env/lib/python3.8/site-packages (from frappe-bench) (62.1.0)
Requirement already satisfied: jinja2~=3.0.3 in ./env/lib/python3.8/site-packages (from frappe-bench) (3.0.3)
Requirement already satisfied: semantic-version~=2.8.2 in ./env/lib/python3.8/site-packages (from frappe-bench) (2.8.5)
Collecting tomli
  Downloading tomli-2.0.1-py3-none-any.whl (12 kB)
Collecting gitpython~=2.1.15
  Downloading GitPython-2.1.15-py2.py3-none-any.whl (452 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 452.8/452.8 kB 41.9 MB/s eta 0:00:00
Collecting python-crontab~=2.6.0
  Downloading python-crontab-2.6.0.tar.gz (55 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 55.3/55.3 kB 17.4 MB/s eta 0:00:00
  Preparing metadata (setup.py) ... done
Collecting honcho
  Downloading honcho-1.1.0-py2.py3-none-any.whl (21 kB)
Requirement already satisfied: requests in ./env/lib/python3.8/site-packages (from frappe-bench) (2.25.1)
Collecting gitdb2<3,>=2
  Downloading gitdb2-2.0.6-py2.py3-none-any.whl (63 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 64.0/64.0 kB 17.3 MB/s eta 0:00:00
Requirement already satisfied: MarkupSafe>=2.0 in ./env/lib/python3.8/site-packages (from jinja2~=3.0.3->frappe-bench) (2.1.1)
Requirement already satisfied: python-dateutil in ./env/lib/python3.8/site-packages (from python-crontab~=2.6.0->frappe-bench) (2.8.2)
Requirement already satisfied: chardet<5,>=3.0.2 in ./env/lib/python3.8/site-packages (from requests->frappe-bench) (4.0.0)
Requirement already satisfied: certifi>=2017.4.17 in ./env/lib/python3.8/site-packages (from requests->frappe-bench) (2021.10.8)
Requirement already satisfied: idna<3,>=2.5 in ./env/lib/python3.8/site-packages (from requests->frappe-bench) (2.10)
Requirement already satisfied: urllib3<1.27,>=1.21.1 in ./env/lib/python3.8/site-packages (from requests->frappe-bench) (1.26.9)
Collecting smmap2>=2.0.0
  Downloading smmap2-3.0.1-py3-none-any.whl (1.1 kB)
Requirement already satisfied: six>=1.5 in ./env/lib/python3.8/site-packages (from python-dateutil->python-crontab~=2.6.0->frappe-bench) (1.15.0)
Requirement already satisfied: smmap>=3.0.1 in ./env/lib/python3.8/site-packages (from smmap2>=2.0.0->gitdb2<3,>=2->gitpython~=2.1.15->frappe-bench) (5.0.0)
Building wheels for collected packages: python-crontab
  Building wheel for python-crontab (setup.py) ... done
  Created wheel for python-crontab: filename=python_crontab-2.6.0-py3-none-any.whl size=25805 sha256=bcad7063f328dc8fdc71b204744ffffdd5b5105f4b33f5bf1cc2e3a0ce352157
  Stored in directory: /home/frappe/.cache/pip/wheels/15/b1/cf/02130d15e4defa826a6cc5cbf2619571bb85eff8998a144fa0
Successfully built python-crontab
Installing collected packages: honcho, tomli, smmap2, python-crontab, gitdb2, gitpython, frappe-bench
  Attempting uninstall: gitpython
    Found existing installation: GitPython 3.1.27
    Uninstalling GitPython-3.1.27:
      Successfully uninstalled GitPython-3.1.27
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
frappe 13.40.0 requires GitPython~=3.1.14, but you have gitpython 2.1.15 which is incompatible.
Successfully installed frappe-bench-5.14.3 gitdb2-2.0.6 gitpython-2.1.15 honcho-1.1.0 python-crontab-2.6.0 smmap2-3.0.1 tomli-2.0.1
```

In bench "GitPython~=2.1.15" but in frappe GitPython~=3.1.14

Problem when deploying bench on frappe...

Ok there is no need to install frappe-bench in venv of bench but why not ?

