### PR TITLE
feat: cache get-app artifacts by commit_hash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # MAC OS
 .DS_Store
 
+# VS Code
+.vscode/
+
 # Vim Gitignore
 ## Swap
 [._]*.s[a-v][a-z]

--- a/bench/app.py
+++ b/bench/app.py
@@ -25,7 +25,6 @@ from bench.utils import (UNSET_ARG, fetch_details_from_tag,
                          get_available_folder_name, get_bench_cache_path,
                          is_bench_directory, is_git_url,
                          is_valid_frappe_branch, log, run_frappe_cmd)
-from bench.utils.app import check_existing_dir
 from bench.utils.bench import build_assets, install_python_dev_dependencies
 from bench.utils.render import step
 
@@ -447,6 +446,7 @@ def get_app(
 	import bench as _bench
 	import bench.cli as bench_cli
 	from bench.bench import Bench
+	from bench.utils.app import check_existing_dir
 
 	bench = Bench(bench_path)
 	app = App(git_url, branch=branch, bench=bench, soft_link=soft_link, commit_hash=commit_hash)
@@ -547,6 +547,7 @@ def install_resolved_deps(
 	skip_assets=False,
 	verbose=False,
 ):
+	from bench.utils.app import check_existing_dir
 	if "frappe" in resolution:
 		# Terminal dependency
 		del resolution["frappe"]

--- a/bench/app.py
+++ b/bench/app.py
@@ -169,7 +169,7 @@ class App(AppMeta):
 		branch: str = None,
 		bench: "Bench" = None,
 		soft_link: bool = False,
-		commit_hash = None,
+		cache_key = None,
 		*args,
 		**kwargs,
 	):
@@ -177,7 +177,7 @@ class App(AppMeta):
 		self.soft_link = soft_link
 		self.required_by = None
 		self.local_resolution = []
-		self.commit_hash =  commit_hash
+		self.cache_key =  cache_key
 		super().__init__(name, branch, *args, **kwargs)
 
 	@step(title="Fetching App {repo}", success="App {repo} Fetched")
@@ -314,15 +314,15 @@ class App(AppMeta):
 		return Path(self.bench.name) / "apps" / self.app_name
 
 	def get_app_cache_path(self, is_compressed=False) -> Path:
-		assert self.commit_hash is not None
+		assert self.cache_key is not None
 
 		cache_path = get_bench_cache_path("apps")
 		ext = "tgz" if is_compressed else "tar"
-		tarfile_name = f"{self.app_name}-{self.commit_hash[:10]}.{ext}"
+		tarfile_name = f"{self.app_name}-{self.cache_key[:10]}.{ext}"
 		return cache_path / tarfile_name
 		
 	def get_cached(self) -> bool:
-		if not self.commit_hash:
+		if not self.cache_key:
 			return False
 		
 		cache_path = self.get_app_cache_path()
@@ -348,7 +348,7 @@ class App(AppMeta):
 		return True
 	
 	def set_cache(self, compress_artifacts=False) -> bool:
-		if not self.commit_hash:
+		if not self.cache_key:
 			return False
 
 		app_path = self.get_app_path()
@@ -359,7 +359,7 @@ class App(AppMeta):
 		cache_path = self.get_app_cache_path(compress_artifacts)
 		mode =  "w:gz" if compress_artifacts else "w"
 		
-		message = f"Caching ${self.app_name} app directory"
+		message = f"Caching {self.app_name} app directory"
 		if compress_artifacts:
 			message += " (compressed)"
 		click.secho(message)
