### PR TITLE
feat: flag to setup bench with developer mode enabled

### DIFF
--- a/bench/bench.py
+++ b/bench/bench.py
@@ -371,12 +371,12 @@ class BenchSetup(Base):
 			)
 
 	@step(title="Setting Up Bench Config", success="Bench Config Set Up")
-	def config(self, redis=True, procfile=True):
+	def config(self, redis=True, procfile=True, additional_config=None):
 		"""Setup config folder
 		- create pids folder
 		- generate sites/common_site_config.json
 		"""
-		setup_config(self.bench.name)
+		setup_config(self.bench.name, additional_config=additional_config)
 
 		if redis:
 			from bench.config.redis import generate_config

--- a/bench/commands/make.py
+++ b/bench/commands/make.py
@@ -39,6 +39,12 @@ import click
 @click.option("--skip-assets", is_flag=True, default=False, help="Do not build assets")
 @click.option("--install-app", help="Install particular app after initialization")
 @click.option("--verbose", is_flag=True, help="Verbose output during install")
+@click.option(
+	"--dev",
+	is_flag=True,
+	default=False,
+	help="Enable developer mode and install development dependencies.",
+)
 def init(
 	path,
 	apps_path,
@@ -54,6 +60,7 @@ def init(
 	skip_assets=False,
 	python="python3",
 	install_app=None,
+	dev=False,
 ):
 	import os
 
@@ -79,6 +86,7 @@ def init(
 			skip_assets=skip_assets,
 			python=python,
 			verbose=verbose,
+			dev=dev,
 		)
 		log(f"Bench {path} initialized", level=1)
 	except SystemExit:

--- a/bench/config/common_site_config.py
+++ b/bench/config/common_site_config.py
@@ -18,12 +18,14 @@ default_config = {
 DEFAULT_MAX_REQUESTS = 5000
 
 
-def setup_config(bench_path):
+def setup_config(bench_path, additional_config=None):
 	make_pid_folder(bench_path)
 	bench_config = get_config(bench_path)
 	bench_config.update(default_config)
 	bench_config.update(get_gunicorn_workers())
 	update_config_for_frappe(bench_config, bench_path)
+	if additional_config:
+		bench_config.update(additional_config)
 
 	put_config(bench_config, bench_path)
 

--- a/bench/utils/system.py
+++ b/bench/utils/system.py
@@ -35,6 +35,7 @@ def init(
 	skip_assets=False,
 	python="python3",
 	install_app=None,
+	dev=False,
 ):
 	"""Initialize a new bench directory
 
@@ -63,7 +64,14 @@ def init(
 	bench.setup.dirs()
 	bench.setup.logging()
 	bench.setup.env(python=python)
-	bench.setup.config(redis=not skip_redis_config_generation, procfile=not no_procfile)
+	config = {}
+	if dev:
+		config["developer_mode"] = 1
+	bench.setup.config(
+		redis=not skip_redis_config_generation,
+		procfile=not no_procfile,
+		additional_config=config,
+	)
 	bench.setup.patches()
 
 	# local apps


### PR DESCRIPTION
Dev dependencies are not installed if developer_mode is not enabled.
When creating a new bench it's not possible to modify this config
upfront, so offer a flag to do it instead.

Note:
- Disabled by default.
- Very few people need this, those who write and run tests locally primarily.
- You mostly should not do this in CI, do `bench setup requirements --dev` explicitly instead.


```
λ bench init testdev --dev
Setting Up Environment
$ python3 -m venv env
$ /home/ankush/benches/develop/testdev/env/bin/python -m pip install --quiet --upgrade pip
$ /home/ankush/benches/develop/testdev/env/bin/python -m pip install --quiet wheel
Getting frappe
$ git clone https://github.com/frappe/frappe.git  --depth 1 --origin upstream
Cloning into 'frappe'...
remote: Enumerating objects: 3268, done.
remote: Counting objects: 100% (3268/3268), done.
remote: Compressing objects: 100% (2878/2878), done.
remote: Total 3268 (delta 427), reused 1707 (delta 277), pack-reused 0
Receiving objects: 100% (3268/3268), 17.93 MiB | 6.18 MiB/s, done.
Resolving deltas: 100% (427/427), done.
Installing frappe
$ /home/ankush/benches/develop/testdev/env/bin/python -m pip install --quiet --upgrade -e /home/ankush/benches/develop/testdev/apps/frappe
$ /home/ankush/benches/develop/testdev/env/bin/python -m pip install --quiet --upgrade coverage~=6.5.0 Faker~=18.10.1 pyngrok~=6.0.0 unittest-xml-reporting~=3.2.0 watchdog~=3.0.0 hypothesis~=6.77.0 responses==0.23.1 freezegun~=1.2.2
... (output clipped)
```



Docs: https://frappeframework.com/docs/user/en/bench/resources/bench-commands-cheatsheet 