### PR TITLE
fix: add safety filter for untarring

### DIFF
--- a/bench/app.py
+++ b/bench/app.py
@@ -346,7 +346,8 @@ class App(AppMeta):
 		with tarfile.open(cache_path, mode) as tar:
 			try:
 				tar.extractall(app_path.parent, filter=get_app_cache_extract_filter())
-			except:
+			except Exception:
+				logger.exception(f"Cache extraction failed for {self.app_name}")
 				shutil.rmtree(app_path)
 				return False
 

--- a/bench/app.py
+++ b/bench/app.py
@@ -24,6 +24,7 @@ from bench.exceptions import NotInBenchDirectoryError
 from bench.utils import (
 	UNSET_ARG,
 	fetch_details_from_tag,
+	get_app_cache_extract_filter,
 	get_available_folder_name,
 	get_bench_cache_path,
 	is_bench_directory,
@@ -343,7 +344,11 @@ class App(AppMeta):
 		
 		click.secho(f"Getting {self.app_name} from cache", fg="yellow")
 		with tarfile.open(cache_path, mode) as tar:
-			tar.extractall(app_path.parent)
+			try:
+				tar.extractall(app_path.parent, filter=get_app_cache_extract_filter())
+			except:
+				shutil.rmtree(app_path)
+				return False
 
 		return True
 	

--- a/bench/utils/__init__.py
+++ b/bench/utils/__init__.py
@@ -10,7 +10,7 @@ from glob import glob
 from pathlib import Path
 from shlex import split
 from tarfile import data_filter, AbsoluteLinkError, TarInfo
-from typing import Callable, List, Optional, Tuple
+from typing import List, Optional, Tuple
 
 # imports - third party imports
 import click
@@ -575,7 +575,7 @@ def get_cmd_from_sysargv():
 def get_app_cache_extract_filter(
 	count_threshold: int = 10_000,
 	size_threshold: int = 1_000_000_000,
-) -> Callable[[TarInfo, str], TarInfo | None]:
+): # -> Callable[[TarInfo, str], TarInfo | None]
 	state = dict(count=0, size=0)
 
 	def filter_function(member: TarInfo, dest_path: str) -> Optional[TarInfo]:

--- a/bench/utils/__init__.py
+++ b/bench/utils/__init__.py
@@ -9,7 +9,7 @@ from functools import lru_cache
 from glob import glob
 from pathlib import Path
 from shlex import split
-from tarfile import AbsoluteLinkError, TarInfo
+from tarfile import TarInfo
 from typing import List, Optional, Tuple
 
 # imports - third party imports
@@ -578,11 +578,12 @@ def get_app_cache_extract_filter(
 ): # -> Callable[[TarInfo, str], TarInfo | None]
 	state = dict(count=0, size=0)
 
-	if sys.version_info.major <=2 or sys.version_info.minor <=8:
-		def data_filter(m, p):
-			return m
-	else:
-		from tarfile import data_filter
+	AbsoluteLinkError = Exception
+	def data_filter(m: TarInfo, _:str) -> TarInfo:
+		return m
+
+	if (sys.version_info.major == 3 and sys.version_info.minor > 7) or sys.version_info.major > 3:
+		from tarfile import data_filter, AbsoluteLinkError
 
 	def filter_function(member: TarInfo, dest_path: str) -> Optional[TarInfo]:
 		state["count"] += 1


### PR DESCRIPTION
Adds a safety filter that checks total extraction size and file count, also uses [`tarfile.data_filter`](https://docs.python.org/3/library/tarfile.html#tarfile.data_filter)