### PR TITLE
fix: Check yarn files during install

### DIFF
--- a/bench/app.py
+++ b/bench/app.py
@@ -423,7 +423,7 @@ class App(AppMeta):
 			remove_unused_node_modules(app_path)
 
 
-def coerce_url_to_name_if_possible(git_url: str, cache_key:str) -> str:
+def coerce_url_to_name_if_possible(git_url: str, cache_key: str) -> str:
 	app_name = os.path.basename(git_url)
 	if can_get_cached(app_name, cache_key):
 		return app_name
@@ -435,7 +435,7 @@ def can_get_cached(app_name: str, cache_key: str) -> bool:
 	Used before App is initialized if passed `git_url` is a
 	file URL as opposed to the app name.
 
-	If True then `git_url` can be coerced into the `app_name` and 
+	If True then `git_url` can be coerced into the `app_name` and
 	checking local remote and fetching can be skipped while keeping
 	get-app command params the same.
 	"""
@@ -671,7 +671,7 @@ def get_app(
 	import bench.cli as bench_cli
 	from bench.bench import Bench
 	from bench.utils.app import check_existing_dir
-	
+
 	if urlparse(git_url).scheme == "file" and cache_key:
 		git_url = coerce_url_to_name_if_possible(git_url, cache_key)
 
@@ -908,7 +908,9 @@ def install_app(
 		install_python_dev_dependencies(apps=app, bench_path=bench_path, verbose=verbose)
 
 	if not using_cached and os.path.exists(os.path.join(app_path, "package.json")):
-		yarn_install = "yarn install --verbose" if verbose else "yarn install"
+		yarn_install = "yarn install --check-files"
+		if verbose:
+			yarn_install += " --verbose"
 		bench.run(yarn_install, cwd=app_path)
 
 	bench.apps.sync(app_name=app, required=resolution, branch=tag, app_dir=app_path)

--- a/bench/utils/bench.py
+++ b/bench/utils/bench.py
@@ -18,8 +18,14 @@ import click
 # imports - module imports
 import bench
 from bench.exceptions import PatchError, ValidationError
-from bench.utils import (exec_cmd, get_bench_cache_path, get_bench_name,
-                         get_cmd_output, log, which)
+from bench.utils import (
+	exec_cmd,
+	get_bench_cache_path,
+	get_bench_name,
+	get_cmd_output,
+	log,
+	which,
+)
 
 logger = logging.getLogger(bench.PROJECT_NAME)
 
@@ -132,7 +138,9 @@ def update_yarn_packages(bench_path=".", apps=None, verbose=None):
 		app_path = os.path.join(apps_dir, app)
 		if os.path.exists(os.path.join(app_path, "package.json")):
 			click.secho(f"\nInstalling node dependencies for {app}", fg="yellow")
-			yarn_install = "yarn install --verbose" if verbose else "yarn install"
+			yarn_install = "yarn install --check-files"
+			if verbose:
+				yarn_install += " --verbose"
 			bench.run(yarn_install, cwd=app_path)
 
 
@@ -329,7 +337,10 @@ def restart_supervisor_processes(bench_path=".", web_workers=False, _raise=False
 		for group in groups:
 			failure = bench.run(f"{sudo}supervisorctl restart {group}", _raise=_raise)
 			if failure:
-				log(f"restarting supervisor group `{group}` failed. Use `bench restart` to retry.", level=3)
+				log(
+					f"restarting supervisor group `{group}` failed. Use `bench restart` to retry.",
+					level=3,
+				)
 
 
 def restart_systemd_processes(bench_path=".", web_workers=False, _raise=True):


### PR DESCRIPTION
We observed that in some cases files are missing when yarn reuses them
from cache. Not sure what's causing it but checking files seems to at
least fix it. This is probably some yarn bug.


https://github.com/yarnpkg/yarn/issues/3223#issuecomment-296373273