### PR TITLE
fix: restart proc manager if set in config

### DIFF
--- a/bench/bench.py
+++ b/bench/bench.py
@@ -147,7 +147,7 @@ class Bench(Base, Validator):
 
 		if conf.get("developer_mode"):
 			restart_process_manager(bench_path=self.name, web_workers=web)
-		if supervisor and conf.get("restart_supervisor_on_update"):
+		if supervisor or conf.get("restart_supervisor_on_update"):
 			restart_supervisor_processes(bench_path=self.name, web_workers=web)
 		if systemd and conf.get("restart_systemd_on_update"):
 			restart_systemd_processes(bench_path=self.name, web_workers=web)

--- a/bench/config/systemd.py
+++ b/bench/config/systemd.py
@@ -105,7 +105,7 @@ def generate_systemd_config(
 	setup_web_config(bench_info, bench_path)
 	setup_redis_config(bench_info, bench_path)
 
-	update_config({"restart_systemd_on_update": True}, bench_path=bench_path)
+	update_config({"restart_systemd_on_update": False}, bench_path=bench_path)
 	update_config({"restart_supervisor_on_update": False}, bench_path=bench_path)
 
 


### PR DESCRIPTION
This used to be the behaviour before, looks like it was changed unintentionally.



https://github.com/frappe/bench/blob/cbf30b4e6a77132bb242606e1d3b3367fab4f3ee/bench/utils/bench.py#L417

Current behaviour doesn't make much sense. It requires passing a flag + setting config both to trigger restart.

alt to https://github.com/frappe/bench/pull/1390