### PR TITLE
fix: don't autorestart scheduler on `exit(0)`

### DIFF
--- a/bench/config/templates/supervisor.conf
+++ b/bench/config/templates/supervisor.conf
@@ -20,7 +20,6 @@ startretries={{ supervisor_startretries }}
 command={{ bench_cmd }} schedule
 priority=3
 autostart=true
-autorestart=true
 stdout_logfile={{ bench_dir }}/logs/schedule.log
 stderr_logfile={{ bench_dir }}/logs/schedule.error.log
 user={{ user }}


### PR DESCRIPTION
for https://github.com/frappe/frappe/pull/26566