### PR TITLE
fix: Add `--no-restart` flag to `init` and `get-app` bench commands

### DIFF
--- a/bench/app.py
+++ b/bench/app.py
@@ -346,6 +346,7 @@ def get_app(
 	soft_link=False,
 	init_bench=False,
 	resolve_deps=False,
+	no_restart=False,
 ):
 	"""bench get-app clones a Frappe App from remote (GitHub or any other git server),
 	and installs it on the current bench. This also resolves dependencies based on the
@@ -366,6 +367,8 @@ def get_app(
 	branch = app.tag
 	bench_setup = False
 	restart_bench = not init_bench
+	if no_restart:
+		restart_bench = False
 	frappe_path, frappe_branch = None, None
 
 	if resolve_deps:

--- a/bench/commands/make.py
+++ b/bench/commands/make.py
@@ -38,6 +38,7 @@ import click
 )
 @click.option("--skip-assets", is_flag=True, default=False, help="Do not build assets")
 @click.option("--install-app", help="Install particular app after initialization")
+@click.option("--no-restart", is_flag=True, default=False, help="Stops bench reload after installing app")
 @click.option("--verbose", is_flag=True, help="Verbose output during install")
 def init(
 	path,
@@ -50,6 +51,7 @@ def init(
 	verbose,
 	skip_redis_config_generation,
 	clone_without_update,
+	no_restart,
 	ignore_exist=False,
 	skip_assets=False,
 	python="python3",
@@ -79,6 +81,7 @@ def init(
 			skip_assets=skip_assets,
 			python=python,
 			verbose=verbose,
+			no_restart=no_restart,
 		)
 		log(f"Bench {path} initialized", level=1)
 	except SystemExit:
@@ -143,9 +146,11 @@ def drop(path):
 	default=False,
 	help="Resolve dependencies before installing app",
 )
+@click.option("--no-restart", is_flag=True, default=False, help="Stops bench reload after installing app")
 def get_app(
 	git_url,
 	branch,
+	no_restart,
 	name=None,
 	overwrite=False,
 	skip_assets=False,
@@ -164,6 +169,7 @@ def get_app(
 		soft_link=soft_link,
 		init_bench=init_bench,
 		resolve_deps=resolve_deps,
+		no_restart=no_restart,
 	)
 
 

--- a/bench/utils/system.py
+++ b/bench/utils/system.py
@@ -35,6 +35,7 @@ def init(
 	skip_assets=False,
 	python="python3",
 	install_app=None,
+	no_restart=False,
 ):
 	"""Initialize a new bench directory
 
@@ -83,6 +84,7 @@ def init(
 			skip_assets=True,
 			verbose=verbose,
 			resolve_deps=False,
+			no_restart=no_restart,
 		)
 
 		# fetch remote apps using config file - deprecate this!


### PR DESCRIPTION
Reason:
In FC, whenever you build a new deploy candidate, it used to fail with the latest bench version because of bench restarting services at the end of FF/any app installation (`supervisorctl restart frappe`). This flag forcefully stops that behavior.

After this change everything seems to work in FC.