### PR TITLE
fix: apps.txt should maintain order

### DIFF
--- a/bench/app.py
+++ b/bench/app.py
@@ -552,7 +552,7 @@ def install_app(
 	resolution=UNSET_ARG,
 ):
 	import bench.cli as bench_cli
-	from bench.bench import Bench
+	from bench.bench import Bench, BenchApps
 
 	install_text = f"Installing {app}"
 	click.secho(install_text, fg="yellow")
@@ -580,6 +580,9 @@ def install_app(
 	if os.path.exists(os.path.join(app_path, "package.json")):
 		bench.run("yarn install", cwd=app_path)
 
+	bench.apps.initialize_apps()
+	if app not in bench.apps:
+		super(BenchApps, bench.apps).append(app)
 	bench.apps.sync(app_name=app, required=resolution, branch=tag, app_dir=app_path)
 
 	if not skip_assets:


### PR DESCRIPTION
Problem: bench is storing apps.txt in random order, this is because every time `bench.apps.sync` is called it does `os.listdir()` to re-initialize apps.txt which gives output in practically random order.

Solution: Enforce invariants everywhere.

1. Initialize apps from disk by reading `apps.txt`
2. Any operation that modifies `apps.txt` should update `bench.apps` e.g. `install-app` does `bench.apps.append(...)`, `remove-app` does `bench.apps.remove(...)`.
3. Once in-memory state is changed, `bench.apps.sync()` should "flush" the changes to apps.txt file. This way it doesn't need to re-initialize the apps from disk


Potential caveats to check/address:
- [ ] If operation fails in between sync and install/remove apps.txt will not be in-sync.
- [ ] Dependency resolution code probably isn't maintaining this invariant?
- [ ] CLI is initialized after `Bench` is created, so non-bench directories are problamatic.