### PR TITLE
fix: check cache hash before using

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
+        python-version: ['3.8', '3.9', '3.10' ]
 
     name: Base (${{ matrix.python-version }})
 
@@ -58,7 +58,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [ '3.7', '3.10' ]
+        python-version: ['3.10' ]
 
     name: Production (${{ matrix.python-version }})
 
@@ -96,7 +96,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.7', '3.10' ]
+        python-version: ['3.10' ]
 
     name: Tests (${{ matrix.python-version }})
 
@@ -119,11 +119,6 @@ jobs:
         if: ${{ matrix.python-version == '3.10' }}
         with:
           node-version: 18
-
-      - uses: actions/setup-node@v3
-        if: ${{ matrix.python-version == '3.7' }}
-        with:
-          node-version: 14
 
       - run: |
           wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.focal_amd64.deb;

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Bench is a command-line utility that helps you to install, update, and manage mu
 
 <div align="center">
 	<a target="_blank" href="https://www.python.org/downloads/" title="Python version">
-		<img src="https://img.shields.io/badge/python-%3E=_3.7-green.svg">
+		<img src="https://img.shields.io/badge/python-%3E=_3.8-green.svg">
 	</a>
 	<a target="_blank" href="https://app.travis-ci.com/github/frappe/bench" title="CI Status">
 		<img src="https://app.travis-ci.com/frappe/bench.svg?branch=develop">

--- a/bench/app.py
+++ b/bench/app.py
@@ -595,7 +595,10 @@ def remove_unused_node_modules(app_path: Path) -> None:
 			can_delete = "vite build" in build_script
 
 		if can_delete:
-			click.secho(f"Bench app-cache: removing {node_modules.as_posix()}")
+			click.secho(
+				f"Bench app-cache: removing {node_modules.as_posix()}",
+				fg="yellow",
+			)
 			shutil.rmtree(node_modules)
 
 

--- a/bench/app.py
+++ b/bench/app.py
@@ -385,13 +385,13 @@ class App(AppMeta):
 		if app_path.is_dir():
 			shutil.rmtree(app_path)
 
-		click.secho(f"Getting {self.app_name} from cache", fg="yellow")
+		click.secho(f"Bench app-cache: getting {self.app_name} from cache", fg="yellow")
 		with tarfile.open(cache_path, mode) as tar:
 			extraction_filter = get_app_cache_extract_filter(count_threshold=150_000)
 			try:
 				tar.extractall(app_path.parent, filter=extraction_filter)
 			except Exception:
-				message = f"Cache extraction failed for {self.app_name}, skipping cache"
+				message = f"Bench app-cache: extraction failed for {self.app_name}, skipping cache"
 				click.secho(message, fg="yellow")
 				logger.exception(message)
 				shutil.rmtree(app_path)
@@ -411,7 +411,7 @@ class App(AppMeta):
 		cache_path = self.get_app_cache_temp_path(compress_artifacts)
 		mode = "w:gz" if compress_artifacts else "w"
 
-		message = f"Caching {self.app_name} app directory"
+		message = f"Bench app-cache: caching {self.app_name} app directory"
 		if compress_artifacts:
 			message += " (compressed)"
 		click.secho(message)
@@ -428,7 +428,7 @@ class App(AppMeta):
 
 			success = True
 		except Exception as exc:
-			log(f"Failed to cache {app_path} {exc}", level=3)
+			log(f"Bench app-cache: failed to cache {app_path} {exc}", level=3)
 			success = False
 		finally:
 			os.chdir(cwd)
