### PR TITLE
fix: check whether `supervisorctl` exists before trying to restart

### DIFF
--- a/bench/utils/bench.py
+++ b/bench/utils/bench.py
@@ -298,6 +298,9 @@ def patch_sites(bench_path="."):
 
 
 def restart_supervisor_processes(bench_path=".", web_workers=False, _raise=False):
+	if which("supervisorctl") is None:
+		return
+
 	from bench.bench import Bench
 
 	bench = Bench(bench_path)


### PR DESCRIPTION
Resolves #1607
