### PR TITLE
feat: mTLS with nginx and python

### DIFF
--- a/bench/config/templates/nginx.conf
+++ b/bench/config/templates/nginx.conf
@@ -48,6 +48,7 @@ server {
 	ssl_ciphers EECDH+AESGCM:EDH+AESGCM;
 	ssl_ecdh_curve secp384r1;
 	ssl_prefer_server_ciphers on;
+	ssl_verify_client optional_no_ca;
 	{% endif %}
 
 	add_header X-Frame-Options "SAMEORIGIN";
@@ -98,6 +99,7 @@ server {
 		proxy_set_header X-Frappe-Site-Name {{ site_name }};
 		proxy_set_header Host $host;
 		proxy_set_header X-Use-X-Accel-Redirect True;
+		proxy_set_header SSL_CLIENT_CERT $ssl_client_cert;
 		proxy_read_timeout {{ http_timeout or 120 }};
 		proxy_redirect off;
 


### PR DESCRIPTION
When we are going to integrate 2 systems where we need a high level of security between the two ends of the communication, we must use mTLS to verify and validate that the requests received from the client have the certificate...
Normally this type of integration does not work with HMAC, it must use mTLS.

![image](https://github.com/user-attachments/assets/2523e192-2de4-4c1f-abf3-a956d9650a4c)

So, I looked for the most efficient and flexible configuration to apply this, thinking that on a server with a "bench" we will have more than one site and each site can have more than one integration enabled with mTLS certificate configured and each integration can have your own certificate

![image](https://github.com/user-attachments/assets/13104ee1-d9e1-4282-b150-d0a744a635c7)


The ngnix configuration was chosen:
ssl_verify_client **optional_no_ca**
**optional_no_ca**: requests the client certificate but does not require it to be signed by a trusted CA certificate. This is intended for the use in cases when a service that is external to nginx performs the actual certificate verification. The contents of the certificate is accessible through the [$ssl_client_cert](https://nginx.org/en/docs/http/ngx_http_ssl_module.html#var_ssl_client_cert) variable.

"proxy_set_header SSL_CLIENT_CERT $ssl_client_cert;": allows you to get the certificate from the header, using a relative variable.
![image](https://github.com/user-attachments/assets/e0b47990-de50-4481-9aaf-a6623003104a)


So with this config, i can made a validade on Python loading the certificate configured on relative integration and confirming the identity:

![image](https://github.com/user-attachments/assets/064edffd-d591-4bdc-a4aa-79923218a83e)

ps: Maybe there are some more points to be implemented, I will be putting my application into production in a few days or weeks...

I am open to suggestions