### PR TITLE
perf: single worker in development install

### DIFF
--- a/bench/config/templates/Procfile
+++ b/bench/config/templates/Procfile
@@ -11,9 +11,7 @@ watch: bench watch
 {% endif %}
 {% if use_rq -%}
 schedule: bench schedule
-worker_short: bench worker --queue short 1>> logs/worker.log 2>> logs/worker.error.log
-worker_long: bench worker --queue long 1>> logs/worker.log 2>> logs/worker.error.log
-worker_default: bench worker --queue default 1>> logs/worker.log 2>> logs/worker.error.log
+worker: bench worker 1>> logs/worker.log 2>> logs/worker.error.log
 {% for worker_name, worker_details in workers.items() %}
 worker_{{ worker_name }}: bench worker --queue {{ worker_name }} 1>> logs/worker.log 2>> logs/worker.error.log
 {% endfor %}


### PR DESCRIPTION
Most developers don't need 3 separate workers in development.  This changes procfile to use single worker to consume from all queues in development. 


Pros:
- Lighter development setups


Cons:
- Not "equivalent to production" - not required in most cases so eh. 

You can still edit procfile to start whatever process you want anyway.


related: https://github.com/frappe/frappe/pull/18995