### PR TITLE
fix: drop cwd=self.bench.name

### DIFF
--- a/bench/utils/bench.py
+++ b/bench/utils/bench.py
@@ -257,9 +257,9 @@ def migrate_env(python, backup=False):
 		logger.log(f"Setting up a New Virtual {python} Environment")
 		if os.environ.get("BENCH_USE_UV"):
 			if os.environ.get("FRAPPE_DOCKER_BUILD"):
-				exec_cmd(f"uv venv {pvenv} --seed --link-mode=copy", cwd=self.bench.name)
+				exec_cmd(f"uv venv {pvenv} --seed --link-mode=copy")
 			else:
-				exec_cmd(f"uv venv {pvenv} --seed", cwd=self.bench.name)
+				exec_cmd(f"uv venv {pvenv} --seed")
 		else:
 			exec_cmd(f"{python} -m venv {pvenv}")
 

--- a/bench/utils/bench.py
+++ b/bench/utils/bench.py
@@ -257,9 +257,9 @@ def migrate_env(python, backup=False):
 		logger.log(f"Setting up a New Virtual {python} Environment")
 		if os.environ.get("BENCH_USE_UV"):
 			if os.environ.get("FRAPPE_DOCKER_BUILD"):
-				exec_cmd(f"uv venv {pvenv} --seed --link-mode=copy")
+				exec_cmd(f"uv venv {pvenv} --seed --link-mode=copy --python {python}")
 			else:
-				exec_cmd(f"uv venv {pvenv} --seed")
+				exec_cmd(f"uv venv {pvenv} --seed --python {python}")
 		else:
 			exec_cmd(f"{python} -m venv {pvenv}")
 


### PR DESCRIPTION
Typo introduced by some bad copy-pasting in 5767e62a8e13fb2ec12d2b6b0cfe9e41b8ef2c3e

