### PR TITLE
fix: don't compile python files manually.

### DIFF
--- a/bench/commands/update.py
+++ b/bench/commands/update.py
@@ -33,7 +33,7 @@ from bench.utils.bench import post_upgrade, patch_sites, build_assets
 @click.option(
 	"--no-compile",
 	is_flag=True,
-	help="If set, Python bytecode won't be compiled before restarting the processes",
+	help="[DEPRECATED] This flag doesn't do anything now.",
 )
 @click.option("--force", is_flag=True, help="Forces major version upgrades")
 @click.option(

--- a/bench/utils/bench.py
+++ b/bench/utils/bench.py
@@ -456,13 +456,6 @@ def update(
 	if version_upgrade[0] or (not version_upgrade[0] and force):
 		post_upgrade(version_upgrade[1], version_upgrade[2], bench_path=bench_path)
 
-	if pull and compile:
-		from compileall import compile_dir
-
-		print("Compiling Python files...")
-		apps_dir = os.path.join(bench_path, "apps")
-		compile_dir(apps_dir, quiet=1, rx=re.compile(".*node_modules.*"))
-
 	bench.reload(web=False, supervisor=restart_supervisor, systemd=restart_systemd)
 
 	conf.update({"maintenance_mode": 0, "pause_scheduler": 0})


### PR DESCRIPTION
This isn't really required and is a micro-optimization at best. All most used code gets compiled the first time it's used. At best, we are shaving off 5 milliseconds on first request. 

added here: https://github.com/frappe/frappe/pull/4197
Moved here: https://github.com/frappe/frappe/pull/11833 -> https://github.com/frappe/bench/pull/1094
closes https://github.com/frappe/bench/issues/1468