### PR TITLE
fix: ignore org check fail if using cache

### DIFF
--- a/bench/app.py
+++ b/bench/app.py
@@ -127,7 +127,8 @@ class AppMeta:
 			self.tag = self.branch = None
 
 	def _setup_details_from_name_tag(self):
-		self.org, self.repo, self.tag = fetch_details_from_tag(self.name)
+		using_cached = bool(self.cache_key)
+		self.org, self.repo, self.tag = fetch_details_from_tag(self.name, using_cached)
 		self.tag = self.tag or self.branch
 
 	def _setup_details_from_git_url(self, url=None):

--- a/bench/utils/__init__.py
+++ b/bench/utils/__init__.py
@@ -417,7 +417,7 @@ def get_env_frappe_commands(bench_path=".") -> List:
 	return []
 
 
-def find_org(org_repo):
+def find_org(org_repo, using_cached: bool=False):
 	import requests
 
 	org_repo = org_repo[0]
@@ -429,10 +429,13 @@ def find_org(org_repo):
 		if res.ok:
 			return org, org_repo
 
-	raise InvalidRemoteException(f"{org_repo} not found in frappe or erpnext")
+	if using_cached:
+		return "", org_repo
+
+	raise InvalidRemoteException(f"{org_repo} not found under frappe or erpnext GitHub accounts")
 
 
-def fetch_details_from_tag(_tag: str) -> Tuple[str, str, str]:
+def fetch_details_from_tag(_tag: str, using_cached: bool=False) -> Tuple[str, str, str]:
 	if not _tag:
 		raise Exception("Tag is not provided")
 
@@ -447,7 +450,7 @@ def fetch_details_from_tag(_tag: str) -> Tuple[str, str, str]:
 	try:
 		org, repo = org_repo
 	except Exception:
-		org, repo = find_org(org_repo)
+		org, repo = find_org(org_repo, using_cached)
 
 	return org, repo, tag
 


### PR DESCRIPTION
If cache is being used org information is redundant, but `get-app` fails if it isn't found. This change skips failing if org is not found and app is using cached.