### PR TITLE
feat provide environment via nix

### DIFF
--- a/bench/commands/__init__.py
+++ b/bench/commands/__init__.py
@@ -1,4 +1,5 @@
 # imports - third party imports
+import os
 import click
 
 # imports - module imports
@@ -8,7 +9,6 @@ from bench.utils.cli import (
 	use_experimental_feature,
 	setup_verbosity,
 )
-
 
 @click.group(cls=MultiCommandGroup)
 @click.option(
@@ -109,9 +109,11 @@ bench_command.add_command(bench_src)
 bench_command.add_command(find_benches)
 bench_command.add_command(migrate_env)
 
-from bench.commands.setup import setup
 
-bench_command.add_command(setup)
+if not os.environ.get("NIX_WRAPPED"):
+	from bench.commands.setup import setup
+
+	bench_command.add_command(setup)
 
 
 from bench.commands.config import config
@@ -124,6 +126,7 @@ bench_command.add_command(remote_set_url)
 bench_command.add_command(remote_reset_url)
 bench_command.add_command(remote_urls)
 
-from bench.commands.install import install
+if not os.environ.get("NIX_WRAPPED"):
+	from bench.commands.install import install
 
-bench_command.add_command(install)
+	bench_command.add_command(install)

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1675584158,
+        "narHash": "sha256-SBkchaDzCHxnPNRDdtZ5ko5caHio9iS0Mbyn/xXbXxs=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "d840126a0890621e7b220894d749132dd4bde6a0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,83 @@
+{
+  description = "CLI to manage Multi-tenant deployments for Frappe apps";
+
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+
+  outputs = {nixpkgs, self}: let
+    perSystem = f: builtins.mapAttrs (_: f) nixpkgs.legacyPackages;
+  in {
+    packages = perSystem (pkgs: rec {
+      default = bench;
+      bench = with pkgs;
+        python3.pkgs.buildPythonApplication rec {
+          pname = "bench";
+          version =
+            builtins.head (
+              builtins.match
+                ''^VERSION = "([^"]+).*''
+                (builtins.readFile ./bench/__init__.py)
+            );
+          format = "pyproject";
+        
+          src = ./.;
+        
+          postPatch = ''
+            substituteInPlace pyproject.toml \
+              --replace 'Jinja2~=3.0.3' 'Jinja2' \
+              --replace 'python-crontab~=2.6.0' 'python-crontab' \
+              --replace 'semantic-version~=2.8.2' 'semantic-version'
+          '';
+
+          # signal to bench that it's executed from a nix wrapper
+          # with the full pythen & bin environment already set up
+          makeWrapperArgs = "--set NIX_WRAPPED 1";
+
+        
+          propagatedBuildInputs = [
+            coreutils
+            gitMinimal
+            # non-python runtime deps
+            redis
+            nodejs
+            mariadb
+            postgresql
+            yarn
+            cron
+            # wkhtmltopdf - has unmaintained dep; pdf printing not available out of the box
+            # https://github.com/frappe/bench/issues/1427
+            nginx
+          ] ++ (with python3.pkgs; [
+            # for bench's own environment management
+            pip
+            supervisor
+            psutil
+            # other
+            click
+            gitpython
+            python-crontab
+            requests
+            semantic-version
+            setuptools
+            tomli
+            # python; but not in pythonPackages
+            honcho
+            staticjinja
+          ]);
+        
+          nativeBuildInputs = with python3.pkgs; [
+            hatchling
+          ];
+        
+          pythonImportsCheck = [ "bench" ];
+        
+          meta = with lib; {
+            description = "CLI to manage Multi-tenant deployments for Frappe apps";
+            homepage = "https://github.com/frappe/bench";
+            license = with licenses; [ gpl3 ];
+            maintainers = with maintainers; [ ];
+          };
+        };
+
+    });
+  };
+}


### PR DESCRIPTION
- feat: provide runtime environment via nix

<details>
<summary>Testing this from the Nix side</summary>

The only thing that didn't work is supervisor binding to 9001 (potentially cause not enough priviliges).

Note that all command invocation are reproducible, i.e. this is not my local `git` but the `gitMinimal` provided by `nixpkgs`, same for `python3` & `yarn`, see:
```
❯ which git
git not found
❯ which python3
python3 not found
❯ which yarn
yarn not found
```

