### PR TITLE
fix: setup: supervisor conf not deployed the first time setting up production

### DIFF
--- a/bench/config/production_setup.py
+++ b/bench/config/production_setup.py
@@ -48,6 +48,7 @@ def setup_production(user, bench_path=".", yes=False):
 		generate_systemd_config(bench_path=bench_path, user=user, yes=yes)
 	else:
 		print("Setting Up supervisor...")
+		conf.update({"restart_supervisor_on_update": True}) # This conf is False the first time, it is set later
 		check_supervisord_config(user=user)
 		generate_supervisor_config(bench_path=bench_path, user=user, yes=yes)
 


### PR DESCRIPTION
Common site settings `restart_supervisor_on_update` and `restart_systemd_on_update` are both `False` initially, so supervisor is used by default, but the conf files are never deployed.

I therefore suggest setting it manually before it is written in the actual `common_site_config.json`.