### PR TITLE
chore(deps): bump `semantic-version` to match frappe framework

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "Jinja2~=3.1.3",
     "python-crontab~=2.6.0",
     "requests",
-    "semantic-version~=2.8.2",
+    "semantic-version~=2.10.0",
     "setuptools>40.9.0",
     "tomli;python_version<'3.11'",
 ]


### PR DESCRIPTION
If you try to installed `frappe-bench` within the same virtualenv where frappe framework is setup, it fails due to different versions of semantic-version being required. (Not a normal use case I assume, but no harm in this)
