### PR TITLE
fix: Handle apps with different repo & app names

### DIFF
--- a/bench/app.py
+++ b/bench/app.py
@@ -268,7 +268,7 @@ class App(AppMeta):
 			except IndexError:
 				return []
 		try:
-			required_deps = get_required_deps(self.org, self.app_name, self.tag or self.branch)
+			required_deps = get_required_deps(self.org, self.repo, self.tag or self.branch)
 			return required_apps_from_hooks(required_deps)
 		except Exception:
 			return []

--- a/bench/app.py
+++ b/bench/app.py
@@ -198,7 +198,7 @@ class App(AppMeta):
 
 	@step(title="Archiving App {repo}", success="App {repo} Archived")
 	def remove(self, no_backup: bool = False):
-		active_app_path = os.path.join("apps", self.repo)
+		active_app_path = os.path.join("apps", self.app_name)
 
 		if no_backup:
 			if not os.path.islink(active_app_path):
@@ -209,7 +209,7 @@ class App(AppMeta):
 		else:
 			archived_path = os.path.join("archived", "apps")
 			archived_name = get_available_folder_name(
-				f"{self.repo}-{date.today()}", archived_path
+				f"{self.app_name}-{date.today()}", archived_path
 			)
 			archived_app_path = os.path.join(archived_path, archived_name)
 

--- a/bench/app.py
+++ b/bench/app.py
@@ -233,7 +233,7 @@ class App(AppMeta):
 
 		verbose = bench.cli.verbose or verbose
 		app_name = get_app_name(self.bench.name, self.app_name)
-		if not resolved and self.repo != "frappe" and not ignore_resolution:
+		if not resolved and self.app_name != "frappe" and not ignore_resolution:
 			click.secho(
 				f"Ignoring dependencies of {self.name}. To install dependencies use --resolve-deps",
 				fg="yellow",
@@ -262,13 +262,13 @@ class App(AppMeta):
 		from bench.utils.app import get_required_deps, required_apps_from_hooks
 
 		if self.on_disk:
-			required_deps = os.path.join(self.mount_path, self.repo, "hooks.py")
+			required_deps = os.path.join(self.mount_path, self.app_name, "hooks.py")
 			try:
 				return required_apps_from_hooks(required_deps, local=True)
 			except IndexError:
 				return []
 		try:
-			required_deps = get_required_deps(self.org, self.repo, self.tag or self.branch)
+			required_deps = get_required_deps(self.org, self.app_name, self.tag or self.branch)
 			return required_apps_from_hooks(required_deps)
 		except Exception:
 			return []
@@ -290,16 +290,16 @@ def make_resolution_plan(app: App, bench: "Bench"):
 	decide what apps and versions to install and in what order
 	"""
 	resolution = OrderedDict()
-	resolution[app.repo] = app
+	resolution[app.app_name] = app
 
 	for app_name in app._get_dependencies():
 		dep_app = App(app_name, bench=bench)
 		is_valid_frappe_branch(dep_app.url, dep_app.branch)
 		dep_app.required_by = app.name
-		if dep_app.repo in resolution:
-			click.secho(f"{dep_app.repo} is already resolved skipping", fg="yellow")
+		if dep_app.app_name in resolution:
+			click.secho(f"{dep_app.app_name} is already resolved skipping", fg="yellow")
 			continue
-		resolution[dep_app.repo] = dep_app
+		resolution[dep_app.app_name] = dep_app
 		resolution.update(make_resolution_plan(dep_app, bench))
 		app.local_resolution = [repo_name for repo_name, _ in reversed(resolution.items())]
 	return resolution

--- a/bench/bench.py
+++ b/bench/bench.py
@@ -131,8 +131,6 @@ class Bench(Base, Validator):
 		except InvalidRemoteException:
 			if not force:
 				raise
-		except ValueError:
-			pass
 
 		self.apps.sync()
 		# self.build() - removed because it seems unnecessary

--- a/bench/bench.py
+++ b/bench/bench.py
@@ -312,13 +312,13 @@ class BenchApps(MutableSequence):
 	def add(self, app: "App"):
 		app.get()
 		app.install()
-		super().append(app.repo)
+		super().append(app.app_name)
 		self.apps.sort()
 
 	def remove(self, app: "App", no_backup: bool = False):
 		app.uninstall()
 		app.remove(no_backup=no_backup)
-		super().remove(app.repo)
+		super().remove(app.app_name)
 
 	def append(self, app: "App"):
 		return self.add(app)

--- a/bench/bench.py
+++ b/bench/bench.py
@@ -131,6 +131,9 @@ class Bench(Base, Validator):
 		except InvalidRemoteException:
 			if not force:
 				raise
+		except ValueError:
+			pass
+
 		self.apps.sync()
 		# self.build() - removed because it seems unnecessary
 		self.reload(_raise=False)

--- a/bench/tests/test_init.py
+++ b/bench/tests/test_init.py
@@ -28,8 +28,8 @@ class TestBenchInit(TestBenchBase):
 		self.init_bench(bench_name, **kwargs)
 		app = App("file:///tmp/frappe")
 		self.assertTupleEqual(
-			(app.mount_path, app.url, app.repo, app.org),
-			("/tmp/frappe", "file:///tmp/frappe", "frappe", "frappe"),
+			(app.mount_path, app.url, app.repo, app.app_name, app.org),
+			("/tmp/frappe", "file:///tmp/frappe", "frappe", "frappe", "frappe"),
 		)
 		self.assert_folders(bench_name)
 		self.assert_virtual_env(bench_name)

--- a/bench/tests/test_utils.py
+++ b/bench/tests/test_utils.py
@@ -101,4 +101,6 @@ class TestUtils(unittest.TestCase):
 
 	def test_ssh_ports(self):
 		app = App("git@github.com:22:frappe/frappe")
-		self.assertEqual((app.use_ssh, app.org, app.repo), (True, "frappe", "frappe"))
+		self.assertEqual(
+			(app.use_ssh, app.org, app.repo, app.app_name), (True, "frappe", "frappe", "frappe")
+		)

--- a/bench/utils/bench.py
+++ b/bench/utils/bench.py
@@ -155,7 +155,7 @@ def update_npm_packages(bench_path=".", apps=None):
 						else:
 							package_json[key] = value
 
-	if package_json is {}:
+	if package_json == {}:
 		with open(os.path.join(os.path.dirname(__file__), "package.json")) as f:
 			package_json = json.loads(f.read())
 


### PR DESCRIPTION
### Changes

* Handle `remove-app` when Name and Repo names don't match
* Update relevant usages to use app_name over repo attr of `App`
