### PR TITLE
chore: bump hatch and hatchling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,7 @@ jobs:
       - name: Setup dependencies
         run: |
           npm install @semantic-release/git @semantic-release/exec --no-save
-          python3 -m pip install wheel twine
-          python3 -m pip install git+https://github.com/pypa/hatch@hatch-v1.9.2
+          python3 -m pip install wheel twine hatch==1.14.1
 
       - name: Create Release
         env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ Source = "https://github.com/frappe/bench"
 
 [build-system]
 requires = [
-    "hatchling>=1.6.0,<=1.21.0",
+    "hatchling==1.27.0",
 ]
 build-backend = "hatchling.build"
 


### PR DESCRIPTION
license key was apparently invalid since metadata 2.1 was being used instead of 2.4