@@ -501,7 +501,7 @@ def can_frappe_use_cached(app: App) -> bool:
 		"""
 		return sv.Version("15.12.0") not in sv.SimpleSpec(min_frappe)
 	except ValueError:
-		click.secho(f"Invalid value found for frappe version '{min_frappe}'", fg="yellow")
+		click.secho(f"Bench app-cache: invalid value found for frappe version '{min_frappe}'", fg="yellow")
 		# Invalid expression
 		return False
 
@@ -610,6 +610,7 @@ def remove_unused_node_modules(app_path: Path) -> None:
 			can_delete = "vite build" in build_script
 
 		if can_delete:
+			click.secho(f"Bench app-cache: removing {node_modules.as_posix()}")
 			shutil.rmtree(node_modules)
 
 

--- a/bench/app.py
+++ b/bench/app.py
@@ -350,35 +350,49 @@ class App(AppMeta):
 		assert self.cache_key is not None
 
 		ext = temp_path.suffix[1:]
-		md5 = get_file_md5(temp_path.as_posix())
+		md5 = get_file_md5(temp_path)
 		tarfile_name = f"{self.app_name}.{self.cache_key}.md5-{md5}.{ext}"
+
 		return temp_path.with_name(tarfile_name)
 
-	def get_app_cache_path(self, is_compressed=False) -> Path:
+	def get_app_cache_path(self) -> "Optional[Path]":
 		assert self.cache_key is not None
 
 		cache_path = get_bench_cache_path("apps")
-		tarfile_name = get_cache_filename(
-			self.app_name,
-			self.cache_key,
-			is_compressed,
-		)
-		return cache_path / tarfile_name
+		glob_pattern = f"{self.app_name}.{self.cache_key}.md5-*"
+
+		for app_cache_path in cache_path.glob(glob_pattern):
+			return app_cache_path
+
+		return None
+
+	def validate_cache_and_get_path(self) -> "Optional[Path]":
+		if not self.cache_key:
+			return
+
+		if not (cache_path := self.get_app_cache_path()):
+			return
+
+		if not cache_path.is_file():
+			click.secho(
+				f"Bench app-cache: file check failed for {cache_path.as_posix()}, skipping cache",
+				fg="yellow",
+			)
+			unlink_no_throw(cache_path)
+			return
+
+		if not is_cache_hash_valid(cache_path):
+			click.secho(
+				f"Bench app-cache: hash validation failed for {cache_path.as_posix()}, skipping cache",
+				fg="yellow",
+			)
+			unlink_no_throw(cache_path)
+			return
+
+		return cache_path
 
 	def get_cached(self) -> bool:
-		if not self.cache_key:
-			return False
-
-		cache_path = self.get_app_cache_path(False)
-		mode = "r"
-
-		# Check if cache exists without gzip
-		if not cache_path.is_file():
-			cache_path = self.get_app_cache_path(True)
-			mode = "r:gz"
-
-		# Check if cache exists with gzip
-		if not cache_path.is_file():
+		if not (cache_path := self.validate_cache_and_get_path()):
 			return False
 
 		app_path = self.get_app_path()
@@ -386,13 +400,18 @@ class App(AppMeta):
 			shutil.rmtree(app_path)
 
 		click.secho(f"Bench app-cache: getting {self.app_name} from cache", fg="yellow")
+
+		mode = "r:gz" if cache_path.suffix.endswith(".tgz") else "r"
 		with tarfile.open(cache_path, mode) as tar:
 			extraction_filter = get_app_cache_extract_filter(count_threshold=150_000)
 			try:
 				tar.extractall(app_path.parent, filter=extraction_filter)
 			except Exception:
 				message = f"Bench app-cache: extraction failed for {self.app_name}, skipping cache"
-				click.secho(message, fg="yellow")
+				click.secho(
+					message,
+					fg="yellow",
+				)
 				logger.exception(message)
 				shutil.rmtree(app_path)
 				return False
@@ -423,7 +442,10 @@ class App(AppMeta):
 		try:
 			with tarfile.open(cache_path, mode) as tar:
 				tar.add(app_path.name)
+
 			hashed_path = self.get_app_cache_hashed_name(cache_path)
+			unlink_no_throw(hashed_path)
+
 			cache_path.rename(hashed_path)
 
 			success = True
@@ -501,7 +523,10 @@ def can_frappe_use_cached(app: App) -> bool:
 		"""
 		return sv.Version("15.12.0") not in sv.SimpleSpec(min_frappe)
 	except ValueError:
-		click.secho(f"Bench app-cache: invalid value found for frappe version '{min_frappe}'", fg="yellow")
+		click.secho(
+			f"Bench app-cache: invalid value found for frappe version '{min_frappe}'",
+			fg="yellow",
+		)
 		# Invalid expression
 		return False
 
@@ -1056,3 +1081,22 @@ def get_apps_json(path):
 
 	with open(path) as f:
 		return json.load(f)
+
+
+def is_cache_hash_valid(cache_path: Path) -> bool:
+	parts = cache_path.name.split(".")
+	if len(parts) < 2 or not parts[-2].startswith("md5-"):
+		return False
+
+	md5 = parts[-2].split("-")[1]
+	return get_file_md5(cache_path) == md5
+
+
+def unlink_no_throw(path: Path):
+	if not path.exists():
+		return
+
+	try:
+		path.unlink(True)
+	except Exception:
+		pass

--- a/bench/app.py
+++ b/bench/app.py
@@ -366,15 +366,21 @@ class App(AppMeta):
 		if app_path.is_dir():
 			shutil.rmtree(app_path)
 
-		click.secho(f"Bench app-cache: getting {self.app_name} from cache", fg="yellow")
+		click.secho(
+			f"Bench app-cache: extracting {self.app_name} from {cache_path.as_posix()}",
+		)
 
 		mode = "r:gz" if cache_path.suffix.endswith(".tgz") else "r"
 		with tarfile.open(cache_path, mode) as tar:
 			extraction_filter = get_app_cache_extract_filter(count_threshold=150_000)
 			try:
 				tar.extractall(app_path.parent, filter=extraction_filter)
