### PR TITLE
feat: set startretries in supervisor configuration

### DIFF
--- a/bench/commands/install.py
+++ b/bench/commands/install.py
@@ -77,7 +77,7 @@ def install_nginx(user=None):
 		setup_sudoers(user)
 
 
-@click.command("virtualbox", help="Installs supervisor")
+@click.command("virtualbox", help="Installs virtualbox")
 def install_virtualbox():
 	run_playbook("vm_build.yml", tag="virtualbox")
 

--- a/bench/commands/setup.py
+++ b/bench/commands/setup.py
@@ -73,7 +73,9 @@ def setup_supervisor(user=None, yes=False, skip_redis=False, skip_supervisord=Fa
 		generate_supervisor_config,
 	)
 
-	which("supervisorctl", raise_err=True)
+	if which("supervisorctl") is None:
+		click.secho("Please install `supervisor` to proceed", fg="red")
+		sys.exit(1)
 
 	if not skip_supervisord and "Permission denied" in get_cmd_output(
 		"supervisorctl status"

--- a/bench/config/supervisor.py
+++ b/bench/config/supervisor.py
@@ -59,6 +59,7 @@ def generate_supervisor_config(bench_path, user=None, yes=False, skip_redis=Fals
 			"skip_redis": skip_redis,
 			"workers": config.get("workers", {}),
 			"multi_queue_consumption": can_enable_multi_queue_consumption(bench_path),
+			"supervisor_startretries": 10,
 		}
 	)
 

--- a/bench/config/templates/supervisor.conf
+++ b/bench/config/templates/supervisor.conf
@@ -14,6 +14,7 @@ stopwaitsecs=40
 killasgroup=true
 user={{ user }}
 directory={{ sites_dir }}
+startretries={{ supervisor_startretries }}
 
 [program:{{ bench_name }}-frappe-schedule]
 command={{ bench_cmd }} schedule
@@ -24,6 +25,7 @@ stdout_logfile={{ bench_dir }}/logs/schedule.log
 stderr_logfile={{ bench_dir }}/logs/schedule.error.log
 user={{ user }}
 directory={{ bench_dir }}
+startretries={{ supervisor_startretries }}
 
 {% if not multi_queue_consumption %}
 [program:{{ bench_name }}-frappe-default-worker]
@@ -39,6 +41,7 @@ directory={{ bench_dir }}
 killasgroup=true
 numprocs={{ background_workers }}
 process_name=%(program_name)s-%(process_num)d
+startretries={{ supervisor_startretries }}
 {% endif %}
 
 [program:{{ bench_name }}-frappe-short-worker]
@@ -54,6 +57,7 @@ directory={{ bench_dir }}
 killasgroup=true
 numprocs={{ background_workers }}
 process_name=%(program_name)s-%(process_num)d
+startretries={{ supervisor_startretries }}
 
 [program:{{ bench_name }}-frappe-long-worker]
 command={{ bench_cmd }} worker --queue long{{',default,short' if multi_queue_consumption else ''}}
@@ -68,6 +72,7 @@ directory={{ bench_dir }}
 killasgroup=true
 numprocs={{ background_workers }}
 process_name=%(program_name)s-%(process_num)d
+startretries={{ supervisor_startretries }}
 
 {% for worker_name, worker_details in workers.items() %}
 [program:{{ bench_name }}-frappe-{{ worker_name }}-worker]
@@ -83,6 +88,7 @@ directory={{ bench_dir }}
 killasgroup=true
 numprocs={{ worker_details["background_workers"] or background_workers }}
 process_name=%(program_name)s-%(process_num)d
+startretries={{ supervisor_startretries }}
 {% endfor %}
 
 
@@ -96,6 +102,7 @@ stdout_logfile={{ bench_dir }}/logs/redis-cache.log
 stderr_logfile={{ bench_dir }}/logs/redis-cache.error.log
 user={{ user }}
 directory={{ sites_dir }}
+startretries={{ supervisor_startretries }}
 
 [program:{{ bench_name }}-redis-queue]
 command={{ redis_server }} {{ redis_queue_config }}
@@ -106,6 +113,7 @@ stdout_logfile={{ bench_dir }}/logs/redis-queue.log
 stderr_logfile={{ bench_dir }}/logs/redis-queue.error.log
 user={{ user }}
 directory={{ sites_dir }}
+startretries={{ supervisor_startretries }}
 {% endif %}
 
 {% if node %}
@@ -118,6 +126,7 @@ stdout_logfile={{ bench_dir }}/logs/node-socketio.log
 stderr_logfile={{ bench_dir }}/logs/node-socketio.error.log
 user={{ user }}
 directory={{ bench_dir }}
+startretries={{ supervisor_startretries }}
 {% endif %}
 
 [group:{{ bench_name }}-web]


### PR DESCRIPTION
- fix: wrong help string
- chore: simplify output of `bench setup supervisor` when supervisor isn't installed
- feat: set `startretries` in supervisor configuration

Resolves #1518