@@ -481,7 +481,7 @@ def get_app(
 	soft_link=False,
 	init_bench=False,
 	resolve_deps=False,
-	commit_hash=None,
+	cache_key=None,
 	compress_artifacts=False,
 ):
 	"""bench get-app clones a Frappe App from remote (GitHub or any other git server),
@@ -497,7 +497,7 @@ def get_app(
 	from bench.utils.app import check_existing_dir
 
 	bench = Bench(bench_path)
-	app = App(git_url, branch=branch, bench=bench, soft_link=soft_link, commit_hash=commit_hash)
+	app = App(git_url, branch=branch, bench=bench, soft_link=soft_link, cache_key=cache_key)
 	git_url = app.url
 	repo_name = app.repo
 	branch = app.tag

--- a/bench/app.py
+++ b/bench/app.py
@@ -365,11 +365,19 @@ class App(AppMeta):
 		click.secho(message)
 
 		self.prune_app_directory()
+		
+		success = False
 		os.chdir(app_path.parent)
-		with tarfile.open(cache_path, mode) as tar:
-			tar.add(app_path.name)
-		os.chdir(cwd)
-		return True
+		try:
+			with tarfile.open(cache_path, mode) as tar:
+				tar.add(app_path.name)
+			success = True
+		except Exception:
+			log(f"Failed to cache {app_path}", level=3)
+			success = False
+		finally:
+			os.chdir(cwd)
+		return success
 	
 	def prune_app_directory(self):
 		app_path = self.get_app_path()

--- a/bench/commands/__init__.py
+++ b/bench/commands/__init__.py
@@ -72,6 +72,7 @@ bench_command.add_command(switch_to_develop)
 
 
 from bench.commands.utils import (
+	app_cache_helper,
 	backup_all_sites,
 	bench_src,
 	disable_production,
@@ -108,6 +109,7 @@ bench_command.add_command(disable_production)
 bench_command.add_command(bench_src)
 bench_command.add_command(find_benches)
 bench_command.add_command(migrate_env)
+bench_command.add_command(app_cache_helper)
 
 from bench.commands.setup import setup
 

--- a/bench/commands/make.py
+++ b/bench/commands/make.py
@@ -151,6 +151,9 @@ def drop(path):
 	default=False,
 	help="Resolve dependencies before installing app",
 )
+@click.option("--commit-hash",  default=None, help="Required for caching get-app artifacts.")
+@click.option("--cache-artifacts", is_flag=True, default=False, help="Whether to cache get-app artifacts. Needs commit-hash.")
+@click.option("--compress-artifacts",  is_flag=True, default=False, help="Whether to gzip get-app artifacts that are to be cached.")
 def get_app(
 	git_url,
 	branch,
@@ -160,6 +163,9 @@ def get_app(
 	soft_link=False,
 	init_bench=False,
 	resolve_deps=False,
+	commit_hash=None,
+	cache_artifacts=False,
+	compress_artifacts=False,
 ):
 	"clone an app from the internet and set it up in your bench"
 	from bench.app import get_app
@@ -172,6 +178,8 @@ def get_app(
 		soft_link=soft_link,
 		init_bench=init_bench,
 		resolve_deps=resolve_deps,
+		commit_hash=commit_hash if cache_artifacts else None,
+		compress_artifacts=compress_artifacts,
 	)
 
 

--- a/bench/commands/make.py
+++ b/bench/commands/make.py
@@ -151,9 +151,18 @@ def drop(path):
 	default=False,
 	help="Resolve dependencies before installing app",
 )
-@click.option("--commit-hash",  default=None, help="Required for caching get-app artifacts.")
-@click.option("--cache-artifacts", is_flag=True, default=False, help="Whether to cache get-app artifacts. Needs commit-hash.")
-@click.option("--compress-artifacts",  is_flag=True, default=False, help="Whether to gzip get-app artifacts that are to be cached.")
+@click.option(
+	"--cache-key",
+	type=str,
+	default=None,
+	help="Caches get-app artifacts if provided (only first 10 chars is used)",
+)
+@click.option(
+	"--compress-artifacts",
+	is_flag=True,
+	default=False,
+	help="Whether to gzip get-app artifacts that are to be cached",
+)
 def get_app(
 	git_url,
 	branch,
@@ -163,8 +172,7 @@ def get_app(
 	soft_link=False,
 	init_bench=False,
 	resolve_deps=False,
-	commit_hash=None,
-	cache_artifacts=False,
+	cache_key=None,
 	compress_artifacts=False,
 ):
 	"clone an app from the internet and set it up in your bench"
@@ -178,7 +186,7 @@ def get_app(
 		soft_link=soft_link,
 		init_bench=init_bench,
 		resolve_deps=resolve_deps,
-		commit_hash=commit_hash if cache_artifacts else None,
+		cache_key=cache_key,
 		compress_artifacts=compress_artifacts,
 	)
 

--- a/bench/commands/utils.py
+++ b/bench/commands/utils.py
@@ -176,3 +176,21 @@ def migrate_env(python, backup=True):
 	from bench.utils.bench import migrate_env
 
 	migrate_env(python=python, backup=backup)
+
+
+@click.command("app-cache", help="View or remove items belonging to bench get-app cache")
+@click.option("--clear", is_flag=True, default=False, help="Remove all items")
+@click.option(
+	"--remove-app",
+	default="",
+	help="Removes all items that match provided app name",
+)
+@click.option(
+	"--remove-hash",
+	default="",
+	help="Removes all items that matches provided commit-hash",
+)
+def app_cache_helper(clear=False, remove_app="", remove_hash=""):
+	from bench.utils.bench import cache_helper
+
+	cache_helper(clear, remove_app, remove_hash)

--- a/bench/commands/utils.py
+++ b/bench/commands/utils.py
@@ -186,11 +186,11 @@ def migrate_env(python, backup=True):
 	help="Removes all items that match provided app name",
 )
 @click.option(
-	"--remove-hash",
+	"--remove-key",
 	default="",
-	help="Removes all items that matches provided commit-hash",
+	help="Removes all items that matches provided cache key",
 )
-def app_cache_helper(clear=False, remove_app="", remove_hash=""):
+def app_cache_helper(clear=False, remove_app="", remove_key=""):
 	from bench.utils.bench import cache_helper
 
-	cache_helper(clear, remove_app, remove_hash)
+	cache_helper(clear, remove_app, remove_key)

--- a/bench/utils/__init__.py
+++ b/bench/utils/__init__.py
@@ -7,8 +7,9 @@ import subprocess
 import sys
 from functools import lru_cache
 from glob import glob
+from pathlib import Path
 from shlex import split
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 # imports - third party imports
 import click
@@ -50,6 +51,15 @@ def is_frappe_app(directory: str) -> bool:
 
 	return bool(is_frappe_app)
 
+def get_bench_cache_path(sub_dir: Optional[str]) -> Path:
+	relative_path = "~/.cache/bench"
+	if sub_dir and not sub_dir.startswith("/"):
+		relative_path += f"/{sub_dir}"
+
+	cache_path = os.path.expanduser(relative_path)
+	cache_path = Path(cache_path)
+	cache_path.mkdir(parents=True, exist_ok=True)
+	return cache_path
 
 @lru_cache(maxsize=None)
 def is_valid_frappe_branch(frappe_path: str, frappe_branch: str):

--- a/bench/utils/bench.py
+++ b/bench/utils/bench.py
@@ -644,12 +644,12 @@ To switch to your required branch, run the following commands: bench switch-to-b
 			sys.exit(1)
 
 
-def cache_helper(clear=False, remove_app="", remove_hash="") -> None:
-	can_remove = bool(remove_hash or remove_app)
+def cache_helper(clear=False, remove_app="", remove_key="") -> None:
+	can_remove = bool(remove_key or remove_app)
 	if not clear and not can_remove:
 		cache_list()
 	elif can_remove:
-		cache_remove(remove_app, remove_hash)
+		cache_remove(remove_app, remove_key)
 	elif clear:
 		cache_clear()
 	else:
@@ -696,17 +696,18 @@ def cache_list() -> None:
 			f"{created:%Y-%m-%d %H:%M:%S}  "
 			f"{accessed:%Y-%m-%d %H:%M:%S}  "
 		)
+
 	if tot_items:
 		click.echo(f"Total size {tot_size / 1_000_000:.3f} MB belonging to {tot_items} items")
 	else:
 		click.echo("No cached items")
 
 
-def cache_remove(app: str = "", hash: str = "") -> None:
+def cache_remove(app: str = "", key: str = "") -> None:
 	rem_items = 0
 	rem_size = 0
 	for item in get_bench_cache_path("apps").iterdir():
-		if not should_remove_item(item, app, hash):
+		if not should_remove_item(item, app, key):
 			continue
 
 		rem_items += 1
@@ -720,18 +721,18 @@ def cache_remove(app: str = "", hash: str = "") -> None:
 		click.echo("No items removed")
 
 
-def should_remove_item(item: Path, app: str, hash: str) -> bool:
+def should_remove_item(item: Path, app: str, key: str) -> bool:
 	if item.suffix not in [".tar", ".tgz"]:
 		return False
 
 	name = item.name
-	if app and hash and name.startswith(f"{app}-{hash[:10]}."):
+	if app and key and name.startswith(f"{app}-{key[:10]}."):
 		return True
 
 	if app and name.startswith(f"{app}-"):
 		return True
 
-	if hash and f"-{hash[:10]}." in name:
+	if key and f"-{key[:10]}." in name:
 		return True
 
 	return False

--- a/bench/utils/bench.py
+++ b/bench/utils/bench.py
@@ -354,11 +354,17 @@ def build_assets(bench_path=".", app=None, using_cached=False):
 	if app:
 		command += f" --app {app}"
 		
-	if using_cached:
+	if using_cached and can_use_cached(bench_path):
 		command += " --using-cached"
 	
 	exec_cmd(command, cwd=bench_path, env={"BENCH_DEVELOPER": "1"})
 
+def can_use_cached(bench_path=".") -> bool:
+	cmd = ["bench", "can-use-cached"]
+	return_code = subprocess.call(
+		cmd, cwd=bench_path, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+	)
+	return not return_code
 
 def handle_version_upgrade(version_upgrade, bench_path, force, reset, conf):
 	from bench.utils import log, pause_exec

--- a/bench/utils/bench.py
+++ b/bench/utils/bench.py
@@ -354,17 +354,11 @@ def build_assets(bench_path=".", app=None, using_cached=False):
 	if app:
 		command += f" --app {app}"
 		
-	if using_cached and can_use_cached(bench_path):
-		command += " --using-cached"
+	env = {"BENCH_DEVELOPER": "1"}
+	if using_cached:
+		env["USING_CACHED"] = "1"
 	
-	exec_cmd(command, cwd=bench_path, env={"BENCH_DEVELOPER": "1"})
-
-def can_use_cached(bench_path=".") -> bool:
-	cmd = ["bench", "can-use-cached"]
-	return_code = subprocess.call(
-		cmd, cwd=bench_path, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
-	)
-	return not return_code
+	exec_cmd(command, cwd=bench_path, env=env)
 
 def handle_version_upgrade(version_upgrade, bench_path, force, reset, conf):
 	from bench.utils import log, pause_exec

--- a/bench/utils/bench.py
+++ b/bench/utils/bench.py
@@ -748,11 +748,8 @@ def cache_clear() -> None:
 	tot_size = get_dir_size(cache_path)
 	shutil.rmtree(cache_path)
 
-	rem_items = tot_items - len(os.listdir(cache_path))
-	rem_size = tot_size - get_dir_size(cache_path)
-
-	if rem_items:
-		click.echo(f"Cleared {rem_size / 1_000_000:.3f} MB belonging to {rem_items} items")
+	if tot_items:
+		click.echo(f"Cleared {tot_size / 1_000_000:.3f} MB belonging to {tot_items} items")
 
 
 def get_dir_size(p: Path) -> int:

--- a/bench/utils/bench.py
+++ b/bench/utils/bench.py
@@ -4,11 +4,13 @@ import json
 import logging
 import os
 import re
+import shutil
 import subprocess
 import sys
 from functools import lru_cache
 from glob import glob
 from json.decoder import JSONDecodeError
+from pathlib import Path
 
 # imports - third party imports
 import click
@@ -16,7 +18,8 @@ import click
 # imports - module imports
 import bench
 from bench.exceptions import PatchError, ValidationError
-from bench.utils import exec_cmd, get_bench_name, get_cmd_output, log, which
+from bench.utils import (exec_cmd, get_bench_cache_path, get_bench_name,
+                         get_cmd_output, log, which)
 
 logger = logging.getLogger(bench.PROJECT_NAME)
 
@@ -353,12 +356,13 @@ def build_assets(bench_path=".", app=None, using_cached=False):
 	command = "bench build"
 	if app:
 		command += f" --app {app}"
-		
+
 	env = {"BENCH_DEVELOPER": "1"}
 	if using_cached:
 		env["USING_CACHED"] = "1"
-	
+
 	exec_cmd(command, cwd=bench_path, env=env)
+
 
 def handle_version_upgrade(version_upgrade, bench_path, force, reset, conf):
 	from bench.utils import log, pause_exec
@@ -638,3 +642,117 @@ To switch to your required branch, run the following commands: bench switch-to-b
 			)
 
 			sys.exit(1)
+
+
+def cache_helper(clear=False, remove_app="", remove_hash="") -> None:
+	can_remove = bool(remove_hash or remove_app)
+	if not clear and not can_remove:
+		cache_list()
+	elif can_remove:
+		cache_remove(remove_app, remove_hash)
+	elif clear:
+		cache_clear()
+	else:
+		pass  # unreachable
+
+
+def cache_list() -> None:
+	from datetime import datetime
+
+	tot_size = 0
+	tot_items = 0
+
+	printed_header = False
+	for item in get_bench_cache_path("apps").iterdir():
+		if item.suffix not in [".tar", ".tgz"]:
+			continue
+
+		stat = item.stat()
+		size_mb = stat.st_size / 1_000_000
+		created = datetime.fromtimestamp(stat.st_ctime)
+		accessed = datetime.fromtimestamp(stat.st_atime)
+
+		app = item.name.split("-")[0]
+		tot_items += 1
+		tot_size += stat.st_size
+		compressed = item.suffix == ".tgz"
+
+		if not printed_header:
+			click.echo(
+				f"{'APP':15}  "
+				f"{'FILE':25}  "
+				f"{'SIZE':>13}  "
+				f"{'COMPRESSED'}  "
+				f"{'CREATED':19}  "
+				f"{'ACCESSED':19}  "
+			)
+			printed_header = True
+
+		click.echo(
+			f"{app:15}  "
+			f"{item.name:25}  "
+			f"{size_mb:10.3f} MB  "
+			f"{str(compressed):10}  "
+			f"{created:%Y-%m-%d %H:%M:%S}  "
+			f"{accessed:%Y-%m-%d %H:%M:%S}  "
+		)
+	if tot_items:
+		click.echo(f"Total size {tot_size / 1_000_000:.3f} MB belonging to {tot_items} items")
+	else:
+		click.echo("No cached items")
+
+
+def cache_remove(app: str = "", hash: str = "") -> None:
+	rem_items = 0
+	rem_size = 0
+	for item in get_bench_cache_path("apps").iterdir():
+		if not should_remove_item(item, app, hash):
+			continue
+
+		rem_items += 1
+		rem_size += item.stat().st_size
+		item.unlink(True)
+		click.echo(f"Removed {item.name}")
+
+	if rem_items:
+		click.echo(f"Cleared {rem_size / 1_000_000:.3f} MB belonging to {rem_items} items")
+	else:
+		click.echo("No items removed")
+
+
+def should_remove_item(item: Path, app: str, hash: str) -> bool:
+	if item.suffix not in [".tar", ".tgz"]:
+		return False
+
+	name = item.name
+	if app and hash and name.startswith(f"{app}-{hash[:10]}."):
+		return True
+
+	if app and name.startswith(f"{app}-"):
+		return True
+
+	if hash and f"-{hash[:10]}." in name:
+		return True
+
+	return False
+
+
+def cache_clear() -> None:
+	cache_path = get_bench_cache_path("apps")
+	tot_items = len(os.listdir(cache_path))
+	if not tot_items:
+		click.echo("No cached items")
+		return
+
+	tot_size = get_dir_size(cache_path)
+	shutil.rmtree(cache_path)
+
+	rem_items = tot_items - len(os.listdir(cache_path))
+	rem_size = tot_size - get_dir_size(cache_path)
+
+	if rem_items:
+		click.echo(f"Cleared {rem_size / 1_000_000:.3f} MB belonging to {rem_items} items")
+
+
+def get_dir_size(p: Path) -> int:
+	return sum(i.stat(follow_symlinks=False).st_size for i in p.iterdir())

--- a/bench/utils/bench.py
+++ b/bench/utils/bench.py
@@ -349,10 +349,14 @@ def restart_process_manager(bench_path=".", web_workers=False):
 		exec_cmd(f"overmind restart {worker}", cwd=bench_path)
 
 
-def build_assets(bench_path=".", app=None):
+def build_assets(bench_path=".", app=None, using_cached=False):
 	command = "bench build"
 	if app:
 		command += f" --app {app}"
+		
+	if using_cached:
+		command += " --using-cached"
+	
 	exec_cmd(command, cwd=bench_path, env={"BENCH_DEVELOPER": "1"})
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "Click>=7.0",
     "GitPython~=3.1.30",
     "honcho",
-    "Jinja2~=3.0.3",
+    "Jinja2~=3.1.3",
     "python-crontab~=2.6.0",
     "requests",
     "semantic-version~=2.8.2",


### PR DESCRIPTION
TLDR: Stores `get-app` artifacts in `.cache` by ~commit hash~ cache key and reuses them when applicable.

Partially Fixes: https://github.com/frappe/press/issues/1242

**TODO:**
- [x] Cache output and restore cache if present.
- [x] Add explicit `compress_artifacts` flag.
- [x] Update `frappe/esbuild/esbuild.js` to account for cached get-app. https://github.com/frappe/frappe/pull/24412
- [x] Complete installation from cache.
- [x] Ensure `$BENCH/sites` is being updated properly.
- [x] Get rid of `node_modules` for apps with built frontends (gameplan, insights, etc).
- [x] Commands to clear, and view app cache.
- [x] Check if it works.

### Usage

Adds two new options to `bench get-app`:
- `--cache-key`: Used to store tarred app folder in `~/.cache/bench/apps` with the following format `"{app}-{cache-key[:10]}.tar"`
- `--compress-artifacts`: Optional flag that causes artifacts to be compressed using gzip, extension will then be `.tgz`.

**Examples:**

```bash
# Get from local repo, apps/gampelan will be cached if not present
bench get-app file:///home/frappe/gameplan --cache-key 87d4aa3b10aa23a620d5a51a968ae47110c43dd1

# Get from remote frappe repo, apps/erpnext will be compressed and cached if not present
bench get-app erpnext --cache-key 7bcea6099da1a41ad530bdd85ff337f627039b80 --compress-artifacts
```

For either of the above if app is present in cache it will be fetched from there, else it will be stored in cache. While installing, cache is checked for both compressed and non compressed tar files.

### Utility Commands

<details>
<summary><code>bench app-cache</code></summary>


<img width="792" alt="Screenshot 2024-01-19 at 19 10 18" src="https://github.com/frappe/bench/assets/29507195/ea021d33-35da-4563-94a6-c5e3e9133053">


</details>


<details>
<summary><code>bench app-cache --remove-app APP_NAME</code></summary>

<img width="792" alt="Screenshot 2024-01-19 at 19 10 40" src="https://github.com/frappe/bench/assets/29507195/b6e48ce8-ffb3-484e-9aa5-6b70506b0c8b">

</details>

<details>
<summary><code>bench app-cache --remove-key CACHE_KEY</code></summary>

<img width="792" alt="Screenshot 2024-01-19 at 19 11 23" src="https://github.com/frappe/bench/assets/29507195/56abb37f-127c-478e-9a61-98d5f977aed8">

</details>

### Why?

When running `get-app` bench spends significant amount of time in git clone, yarn install, pip install, building frontend dependencies. If it's running get-app on the same code (same app, same repo, same commit hash), `get-app` artifacts from the previous run can be reused.


### How?

After `get-app` has completed for some `$APP` the relevant folders that change are:
- `$BENCH/apps/$APP`: cloned source files, and built frontend files and dependencies.
- `$BENCH/env`: python dependencies for the get-app'd `$APP`.
- `$BENCH/sites`: link to the `assets/$APP` folder, update `assets.json`, `apps.json`, `apps.txt`.

Caching the contents of `$BENCH/apps/$APP` covers repo cloning, yarn install and yarn build. That's what this PR facilitates.

<details>
<summary>Reference</summary>

File system changes after running `get-app` for `frappe/hrms`.

<img width="751" alt="Screenshot 2024-01-15 at 11 49 18" src="https://github.com/frappe/bench/assets/29507195/74c7260e-a394-41a5-b6dc-2888972a3ee0">

</details>

**Regarding `$BENCH/env`**

Pip install does take a considerable amount of time but since it isn't contained in the app folder it won't be included for now. Future updates might have python dependencies stored inside the app folder. Out of scope for now.

