### PR TITLE
refactor: use 127.0.0.1 instead of localhost

### DIFF
--- a/bench/config/common_site_config.py
+++ b/bench/config/common_site_config.py
@@ -83,7 +83,7 @@ def update_config_for_frappe(config, bench_path):
 
 	for key in ("redis_cache", "redis_queue", "redis_socketio"):
 		if key not in config:
-			config[key] = f"redis://localhost:{ports[key]}"
+			config[key] = f"redis://127.0.0.1:{ports[key]}"
 
 	for key in ("webserver_port", "socketio_port", "file_watcher_port"):
 		if key not in config:

--- a/bench/tests/test_init.py
+++ b/bench/tests/test_init.py
@@ -54,9 +54,9 @@ class TestBenchInit(TestBenchBase):
 				"webserver_port": 8000,
 				"socketio_port": 9000,
 				"file_watcher_port": 6787,
-				"redis_queue": "redis://localhost:11000",
-				"redis_socketio": "redis://localhost:13000",
-				"redis_cache": "redis://localhost:13000",
+				"redis_queue": "redis://127.0.0.1:11000",
+				"redis_socketio": "redis://127.0.0.1:13000",
+				"redis_cache": "redis://127.0.0.1:13000",
 			},
 		)
 
@@ -66,9 +66,9 @@ class TestBenchInit(TestBenchBase):
 				"webserver_port": 8001,
 				"socketio_port": 9001,
 				"file_watcher_port": 6788,
-				"redis_queue": "redis://localhost:11001",
-				"redis_socketio": "redis://localhost:13001",
-				"redis_cache": "redis://localhost:13001",
+				"redis_queue": "redis://127.0.0.1:11001",
+				"redis_socketio": "redis://127.0.0.1:13001",
+				"redis_cache": "redis://127.0.0.1:13001",
 			},
 		)
 


### PR DESCRIPTION
- fix: nodejs redis v4 interprets localhost as ipv6 address
- test: fix expected failing tests


repeat of https://github.com/frappe/bench/pull/1466

Not really required but SLIGHTLY faster, so eh. 