### PR TITLE
fix: Prevent Gunicorn child workers hangup

### DIFF
--- a/bench/config/templates/supervisor.conf
+++ b/bench/config/templates/supervisor.conf
@@ -2,13 +2,15 @@
 ; priority=1 --> Lower priorities indicate programs that start first and shut down last
 ; killasgroup=true --> send kill signal to child processes too
 
+; graceful timeout should always be lower than stopwaitsecs to avoid orphan gunicorn workers.
 [program:{{ bench_name }}-frappe-web]
-command={{ bench_dir }}/env/bin/gunicorn -b 127.0.0.1:{{ webserver_port }} -w {{ gunicorn_workers }} --max-requests {{ gunicorn_max_requests }} --max-requests-jitter {{ gunicorn_max_requests_jitter }} -t {{ http_timeout }} frappe.app:application --preload
+command={{ bench_dir }}/env/bin/gunicorn -b 127.0.0.1:{{ webserver_port }} -w {{ gunicorn_workers }} --max-requests {{ gunicorn_max_requests }} --max-requests-jitter {{ gunicorn_max_requests_jitter }} -t {{ http_timeout }} --graceful-timeout 30 frappe.app:application --preload
 priority=4
 autostart=true
 autorestart=true
 stdout_logfile={{ bench_dir }}/logs/web.log
 stderr_logfile={{ bench_dir }}/logs/web.error.log
+stopwaitsecs=40
 user={{ user }}
 directory={{ sites_dir }}
 


### PR DESCRIPTION
Problem:

- Prerequisite: long running reqeust is going on.
- `bench restart` is requested.
- supervisord sends sigterm to gunicorn master process.
- gunicorn passes it to all child workers and waits for graceful shutdown (30 seconds)
- supervisord has no chill, and sends sigkill to master process in 10 seconds
- gunicorn master proesss is dead, so now child workers will keep running until they complete request which can take a really long time.
- This entire time the sites will be down.

![image](https://github.com/frappe/bench/assets/9079960/00421609-37e8-4a8d-b351-0bb2521291d1)

![image](https://github.com/frappe/bench/assets/9079960/95452a82-eb37-48e9-a991-4c377abecd2a)


Fix:
- Explicitly encode default graceful_timeout in config - 30 seconds.
- Make supervisor wait 10 more seconds for gunicorn to do its thing, then only send sigkill.

Detailed analysis: https://gameplan.frappe.cloud/g/engineering/projects/152/discussion/2523