### PR TITLE
feat: `bench validate-dependencies` command

### DIFF
--- a/bench/commands/__init__.py
+++ b/bench/commands/__init__.py
@@ -46,6 +46,7 @@ from bench.commands.make import (
 	new_app,
 	pip,
 	remove_app,
+	validate_dependencies,
 )
 
 bench_command.add_command(init)
@@ -56,6 +57,7 @@ bench_command.add_command(remove_app)
 bench_command.add_command(exclude_app_for_update)
 bench_command.add_command(include_app_for_update)
 bench_command.add_command(pip)
+bench_command.add_command(validate_dependencies)
 
 
 from bench.commands.update import (

--- a/bench/commands/make.py
+++ b/bench/commands/make.py
@@ -253,3 +253,20 @@ def pip(ctx, args):
 
 	env_py = get_env_cmd("python")
 	os.execv(env_py, (env_py, "-m", "pip") + args)
+
+
+@click.command(
+	"validate-dependencies",
+	help="Validates that all requirements specified in frappe-dependencies are met curently.",
+)
+@click.pass_context
+def validate_dependencies(ctx):
+	"Validate all specified frappe-dependencies."
+	from bench.bench import Bench
+	from bench.app import App
+
+	bench = Bench(".")
+
+	for app_name in bench.apps:
+		app = App(app_name, bench=bench)
+		app.validate_app_dependencies(throw=True)


### PR DESCRIPTION
This validates all `frappe-dependencies` and exits with 1 if any of
specifications fail.

This will be internal feature for FC for now. If this works well we can
make the validation fail during install-app itself without requiring any
additional command/steps.


kind of addresses https://github.com/frappe/bench/issues/1524 but not quite there yet. 