### PR TITLE
fix: port number mismatch when having multiple benches

### DIFF
--- a/bench/config/common_site_config.py
+++ b/bench/config/common_site_config.py
@@ -129,6 +129,10 @@ def make_ports(bench_path):
 
 		ports[key] = value
 
+	# Backward compatbility: always keep redis_cache and redis_socketio port same
+	# Note: not required from v15
+	ports["redis_socketio"] = ports["redis_cache"]
+
 	return ports
 
 


### PR DESCRIPTION
https://discuss.frappe.io/t/new-version-14-bench-cannot-start-issue-redis-socketio-conf-missing/109022/3