### PR TITLE
fix: Restart supervisor / systemd on bench update

### DIFF
--- a/bench/utils/bench.py
+++ b/bench/utils/bench.py
@@ -398,6 +398,9 @@ def update(
 
 	if not (pull or patch or build or requirements):
 		pull, patch, build, requirements = True, True, True, True
+		
+		if not restart_supervisor and not restart_systemd:
+			restart_supervisor, restart_systemd = True, True
 
 	if apps and pull:
 		apps = [app.strip() for app in re.split(",| ", apps) if app]


### PR DESCRIPTION
**Problem:** When you run a simple "bench update", the supervisor processes are not being reloaded. The web workers and background workers keeps running on the previously compiled code. This is a *huge* problem that causes old/stale code to run even after updating, causing unexpected errors!

**Solution:** Make the default behavior of _"bench update" without arguments_ consider the `restart_supervisor` and `restart_systemd` options as True.

The system admin would still have the option to disable the `restart_supervisor` and `restart_systemd` configurations from `common_site_config.json`

**Note:** I only know that we need to restart supervisor, not sure if systemd should also be restarted by default but there's no harm in it since it's disabled in config by default.

**Screenshot**
No supervisorctl restart
![image](https://user-images.githubusercontent.com/328330/203559843-727559ff-55b2-4040-8625-4ee9d8379d55.png)
