### PR TITLE
fix: RQ crashes on Mac

### DIFF
--- a/bench/config/procfile.py
+++ b/bench/config/procfile.py
@@ -1,19 +1,19 @@
-# imports - standard imports
 import os
+import platform
 
-# imports - third party imports
 import click
 
-# imports - module imports
 import bench
 from bench.app import use_rq
-from bench.utils import which
 from bench.bench import Bench
+from bench.utils import which
 
 
 def setup_procfile(bench_path, yes=False, skip_redis=False):
 	config = Bench(bench_path).conf
 	procfile_path = os.path.join(bench_path, "Procfile")
+
+	is_mac = platform.system() == "Darwin"
 	if not yes and os.path.exists(procfile_path):
 		click.confirm(
 			"A Procfile already exists and this will overwrite it. Do you want to continue?",
@@ -30,6 +30,7 @@ def setup_procfile(bench_path, yes=False, skip_redis=False):
 			CI=os.environ.get("CI"),
 			skip_redis=skip_redis,
 			workers=config.get("workers", {}),
+			is_mac=is_mac,
 		)
 	)
 

--- a/bench/config/templates/Procfile
+++ b/bench/config/templates/Procfile
@@ -5,18 +5,14 @@ redis_queue: redis-server config/redis_queue.conf
 web: bench serve {% if webserver_port -%} --port {{ webserver_port }} {%- endif %}
 
 socketio: {{ node }} apps/frappe/socketio.js
+
 {% if not CI %}
 watch: bench watch
 {% endif %}
-{% if use_rq -%}
+
 schedule: bench schedule
-worker: bench worker 1>> logs/worker.log 2>> logs/worker.error.log
+worker: {{ 'OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES NO_PROXY=*' if is_mac else '' }} bench worker 1>> logs/worker.log 2>> logs/worker.error.log
 {% for worker_name, worker_details in workers.items() %}
-worker_{{ worker_name }}: bench worker --queue {{ worker_name }} 1>> logs/worker.log 2>> logs/worker.error.log
+worker_{{ worker_name }}: {{ 'OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES NO_PROXY=*' if is_mac else '' }} bench worker --queue {{ worker_name }} 1>> logs/worker.log 2>> logs/worker.error.log
 {% endfor %}
-{% else %}
-workerbeat: sh -c 'cd sites && exec ../env/bin/python -m frappe.celery_app beat -s scheduler.schedule'
-worker: sh -c 'cd sites && exec ../env/bin/python -m frappe.celery_app worker -n jobs@%h -Ofair --soft-time-limit 360 --time-limit 390'
-longjob_worker: sh -c 'cd sites && exec ../env/bin/python -m frappe.celery_app worker -n longjobs@%h -Ofair --soft-time-limit 1500 --time-limit 1530'
-async_worker: sh -c 'cd sites && exec ../env/bin/python -m frappe.celery_app worker -n async@%h -Ofair --soft-time-limit 1500 --time-limit 1530'
-{%- endif %}
+


### PR DESCRIPTION
It will still crash if spawned outside of Procfile. This is just a
workaround for developers who are starting out and won't be able to
figure out the crash. You can also add env variables in your RC file.

Permanent fix: Use Linux. :new_moon_with_face: 
