### PR TITLE
fix: use a tuple instead of a list

### DIFF
--- a/bench/utils/bench.py
+++ b/bench/utils/bench.py
@@ -86,7 +86,7 @@ def install_python_dev_dependencies(bench_path=".", apps=None, verbose=False):
 	bench = Bench(bench_path)
 
 	if isinstance(apps, str):
-		apps = [apps]
+		apps = (apps,)
 	elif not apps:
 		apps = bench.get_installed_apps()
 


### PR DESCRIPTION
From perflint:
bench/utils/bench.py:89:9: W8301: Use tuple instead of list for a non-mutated sequence (use-tuple-over-list)

(just needed a "fix" to trigger a new release)
