### PR TITLE
fix: easy install incorrect dev documentation link

### DIFF
--- a/easy-install.py
+++ b/easy-install.py
@@ -232,7 +232,7 @@ def setup_dev_instance(project: str):
 				check=True,
 			)
 			cprint(
-				"Please go through the Development Documentation: https://github.com/frappe/frappe_docker/tree/main/development to fully complete the setup.",
+				"Please go through the Development Documentation: https://github.com/frappe/frappe_docker/tree/main/docs/development.md to fully complete the setup.",
 				level=2,
 			)
 			logging.info("Development Setup completed")


### PR DESCRIPTION
Development Documentation was moved [development/README.md → docs/development.md](https://github.com/frappe/frappe_docker/commit/e6088af885390e89a9f5d3e596c47f683cf5a6fd#diff-97db29a7915320e63d41d38a0440360a87055ee8ed03757aa263116dbbb4aabe)

The new location was never updated in easy-install.py.