### PR TITLE
fix: FileNotFound bug in App.py

### DIFF
--- a/bench/app.py
+++ b/bench/app.py
@@ -198,7 +198,7 @@ class App(AppMeta):
 
 	@step(title="Archiving App {repo}", success="App {repo} Archived")
 	def remove(self, no_backup: bool = False):
-		active_app_path = os.path.join("apps", self.name)
+		active_app_path = os.path.join("apps", self.repo)
 
 		if no_backup:
 			if not os.path.islink(active_app_path):


### PR DESCRIPTION
Hello everyone..

When the user chooses to overwrite the app while installing it using `bench get-app`, the process results in a FileNotFound error because of a bug in the `remove` method of `App` class..

In the `remove` method the `self.name` is used to get the active app path which results in getting the wrong path since the variable holds the repo url and not the repo name.
**Code**
`active_app_path = os.path.join("apps", self.name)`
**Result**
`apps/https://github.com/user/repo`

On the other hand, the variable `self.repo` holds the name of the repo so if it's used inseted of `self.name`, it will return the right path of active app.
**Code**
`active_app_path = os.path.join("apps", self.repo)`
**Result**
`apps/repo`

I hope that I'm right and that this change fixes a problem faced by some users.

Best regards