### PR TITLE
feat: add support for uv

### DIFF
--- a/bench/bench.py
+++ b/bench/bench.py
@@ -159,7 +159,10 @@ class Bench(Base, Validator):
 	def get_installed_apps(self) -> List:
 		"""Returns list of installed apps on bench, not in excluded_apps.txt"""
 		try:
-			installed_packages = get_cmd_output(f"{self.python} -m pip freeze", cwd=self.name)
+			if os.environ.get("BENCH_USE_UV"):
+				installed_packages = get_cmd_output(f"uv pip freeze --python {self.python}", cwd=self.name)
+			else:
+				installed_packages = get_cmd_output(f"{self.python} -m pip freeze", cwd=self.name)
 		except Exception:
 			installed_packages = []
 
@@ -361,8 +364,11 @@ class BenchSetup(Base):
 		quiet_flag = "" if verbose else "--quiet"
 
 		if not os.path.exists(self.bench.python):
-			venv = get_venv_path(verbose=verbose, python=python)
-			self.run(f"{venv} env", cwd=self.bench.name)
+			if os.environ.get("BENCH_USE_UV"):
+				self.run("uv venv env", cwd=self.bench.name)
+			else:
+				venv = get_venv_path(verbose=verbose, python=python)
+				self.run(f"{venv} env", cwd=self.bench.name)
 
 		self.pip()
 		self.wheel()
@@ -379,10 +385,16 @@ class BenchSetup(Base):
 							"PKG_CONFIG_PATH": get_mariadb_pkgconfig_path(),
 						}
 
-				self.run(
-					f"{self.bench.python} -m pip install {quiet_flag} --upgrade -e {frappe}",
-					cwd=self.bench.name, env=env,
-				)
+				if os.environ.get("BENCH_USE_UV"):
+					self.run(
+						f"uv pip install {quiet_flag} --upgrade -e {frappe} --python {self.bench.python}",
+						cwd=self.bench.name, env=env,
+					)
+				else:
+					self.run(
+						f"{self.bench.python} -m pip install {quiet_flag} --upgrade -e {frappe}",
+						cwd=self.bench.name, env=env,
+					)
 
 	@step(title="Setting Up Bench Config", success="Bench Config Set Up")
 	def config(self, redis=True, procfile=True, additional_config=None):
@@ -503,7 +515,10 @@ class BenchSetup(Base):
 						"PKG_CONFIG_PATH": get_mariadb_pkgconfig_path(),
 					}
 
-			self.run(f"{self.bench.python} -m pip install {quiet_flag} --upgrade -e {app_path}", env=env)
+			if os.environ.get("BENCH_USE_UV"):
+				self.run(f"uv pip install {quiet_flag} --upgrade -e {app_path} --python {self.bench.python}", env=env)
+			else:
+				self.run(f"{self.bench.python} -m pip install {quiet_flag} --upgrade -e {app_path}", env=env)
 
 	def node(self, apps=None):
 		"""Install and upgrade Node dependencies for specified / all apps on given Bench"""

--- a/bench/commands/make.py
+++ b/bench/commands/make.py
@@ -248,11 +248,15 @@ def include_app_for_update(app_name):
 def pip(ctx, args):
 	"Run pip commands in bench env"
 	import os
+	import shutil
 
 	from bench.utils.bench import get_env_cmd
 
