### PR TITLE
fix: Set stricter click version to ~=8.1.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Topic :: System :: Installation/Setup",
 ]
 dependencies = [
-    "Click~=7.0",
+    "Click~=8.1.0",
     "GitPython~=3.1.30",
     "honcho",
     "Jinja2~=3.1.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Topic :: System :: Installation/Setup",
 ]
 dependencies = [
-    "Click>=7.0",
+    "Click~=7.0",
     "GitPython~=3.1.30",
     "honcho",
     "Jinja2~=3.1.3",


### PR DESCRIPTION
closes #1633 

Does currently break all custom frappe_docker builds because of the new release of Click 8.0!

- [ ] Changes to Existing Features
- [ ] New Feature Submissions
- [x] Bug 
- [ ] Breaking Change (include change in API behaviours, etc.)