### PR TITLE
fix(ansible): Use include_tasks instead of include

### DIFF
--- a/bench/playbooks/macosx.yml
+++ b/bench/playbooks/macosx.yml
@@ -24,7 +24,7 @@
         state: present
 
     - name: configure mariadb
-      include: roles/mariadb/tasks/main.yml
+      include_tasks: roles/mariadb/tasks/main.yml
       vars:
         mysql_conf_tpl: roles/mariadb/files/mariadb_config.cnf
 
@@ -32,10 +32,10 @@
       pip: name=mysql-python version=1.2.5
 
     # setup frappe-bench
-    - include: includes/setup_bench.yml
+    - include_tasks: includes/setup_bench.yml
 
     # setup development environment
-    - include: includes/setup_dev_env.yml
+    - include_tasks: includes/setup_dev_env.yml
       when: not production
 
 ...


### PR DESCRIPTION
Happens on **Ubuntu 24.04** during `bench setup production`.

https://serverfault.com/questions/875247/whats-the-difference-between-include-tasks-and-import-tasks#comment1143958_875292

https://github.com/ansible/ansible/issues/76684

```yaml
ERROR! [DEPRECATED]: ansible.builtin.include has been removed. Use include_tasks or import_tasks instead. This feature was removed from ansible-core in a release after 2023-05-16. Please update your playbooks.

The error appears to be in '/usr/local/lib/python3.12/dist-packages/bench/playbooks/roles/mariadb/tasks/main.yml': line 2, column 3, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

---
- include: centos.yml
  ^ here
ERROR: Command '['ansible-playbook', '-c', 'local', 'site.yml', '-vvvv', '-e', '{"production": true, "admin_emails": "", "mysql_root_password": null, "container": false}', '-t', 'fail2ban']' returned non-zero exit status 1.

```