### PR TITLE
fix: increase tar file limit

### DIFF
--- a/bench/app.py
+++ b/bench/app.py
@@ -374,7 +374,9 @@ class App(AppMeta):
 			try:
 				tar.extractall(app_path.parent, filter=extraction_filter)
 			except Exception:
-				logger.exception(f"Cache extraction failed for {self.app_name}")
+				message = f"Cache extraction failed for {self.app_name}, skipping cache"
+				click.secho(message, fg="yellow")
+				logger.exception(message)
 				shutil.rmtree(app_path)
 				return False
 

--- a/bench/app.py
+++ b/bench/app.py
@@ -370,8 +370,9 @@ class App(AppMeta):
 
 		click.secho(f"Getting {self.app_name} from cache", fg="yellow")
 		with tarfile.open(cache_path, mode) as tar:
+			extraction_filter = get_app_cache_extract_filter(count_threshold=150_000)
 			try:
-				tar.extractall(app_path.parent, filter=get_app_cache_extract_filter())
+				tar.extractall(app_path.parent, filter=extraction_filter)
 			except Exception:
 				logger.exception(f"Cache extraction failed for {self.app_name}")
 				shutil.rmtree(app_path)


### PR DESCRIPTION
Including `node_modules` in tar blob causes
file counts to be consistently above 10k
eg:
- gameplan: 25,269
- hrms: 32,369