### PR TITLE
fix: --no-mariadb-socket is DEPRECATED

### DIFF
--- a/easy-install.py
+++ b/easy-install.py
@@ -416,7 +416,7 @@ def create_site(
         "backend",
         "bench",
         "new-site",
-        "--no-mariadb-socket",
+        "--mariadb-user-host-login-scope=%",
         f"--db-root-password={db_pass}",
         f"--admin-password={admin_pass}",
     ]


### PR DESCRIPTION
--no-mariadb-socket is DEPRECATED; use --mariadb-user-host-login-scope='%' (wildcard) or --mariadb-user-host-login-scope=, instead.