### PR TITLE
fix!: use check_nested_command, drop python 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
 
     name: Base (${{ matrix.python-version }})
 

--- a/bench/utils/cli.py
+++ b/bench/utils/cli.py
@@ -1,6 +1,6 @@
 from typing import List
 import click
-from click.core import _check_multicommand
+from click.core import _check_nested_chain
 
 
 def print_bench_version(ctx, param, value):
@@ -25,7 +25,7 @@ class MultiCommandGroup(click.Group):
 		name = name or cmd.name
 		if name is None:
 			raise TypeError("Command has no name.")
-		_check_multicommand(self, name, cmd, register=True)
+		_check_nested_chain(self, name, cmd, register=True)
 
 		try:
 			self.commands[name] = cmd

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Topic :: System :: Installation/Setup",
 ]
 dependencies = [
-    "Click>=7.0",
+    "Click~=8.2.0",
     "GitPython~=3.1.30",
     "honcho",
     "Jinja2~=3.1.3",


### PR DESCRIPTION
Click released a new version 8.2.0
It doesnt have the _check_multicommand function as it has been renamed
Ref https://github.com/pallets/click/blob/8.2.0/src/click/core.py

```pip install frappe-bench```  fails because of this 

> [!CAUTION]
> This PR drops support for python3.9.