### PR TITLE
perf: set default niceness for non-web processes

### DIFF
--- a/bench/config/supervisor.py
+++ b/bench/config/supervisor.py
@@ -59,6 +59,7 @@ def generate_supervisor_config(bench_path, user=None, yes=False, skip_redis=Fals
 			"bench_cmd": which("bench"),
 			"skip_redis": skip_redis,
 			"workers": config.get("workers", {}),
+			"nice": which("nice"),
 		}
 	)
 

--- a/bench/config/templates/supervisor.conf
+++ b/bench/config/templates/supervisor.conf
@@ -14,7 +14,7 @@ directory={{ sites_dir }}
 
 {% if use_rq %}
 [program:{{ bench_name }}-frappe-schedule]
-command={{ bench_cmd }} schedule
+command={% if nice -%} {{ nice }} -n6 {% endif -%} {{ bench_cmd }} schedule
 priority=3
 autostart=true
 autorestart=true
@@ -24,7 +24,7 @@ user={{ user }}
 directory={{ bench_dir }}
 
 [program:{{ bench_name }}-frappe-default-worker]
-command={{ bench_cmd }} worker --queue default
+command={% if nice -%} {{ nice }} -n8 {% endif -%} {{ bench_cmd }} worker --queue default
 priority=4
 autostart=true
 autorestart=true
@@ -38,7 +38,7 @@ numprocs={{ background_workers }}
 process_name=%(program_name)s-%(process_num)d
 
 [program:{{ bench_name }}-frappe-short-worker]
-command={{ bench_cmd }} worker --queue short
+command={% if nice -%} {{ nice }} -n7 {% endif -%} {{ bench_cmd }} worker --queue short
 priority=4
 autostart=true
 autorestart=true
@@ -52,7 +52,7 @@ numprocs={{ background_workers }}
 process_name=%(program_name)s-%(process_num)d
 
 [program:{{ bench_name }}-frappe-long-worker]
-command={{ bench_cmd }} worker --queue long
+command={% if nice -%} {{ nice }} -n9 {% endif -%} {{ bench_cmd }} worker --queue long
 priority=4
 autostart=true
 autorestart=true
@@ -67,7 +67,7 @@ process_name=%(program_name)s-%(process_num)d
 
 {% for worker_name, worker_details in workers.items() %}
 [program:{{ bench_name }}-frappe-{{ worker_name }}-worker]
-command={{ bench_cmd }} worker --queue {{ worker_name }}
+command={% if nice -%} {{ nice }} -n8 {% endif -%} {{ bench_cmd }} worker --queue {{ worker_name }}
 priority=4
 autostart=true
 autorestart=true
@@ -166,7 +166,7 @@ directory={{ sites_dir }}
 
 {% if node %}
 [program:{{ bench_name }}-node-socketio]
-command={{ node }} {{ bench_dir }}/apps/frappe/socketio.js
+command={% if nice -%} {{ nice }} -n1 {% endif -%} {{ node }} {{ bench_dir }}/apps/frappe/socketio.js
 priority=4
 autostart=true
 autorestart=true


### PR DESCRIPTION
Set [niceness](https://en.wikipedia.org/wiki/Nice_(Unix)) for non-web processes so that the web workers get priority over them.

Defaults applied:

| Process    | Niceness   |
|------------|------------|
| socketio server | 1 |
| bench schedule    | 6       |
| short worker    | 7       |
| default worker    | 8       |
| custom workers    | 8       |
| long worker   | 9      |

**Note:** 
- Default niceness is 10 if not specified. Same has been [applied for `bench backup` process](https://github.com/frappe/frappe/blob/3e95c00fd0c01dd1e970c79297fa46432d576e16/frappe/utils/__init__.py#L466) in `frappe`.
- Above _niced_ processes will get less CPU priority than any other user-initiated processes because the default niceness for any processes which hasn't been niced is 0. In view of this, the `socketio` process may be skipped if needed. Other processes are supposed to be "background".
- It is technically possible to set negative niceness (higher priority) for the web workers, but this requires `sudo` privileges which may not be available to user running `bench restart`.

### Config if `nice` cli is not found (unchanged)

```
--- snip ---

[program:dev-node-socketio]
command=/usr/bin/node /home/snv/Work/dev/apps/frappe/socketio.js

--- snip ---
```


### Config if `nice` cli is found

```
--- snip ---

[program:dev-node-socketio]
command=/usr/bin/nice -n1 /usr/bin/node /home/snv/Work/dev/apps/frappe/socketio.js

--- snip ---
```