### PR TITLE
fix: ERROR! [DEPRECATED] ansible.builtin.include has been removed. Use include_tasks or import_tasks instead. This feature was removed from ansible-core in a release after 2023-05-16. Please update your playbooks.

### DIFF
--- a/bench/playbooks/roles/mariadb/tasks/main.yml
+++ b/bench/playbooks/roles/mariadb/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
-- include: centos.yml
+- include_tasks: centos.yml
   when: ansible_distribution == 'CentOS' and ansible_distribution_major_version|int >= 6
 
-- include: ubuntu-trusty.yml
+- include_tasks: ubuntu-trusty.yml
   when: ansible_distribution == 'Ubuntu' and ansible_distribution_version == '14.04'
 
-- include: ubuntu-xenial_bionic.yml
+- include_tasks: ubuntu-xenial_bionic.yml
   when: ansible_distribution == 'Ubuntu' and ansible_distribution_major_version|int >= 16
 
 - name: Add configuration


### PR DESCRIPTION
Since 2023-05-16 ansible.builtin.include has been remove must use include_tasks instead

$ bench setup role supervisor

ansible-playbook [core 2.16.7]
  config file = None
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.10/dist-packages/ansible
  ansible collection location = /root/.ansible/collections:/usr/share/ansible/collections
  executable location = /usr/local/bin/ansible-playbook
  python version = 3.10.12 (main, Nov 20 2023, 15:14:05) [GCC 11.4.0] (/usr/bin/python3)
  jinja version = 3.1.4
  libyaml = True
No config file found; using defaults
setting up inventory plugins
Loading collection ansible.builtin from 
host_list declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
script declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
auto declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
yaml declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
ini declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
toml declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'
ERROR! [DEPRECATED]: ansible.builtin.include has been removed. Use include_tasks or import_tasks instead. This feature was removed from ansible-core in a release after 2023-05-16. Please update your playbooks.

The error appears to be in '/usr/local/lib/python3.10/dist-packages/bench/playbooks/roles/mariadb/tasks/main.yml': line 2, column 3, but may
be elsewhere in the file depending on the exact syntax problem.
