### PR TITLE
refactor: single worker for working short+default

### DIFF
--- a/bench/config/templates/supervisor.conf
+++ b/bench/config/templates/supervisor.conf
@@ -24,7 +24,7 @@ user={{ user }}
 directory={{ bench_dir }}
 
 [program:{{ bench_name }}-frappe-default-worker]
-command={{ bench_cmd }} worker --queue default
+command={{ bench_cmd }} worker --queue short,default
 priority=4
 autostart=true
 autorestart=true
@@ -32,20 +32,6 @@ stdout_logfile={{ bench_dir }}/logs/worker.log
 stderr_logfile={{ bench_dir }}/logs/worker.error.log
 user={{ user }}
 stopwaitsecs=1560
-directory={{ bench_dir }}
-killasgroup=true
-numprocs={{ background_workers }}
-process_name=%(program_name)s-%(process_num)d
-
-[program:{{ bench_name }}-frappe-short-worker]
-command={{ bench_cmd }} worker --queue short
-priority=4
-autostart=true
-autorestart=true
-stdout_logfile={{ bench_dir }}/logs/worker.log
-stderr_logfile={{ bench_dir }}/logs/worker.error.log
-user={{ user }}
-stopwaitsecs=360
 directory={{ bench_dir }}
 killasgroup=true
 numprocs={{ background_workers }}
@@ -182,7 +168,7 @@ programs={{ bench_name }}-frappe-web {%- if node -%} ,{{ bench_name }}-node-sock
 {% if use_rq %}
 
 [group:{{ bench_name }}-workers]
-programs={{ bench_name }}-frappe-schedule,{{ bench_name }}-frappe-default-worker,{{ bench_name }}-frappe-short-worker,{{ bench_name }}-frappe-long-worker
+programs={{ bench_name }}-frappe-schedule,{{ bench_name }}-frappe-default-worker,{{ bench_name }}-frappe-long-worker
 
 {% else %}
 


### PR DESCRIPTION
Why do this?

In practice we have observed very low utilization of short + default
separate workers. So instead of running one worker per each queue we can
run single worker with higher priority for "short" queue. This drop
memory usage of 1 worker while offering practically same utilization and
responsiveness.

---

Scope for further improvement:
- Make count for each type separately configurable.

