### PR TITLE
feat: add bench show-ports command to list site ports

### DIFF
--- a/bench/commands/__init__.py
+++ b/bench/commands/__init__.py
@@ -92,6 +92,7 @@ from bench.commands.utils import (
 	set_ssl_certificate_key,
 	set_url_root,
 	start,
+    show_ports
 )
 
 bench_command.add_command(start)
@@ -112,6 +113,7 @@ bench_command.add_command(bench_src)
 bench_command.add_command(find_benches)
 bench_command.add_command(migrate_env)
 bench_command.add_command(app_cache_helper)
+bench_command.add_command(show_ports)
 
 from bench.commands.setup import setup
 

--- a/bench/commands/utils.py
+++ b/bench/commands/utils.py
@@ -194,3 +194,93 @@ def app_cache_helper(clear=False, remove_app="", remove_key=""):
 	from bench.utils.bench import cache_helper
 
 	cache_helper(clear, remove_app, remove_key)
+
+
+from pathlib import Path
+from typing import List, Tuple
+import click
+import re
+from bench.utils import get_bench_name
+
+LISTEN_PORT_RE = re.compile(
+    r'\blisten\b\s+(?:\[[^\]]+\]:|[0-9a-zA-Z\.\-]+:)?(?P<port>\d+)', re.IGNORECASE
+)
+
+
+@click.command("show-ports", help="Show which sites are configured on which ports")
+@click.option("--site", "-s", required=False, help="Filter by site name")
+def show_ports(site: str = None):
+    """Show which sites are configured on which ports (safe, linear scan)."""
+    bench_path = Path(os.getcwd())
+    conf_path = bench_path / "config" / "nginx.conf"
+
+    if not conf_path.exists():
+        click.echo("No nginx.conf found. Try running `bench setup nginx` first.")
+        return
+
+    try:
+        bench_name = get_bench_name(str(bench_path))
+    except Exception:
+        bench_name = "<unknown>"
+
+    sites_ports: List[Tuple[str, int]] = []
+    in_server_block = False
+    current_names: List[str] = []
+    current_listens: List[int] = []
+
+    with conf_path.open("r", encoding="utf-8", errors="ignore") as fh:
+        lines_iter = iter(fh)
+        for raw in lines_iter:
+            line = raw.strip()
+            if not line or line.startswith("#"):
+                continue
+
+            if line.startswith("server") and "{" in line:
+                in_server_block = True
+                current_names.clear()
+                current_listens.clear()
+                continue
+
+            if not in_server_block:
+                continue
+
+            if "listen" in line:
+                m = LISTEN_PORT_RE.search(line)
+                if m:
+                    try:
+                        current_listens.append(int(m.group("port")))
+                    except (ValueError, TypeError):
+                        pass
+
+            if "server_name" in line:
+                after = line.split("server_name", 1)[1]
+                buf = after
+                while ";" not in buf:
+                    try:
+                        buf += " " + next(lines_iter).strip()
+                    except StopIteration:
+                        break
+                name_segment = buf.split(";", 1)[0].strip()
+                if name_segment:
+                    tokens = name_segment.split()
+                    current_names.extend(t.strip() for t in tokens if t.strip())
+
+            if "}" in line:
+                names_to_use = current_names or ["<no server_name>"]
+                for n in names_to_use:
+                    for p in current_listens:
+                        if (n, p) not in sites_ports:
+                            sites_ports.append((n, p))
+                in_server_block = False
+                current_names.clear()
+                current_listens.clear()
+
+    if site:
+        sites_ports = [(n, p) for (n, p) in sites_ports if n == site]
+
+    if not sites_ports:
+        click.echo("No matching sites/ports found in nginx.conf")
+        return
+
+    out_lines = [f"Site {n} → Port {p}" for (n, p) in sites_ports]
+    click.echo(f"Bench {bench_name} sites and ports:\n" + "\n".join(out_lines))


### PR DESCRIPTION
What type of PR is this?

 New Feature Submissions

 Changes to Existing Features

 Bug Fix

 Breaking Change (include change in API behaviours, etc.)

Details / Problem this PR solves

Currently, Frappe developers have no easy way to check which sites are running on which NGINX ports. Typically, they need to manually open config/nginx.conf and inspect the configuration. This is tedious, error-prone, and not convenient, especially for benches with multiple sites.

This PR introduces a new bench command:

bench show-ports


Features:

Lists all sites and their configured NGINX ports.

Supports filtering a single site:

bench show-ports site1.local


Gracefully handles missing nginx.conf.

Works with Python 3.10+ and Click.

Uses get_bench_name() correctly with the bench path.

Usage Examples

List all sites and ports in the bench:

$ bench show-ports
Bench my-bench sites and ports:
site1.local → Port 80
site2.local → Port 443


Filter by a single site:

$ bench show-ports --site site1.local
site1.local → Port 80


When nginx.conf is missing:

$ bench show-ports
No nginx.conf found. Try running `bench setup nginx` first.

Real-life Scenario

Imagine a developer managing a Frappe bench with 10 different sites. Some sites run on default port 80, others on 443, and maybe a few custom ports. During deployment, debugging, or testing, they need to quickly verify which site is mapped to which port — especially when multiple sites share the same domain with different ports.

Before this feature, they would have to open config/nginx.conf and manually search for each site, which is slow and error-prone. With bench show-ports, they can instantly see all site-port mappings in one command, making site management, debugging, and configuration much faster and reliable.

