### PR TITLE
refactor(treewide): use `mariadb` commands and service instead of `mysql`

### DIFF
--- a/bench/commands/install.py
+++ b/bench/commands/install.py
@@ -25,9 +25,10 @@ def install_prerequisites():
 @click.command(
 	"mariadb", help="Install and setup MariaDB of specified version and root password"
 )
-@click.option("--mysql_root_password", "--mysql-root-password", default="")
+@click.option("--mysql_root_password", "--mysql-root-password",
+			  "--mariadb_root_password", "--mariadb-root-password", default="")
 @click.option("--version", default="10.3")
-def install_maridb(mysql_root_password, version):
+def install_mariadb(mysql_root_password, version):
 	if mysql_root_password:
 		extra_vars.update(
 			{
@@ -111,7 +112,7 @@ def install_failtoban(**kwargs):
 
 
 install.add_command(install_prerequisites)
-install.add_command(install_maridb)
+install.add_command(install_mariadb)
 install.add_command(install_wkhtmltopdf)
 install.add_command(install_nodejs)
 install.add_command(install_psutil)

--- a/bench/commands/setup.py
+++ b/bench/commands/setup.py
@@ -358,7 +358,7 @@ def sync_domains(domain=None, site=None):
 @click.command("role", help="Install dependencies via ansible roles")
 @click.argument("role")
 @click.option("--admin_emails", default="")
-@click.option("--mysql_root_password")
+@click.option("--mysql_root_password", "--mariadb_root_password")
 @click.option("--container", is_flag=True, default=False)
 def setup_roles(role, **kwargs):
 	extra_vars = {"production": True}

--- a/bench/playbooks/roles/mariadb/README.md
+++ b/bench/playbooks/roles/mariadb/README.md
@@ -13,7 +13,7 @@ Debain 9
 
 ## Post install
 
-Run `mysql_secure_installation`
+Run `mariadb-secure-installation`
 
 ## Requirements
 
@@ -39,7 +39,7 @@ Configuration filename:
 mysql_conf_file: settings.cnf
 ```
 
-### Experimental unattended mysql_secure_installation
+### Experimental unattended mariadb-secure-installation
 
 ```
 ansible-playbook release.yml --extra-vars "mysql_secure_installation=true mysql_root_password=your_very_secret_password"

--- a/bench/playbooks/roles/mariadb/handlers/main.yml
+++ b/bench/playbooks/roles/mariadb/handlers/main.yml
@@ -1,3 +1,3 @@
 ---
-- name: restart mysql
-  service: name=mysql state=restarted
+- name: restart mariadb
+  service: name=mariadb state=restarted

--- a/bench/playbooks/roles/mariadb/tasks/main.yml
+++ b/bench/playbooks/roles/mariadb/tasks/main.yml
@@ -16,7 +16,7 @@
     group: root
     mode: 0644
   when: mysql_conf_tpl != 'change_me' and ansible_distribution != 'Debian'
-  notify: restart mysql
+  notify: restart mariadb
 
 - include_tasks: debian.yml
   when: ansible_distribution == 'Debian'
@@ -29,7 +29,7 @@
     group: root
     mode: 0644
   when: mysql_conf_tpl != 'change_me' and ansible_distribution == 'Debian'
-  notify: restart mysql
+  notify: restart mariadb
 
 - name: Add additional conf for MariaDB 10.2 in mariadb.conf.d
   blockinfile:
@@ -59,7 +59,7 @@
 
 - name: Start and enable service
   service:
-    name: mysql
+    name: mariadb
     state: started
     enabled: yes
 

--- a/bench/playbooks/roles/mariadb/tasks/mysql_secure_installation.yml
+++ b/bench/playbooks/roles/mariadb/tasks/mysql_secure_installation.yml
@@ -19,28 +19,28 @@
     - ::1
 
 - name: Reload privilege tables
-  command: 'mysql -ne "{{ item }}"'
+  command: 'mariadb -ne "{{ item }}"'
   with_items:
     - FLUSH PRIVILEGES
   changed_when: False
   when: run_travis is not defined
 
 - name: Remove anonymous users
-  command: 'mysql -ne "{{ item }}"'
+  command: 'mariadb -ne "{{ item }}"'
   with_items:
     - DELETE FROM mysql.user WHERE User=''
   changed_when: False
   when: run_travis is not defined
 
 - name: Disallow root login remotely
-  command: 'mysql -ne "{{ item }}"'
+  command: 'mariadb -ne "{{ item }}"'
   with_items:
     - DELETE FROM mysql.user WHERE User='root' AND Host NOT IN ('localhost', '127.0.0.1', '::1')
   changed_when: False
   when: run_travis is not defined
 
 - name: Remove test database and access to it
-  command: 'mysql -ne "{{ item }}"'
+  command: 'mariadb -ne "{{ item }}"'
   with_items:
     - DROP DATABASE IF EXISTS test
     - DELETE FROM mysql.db WHERE Db='test' OR Db='test\\_%'
@@ -48,7 +48,7 @@
   when: run_travis is not defined
 
 - name: Reload privilege tables
-  command: 'mysql -ne "{{ item }}"'
+  command: 'mariadb -ne "{{ item }}"'
   with_items:
     - FLUSH PRIVILEGES
   changed_when: False


### PR DESCRIPTION
refactor: use `mariadb` commands and service instead of `mysql`

This resolves #1472

This has been done because the mysql command issues a deprecation warning now
mysql: Deprecated program name. It will be removed in a future release, use '/usr/bin/mariadb' instead
