### PR TITLE
fix: migrate env

### DIFF
--- a/bench/utils/bench.py
+++ b/bench/utils/bench.py
@@ -218,7 +218,7 @@ def migrate_env(python, backup=False):
 		venv_creation = exec_cmd(f"{virtualenv} --python {python} {pvenv}")
 
 		apps = " ".join([f"-e {os.path.join('apps', app)}" for app in bench.apps])
-		packages_setup = exec_cmd(f"{pvenv} -m pip install --upgrade {apps}")
+		packages_setup = exec_cmd(f"{pvenv}/bin/python -m pip install --upgrade {apps}")
 
 		logger.log(f"Migration Successful to {python}")
 	except Exception:

--- a/bench/utils/bench.py
+++ b/bench/utils/bench.py
@@ -175,10 +175,6 @@ def migrate_env(python, backup=False):
 	nvenv = "env"
 	path = os.getcwd()
 	python = which(python)
-	virtualenv = which("virtualenv")
-	if not virtualenv:
-		raise FileNotFoundError("`virtualenv` not found. Install it and try again.")
-
 	pvenv = os.path.join(path, nvenv)
 
 	# Clear Cache before Bench Dies.
@@ -218,7 +214,7 @@ def migrate_env(python, backup=False):
 
 	try:
 		logger.log(f"Setting up a New Virtual {python} Environment")
-		exec_cmd(f"{virtualenv} --python {python} {pvenv}")
+		exec_cmd(f"{python} -m venv {pvenv}")
 
 		# Install frappe first
 		_install_app("frappe")

--- a/bench/utils/bench.py
+++ b/bench/utils/bench.py
@@ -177,6 +177,15 @@ def migrate_env(python, backup=False):
 	python = which(python)
 	pvenv = os.path.join(path, nvenv)
 
+	if python.startswith(pvenv):
+		# The supplied python version is in active virtualenv which we are about to nuke.
+		click.secho(
+			"Python version supplied is present in currently sourced virtual environment.\n"
+			"`deactiviate` the current virtual environment before migrating environments.",
+			fg="yellow",
+		)
+		sys.exit(1)
+
 	# Clear Cache before Bench Dies.
 	try:
 		config = bench.conf

--- a/bench/utils/bench.py
+++ b/bench/utils/bench.py
@@ -223,7 +223,8 @@ def migrate_env(python, backup=False):
 		logger.log(f"Migration Successful to {python}")
 	except Exception:
 		if venv_creation or packages_setup:
-			logger.warning("Migration Error")
+			logger.warning("Migration Error", exc_info=True)
+		raise
 
 
 def validate_upgrade(from_ver, to_ver, bench_path="."):


### PR DESCRIPTION
- dont fail silently
- Use correct path for python exec (`bench/env` -> `bench/env/bin/python`)
- Install frappe first and re-install one app at time.
- Use `venv` instead of `virtualenv`
- Don't attmept to migrate if target is present in current venv (LOL?)


Tested with.

- 3.7 -> 3.10
- 3.10 -> 3.11
- 3.11 -> 3.10