```console
❯ nix run . -- init test
Setting Up Environment
$ python3 -m venv env
$ /home/blaggacao/src/github.com/frappe/bench/test/env/bin/python -m pip install --quiet --upgrade pip
$ /home/blaggacao/src/github.com/frappe/bench/test/env/bin/python -m pip install --quiet wheel
Getting frappe
$ git clone https://github.com/frappe/frappe.git  --depth 1 --origin upstream
Cloning into 'frappe'...
remote: Enumerating objects: 3149, done.
remote: Counting objects: 100% (3149/3149), done.
remote: Compressing objects: 100% (2832/2832), done.
remote: Total 3149 (delta 430), reused 1238 (delta 221), pack-reused 0
Receiving objects: 100% (3149/3149), 15.92 MiB | 79.00 KiB/s, done.
Resolving deltas: 100% (430/430), done.
Installing frappe
$ /home/blaggacao/src/github.com/frappe/bench/test/env/bin/python -m pip install --quiet --upgrade -e /home/blaggacao/src/github.com/frappe/bench/test/apps/frappe
$ yarn install
yarn install v1.22.19
[1/5] Validating package.json...
[2/5] Resolving packages...
[3/5] Fetching packages...
[4/5] Linking dependencies...
warning " > @frappe/esbuild-plugin-postcss2@0.1.3" has unmet peer dependency "less@^4.x".
warning " > @frappe/esbuild-plugin-postcss2@0.1.3" has unmet peer dependency "stylus@^0.x".
warning " > @vue/component-compiler@4.2.4" has unmet peer dependency "vue-template-compiler@*".
[5/5] Building fresh packages...
Done in 3.85s.
Found existing apps updating states...
$ supervisorctl restart frappe:
http://localhost:9001 refused connection
WARN: restarting supervisor failed. Use `bench restart` to retry.
$ bench build
Assets for Commit 790b09f95fc3844bcc90314b984bf23568b28ff7 don't exist
Linking /home/blaggacao/src/github.com/frappe/bench/test/apps/frappe/node_modules to ./assets/frappe/node_modules                                                                                                   ✔ Application Assets Linked


yarn run v1.22.19
$ node esbuild --production --run-build-command
[@vue/compiler-sfc] the >>> and /deep/ combinators have been deprecated. Use :deep() instead.

[@vue/compiler-sfc] the >>> and /deep/ combinators have been deprecated. Use :deep() instead.

File                                                        Size

frappe/dist/js/
├─ bootstrap-4-web.bundle.22U72DEL.js                       1.73 Kb
├─ controls.bundle.MZVOEH6L.js                              1229.98 Kb
├─ data_import_tools.bundle.HSGYD5FV.js                     106.80 Kb
├─ desk.bundle.O7GXVZTG.js                                  1295.01 Kb
├─ dialog.bundle.XAGVNAW3.js                                54.53 Kb
├─ form.bundle.PF5B35WP.js                                  155.96 Kb
├─ frappe-web.bundle.AEZLDEEC.js                            728.68 Kb
├─ libs.bundle.LZZGUWMT.js                                  473.78 Kb
├─ list.bundle.5O3X26YN.js                                  186.81 Kb
├─ logtypes.bundle.7STJ7YLS.js                              0.73 Kb
├─ report.bundle.7O75DNSS.js                                173.34 Kb
├─ user_profile_controller.bundle.YR6XHZRM.js               11.35 Kb
├─ video_player.bundle.UO3KNN5D.js                          120.59 Kb
├─ web_form.bundle.5GC6IDHU.js                              1563.95 Kb
├─ form_builder.bundle.HW6F2A26.js                          719.82 Kb
├─ form_builder.bundle.EAXMON22.css                         20.44 Kb
├─ print_format_builder.bundle.SRJZUEMJ.js                  668.90 Kb
├─ print_format_builder.bundle.QMA6XAQ4.css                 5.54 Kb
├─ build_events.bundle.ZK2QAXSR.js                          104.33 Kb
├─ build_events.bundle.L552AT3F.css                         1.29 Kb
├─ file_uploader.bundle.2C3I6MV6.js                         175.56 Kb
├─ file_uploader.bundle.EMOY27BA.css                        2.76 Kb
├─ recorder.bundle.O4ZTIAZR.js                              151.03 Kb
├─ recorder.bundle.6X4644PY.css                             0.12 Kb
└─ kanban_board.bundle.TOJBZTGE.js                          563.86 Kb

frappe/dist/css/
├─ desk.bundle.TE7OIC72.css                                 547.01 Kb
├─ email.bundle.O2AMRDH2.css                                4.02 Kb
├─ login.bundle.TCU3YURC.css                                27.68 Kb
├─ print.bundle.6IW3K65Z.css                                196.34 Kb
├─ print_format.bundle.YGSCLXOU.css                         178.50 Kb
├─ report.bundle.BHVNLEG6.css                               5.36 Kb
├─ web_form.bundle.RRTMFLCF.css                             14.73 Kb
└─ website.bundle.CJ6VVOPE.css                              421.87 Kb

frappe/dist/css-rtl/
├─ desk.bundle.PBPLVVSG.css                                 547.26 Kb
├─ email.bundle.N47NQGJB.css                                4.02 Kb
├─ login.bundle.QZJT34RM.css                                27.68 Kb
├─ print.bundle.X4CQDPAX.css                                196.48 Kb
├─ print_format.bundle.KBQ5OANA.css                         178.61 Kb
├─ report.bundle.DGGN5N47.css                               5.35 Kb
├─ web_form.bundle.EUFZMJFR.css                             14.72 Kb
└─ website.bundle.NKJUX6SH.css                              422.01 Kb

 DONE  Total Build Time: 10.124s

 WARN  Cannot connect to redis_cache to update assets_json
 WARN  Cannot connect to redis_cache to update assets_json
 WARN  Cannot connect to redis_cache to update assets_json
Done in 13.68s.
SUCCESS: Bench test initialized
```

</details>