### PR TITLE
fix: shutil.rmtree does not support symlink

### DIFF
--- a/bench/app.py
+++ b/bench/app.py
@@ -201,7 +201,10 @@ class App(AppMeta):
 		active_app_path = os.path.join("apps", self.name)
 
 		if no_backup:
-			shutil.rmtree(active_app_path)
+			if not os.path.islink(active_app_path):
+				shutil.rmtree(active_app_path)
+			else:
+				os.remove(active_app_path)
 			log(f"App deleted from {active_app_path}")
 		else:
 			archived_path = os.path.join("archived", "apps")


### PR DESCRIPTION
**Introduced In:**  https://github.com/frappe/bench/pull/1315

https://docs.python.org/3/library/shutil.html#shutil.rmtree
> Delete an entire directory tree; path must point to a directory **(but not a symbolic link to a directory).** 