+				click.secho(
+					f"Bench app-cache: extraction succeeded for {self.app_name}",
+					fg="green",
+				)
 			except Exception:
-				message = f"Bench app-cache: extraction failed for {self.app_name}, skipping cache"
+				message = f"Bench app-cache: extraction failed for {self.app_name}"
 				click.secho(
 					message,
 					fg="yellow",
@@ -397,7 +403,7 @@ class App(AppMeta):
 		cache_path = self.get_app_cache_temp_path(compress_artifacts)
 		mode = "w:gz" if compress_artifacts else "w"
 
-		message = f"Bench app-cache: caching {self.app_name} app directory"
+		message = f"Bench app-cache: caching {self.app_name}"
 		if compress_artifacts:
 			message += " (compressed)"
 		click.secho(message)
@@ -414,10 +420,14 @@ class App(AppMeta):
 			unlink_no_throw(hashed_path)
 
 			cache_path.rename(hashed_path)
+			click.secho(
+				f"Bench app-cache: caching succeeded for {self.app_name} into {hashed_path.as_posix()}",
+				fg="green",
+			)
 
 			success = True
 		except Exception as exc:
-			log(f"Bench app-cache: failed to cache {app_path} {exc}", level=3)
+			log(f"Bench app-cache: caching failed for {self.app_name} {exc}", level=3)
 			success = False
 		finally:
 			os.chdir(cwd)

--- a/bench/app.py
+++ b/bench/app.py
@@ -421,7 +421,7 @@ class App(AppMeta):
 
 			cache_path.rename(hashed_path)
 			click.secho(
-				f"Bench app-cache: caching succeeded for {self.app_name} into {hashed_path.as_posix()}",
+				f"Bench app-cache: caching succeeded for {self.app_name} as {hashed_path.as_posix()}",
 				fg="green",
 			)
 

--- a/bench/utils/__init__.py
+++ b/bench/utils/__init__.py
@@ -5,6 +5,7 @@ import os
 import re
 import subprocess
 import sys
+import hashlib
 from functools import lru_cache
 from glob import glob
 from pathlib import Path
@@ -22,6 +23,12 @@ from bench.exceptions import (
 	CommandFailedError,
 	InvalidRemoteException,
 )
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+	from typing import Optional
+
 
 logger = logging.getLogger(PROJECT_NAME)
 paths_in_app = ("hooks.py", "modules.txt", "patches.txt")
@@ -605,3 +612,10 @@ def get_app_cache_extract_filter(
 			return None
 
 	return filter_function
+
+def get_file_md5(p: str) -> "str":
+	with open(p, "rb") as f:
+		file_md5 = hashlib.md5()
+		while chunk := f.read(2**16):
+			file_md5.update(chunk)
+	return file_md5.hexdigest()

--- a/bench/utils/__init__.py
+++ b/bench/utils/__init__.py
@@ -613,8 +613,8 @@ def get_app_cache_extract_filter(
 
 	return filter_function
 
-def get_file_md5(p: str) -> "str":
-	with open(p, "rb") as f:
+def get_file_md5(p: Path) -> "str":
+	with open(p.as_posix(), "rb") as f:
 		file_md5 = hashlib.md5()
 		while chunk := f.read(2**16):
 			file_md5.update(chunk)

--- a/bench/utils/bench.py
+++ b/bench/utils/bench.py
@@ -688,7 +688,7 @@ def cache_list() -> None:
 		created = datetime.fromtimestamp(stat.st_ctime)
 		accessed = datetime.fromtimestamp(stat.st_atime)
 
-		app = item.name.split("-")[0]
+		app = item.name.split(".")[0]
 		tot_items += 1
 		tot_size += stat.st_size
 		compressed = item.suffix == ".tgz"
@@ -696,7 +696,7 @@ def cache_list() -> None:
 		if not printed_header:
 			click.echo(
 				f"{'APP':15}  "
-				f"{'FILE':25}  "
+				f"{'FILE':90}  "
 				f"{'SIZE':>13}  "
 				f"{'COMPRESSED'}  "
 				f"{'CREATED':19}  "
@@ -706,7 +706,7 @@ def cache_list() -> None:
 
 		click.echo(
 			f"{app:15}  "
-			f"{item.name:25}  "
+			f"{item.name:90}  "
 			f"{size_mb:10.3f} MB  "
 			f"{str(compressed):10}  "
 			f"{created:%Y-%m-%d %H:%M:%S}  "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "frappe-bench"
 description = "CLI to manage Multi-tenant deployments for Frappe apps"
 readme = "README.md"
 license = "GPL-3.0-only"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 authors = [
     { name = "Frappe Technologies Pvt Ltd", email = "developers@frappe.io" },
 ]


### PR DESCRIPTION
Check hash md5 against previously calculated md5 (when setting cache), improve a few of the bench app-cache messages.