-	env_py = get_env_cmd("python")
-	os.execv(env_py, (env_py, "-m", "pip") + args)
+	if os.environ.get("BENCH_USE_UV") and (env_uv := shutil.which("uv")):
+		os.execv(env_uv, (env_uv, "pip") + args)
+	else:
+		env_py = get_env_cmd("python")
+		os.execv(env_py, (env_py, "-m", "pip") + args)
 
 
 @click.command(

--- a/bench/utils/bench.py
+++ b/bench/utils/bench.py
@@ -99,12 +99,20 @@ def install_python_dev_dependencies(bench_path=".", apps=None, verbose=False):
 		if os.path.exists(pyproject_path):
 			pyproject_deps = _generate_dev_deps_pattern(pyproject_path)
 			if pyproject_deps:
-				bench.run(f"{bench.python} -m pip install {quiet_flag} --upgrade {pyproject_deps}")
+				if os.environ.get("BENCH_USE_UV"):
+					bench.run(f"uv pip install {quiet_flag} --upgrade {pyproject_deps} --python {bench.python}")
+				else:
+					bench.run(f"{bench.python} -m pip install {quiet_flag} --upgrade {pyproject_deps}")
 
 		if not pyproject_deps and os.path.exists(dev_requirements_path):
-			bench.run(
-				f"{bench.python} -m pip install {quiet_flag} --upgrade -r {dev_requirements_path}"
-			)
+			if os.environ.get("BENCH_USE_UV"):
+				bench.run(
+					f"uv pip install {quiet_flag} --upgrade -r {dev_requirements_path} --python {bench.python}"
+				)
+			else:
+				bench.run(
+					f"{bench.python} -m pip install {quiet_flag} --upgrade -r {dev_requirements_path}"
+				)
 
 
 def _generate_dev_deps_pattern(pyproject_path):
@@ -240,11 +248,17 @@ def migrate_env(python, backup=False):
 	# Create virtualenv using specified python
 	def _install_app(app):
 		app_path = f"-e {os.path.join('apps', app)}"
-		exec_cmd(f"{pvenv}/bin/python -m pip install --upgrade {app_path}")
+		if os.environ.get("BENCH_USE_UV"):
+			exec_cmd(f"uv pip install --upgrade {app_path} --python {pyenv}/bin/python")
+		else:
+			exec_cmd(f"{pyenv}/bin/python -m pip install --upgrade {app_path}")
 
 	try:
 		logger.log(f"Setting up a New Virtual {python} Environment")
-		exec_cmd(f"{python} -m venv {pvenv}")
+		if os.environ.get("BENCH_USE_UV"):
+			exec_cmd(f"uv venv {pvenv}")
+		else:
+			exec_cmd(f"{python} -m venv {pvenv}")
 
 		# Install frappe first
 		_install_app("frappe")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "semantic-version~=2.10.0",
     "setuptools>=71.0.0",
     "tomli;python_version<'3.11'",
+    "uv~=0.7.12"
 ]
 dynamic = [
     "version",


### PR DESCRIPTION
<details>

<summary>Initial rough benchmarks</summary>

Some very rough benchmarks:

```
hyperfine --prepare "rm -rf env && python -m venv ./env && pip cache purge" --cleanup "rm -rf env && python -m venv ./env && pip cache purge" "./env/bin/pip install -e ./frappe" --show-output

Time (mean ± σ):     58.030 s ±  1.462 s    [User: 26.213 s, System: 4.352 s]
  Range (min … max):   55.937 s … 60.069 s    10 runs
```
<hr>

```
hyperfine --prepare "rm -rf env && uv venv ./env && rm -rf ~/.cache/uv" --cleanup "rm -rf env && uv venv ./env && rm -rf ~/.cache/uv" "uv pip install -e ./frappe --python ./env/bin/python" --show-output

Time (mean ± σ):     10.848 s ±  0.362 s    [User: 9.305 s, System: 3.330 s]
  Range (min … max):   10.502 s … 11.645 s    10 runs
```

<hr>
</details>

<details>
<summary>Probably a better way, just frappe app</summary>

```docker
FROM python:3.13-slim

RUN apt update -y

RUN apt install pkg-config libmariadb-dev build-essential -y

RUN pip install uv

COPY frappe /frappe

WORKDIR /
```

```hyperfine --warmup 3 --runs 20 'docker run --rm benchmark pip install --no-cache-dir -e /frappe' 'docker run --rm benchmark uv pip install --no-cache -e /frappe --system'```

| Tool  | Mean Time (± σ)       | Time Range (min ... max)    | Runs |
| :---- | :---------------------- | :-------------------------- | :--- |
| `pip` | 54.701 s ± 3.145 s      | 47.724 s … 59.360 s         | 20   |
| `uv`  | 17.640 s ± 1.729 s      | 14.448 s … 20.396 s         | 20   |

---

**Summary:**

`uv` ran **3.10 ± 0.35** times faster than `pip`.

</details>

<details>
<summary> frappe+erpnext </summary>

```
❯ hyperfine --warmup 2 --runs 10 'docker run --rm benchmark bash /pip.sh' 'docker run --rm benchmark bash /uv.sh'

Benchmark 1: docker run --rm benchmark bash /pip.sh
  Time (mean ± σ):     62.483 s ±  3.292 s    [User: 0.014 s, System: 0.018 s]
  Range (min … max):   59.350 s … 70.381 s    10 runs

Benchmark 2: docker run --rm benchmark bash /uv.sh
  Time (mean ± σ):     20.159 s ±  2.653 s    [User: 0.007 s, System: 0.011 s]
  Range (min … max):   17.383 s … 23.804 s    10 runs

Summary
  docker run --rm benchmark bash /uv.sh ran
    3.10 ± 0.44 times faster than docker run --rm benchmark bash /pip.sh
```

</details>