### PR TITLE
fix: get-app softlink error

### DIFF
--- a/bench/app.py
+++ b/bench/app.py
@@ -86,7 +86,9 @@ class AppMeta:
 	def setup_details(self):
 		# support for --no-git
 		if not self.is_repo:
+			self.on_disk = True
 			self.repo = self.app_name = self.name
+			self.tag = self.branch = None
 			return
 		# fetch meta from installed apps
 		if self.bench and os.path.exists(os.path.join(self.bench.name, "apps", self.name)):


### PR DESCRIPTION
I haven't done the test for other case but after add these change, I was able to install app using `--soft-link`.

Error detailed here: https://github.com/frappe/bench/issues/1628