### PR TITLE
feat: integrate mprocs

### DIFF
--- a/bench/bench.py
+++ b/bench/bench.py
@@ -399,7 +399,7 @@ class BenchSetup(Base):
 					)
 
 	@step(title="Setting Up Bench Config", success="Bench Config Set Up")
-	def config(self, redis=True, procfile=True, additional_config=None):
+	def config(self, redis=True, procfile=True, use_mprocs=False, additional_config=None, default_app=None):
 		"""Setup config folder
 		- create pids folder
 		- generate sites/common_site_config.json
@@ -414,7 +414,7 @@ class BenchSetup(Base):
 		if procfile:
 			from bench.config.procfile import setup_procfile
 
-			setup_procfile(self.bench.name, skip_redis=not redis)
+			setup_procfile(self.bench.name, skip_redis=not redis, use_mprocs=use_mprocs, default_app=default_app)
 
 	@step(title="Updating pip", success="Updated pip")
 	def pip(self, verbose=False):

--- a/bench/commands/make.py
+++ b/bench/commands/make.py
@@ -26,6 +26,7 @@ import click
 	"--clone-without-update", is_flag=True, help="copy repos from path without update"
 )
 @click.option("--no-procfile", is_flag=True, help="Do not create a Procfile")
+@click.option("--use-mprocs", is_flag=True, help="Use mprocs instead of honcho")
 @click.option(
 	"--no-backups",
 	is_flag=True,
@@ -38,6 +39,7 @@ import click
 )
 @click.option("--skip-assets", is_flag=True, default=False, help="Do not build assets")
 @click.option("--install-app", help="Install particular app after initialization")
+@click.option("--default-app", help="Select particular app for frontend development.")
 @click.option("--verbose", is_flag=True, help="Verbose output during install")
 @click.option(
 	"--dev",
@@ -61,6 +63,8 @@ def init(
 	python="python3",
 	install_app=None,
 	dev=False,
+	use_mprocs=False,
+	default_app=None,
 ):
 	import os
 
@@ -76,6 +80,7 @@ def init(
 			path,
 			apps_path=apps_path,  # can be used from --config flag? Maybe config file could have more info?
 			no_procfile=no_procfile,
+			use_mprocs=use_mprocs,
 			no_backups=no_backups,
 			frappe_path=frappe_path,
 			frappe_branch=frappe_branch,
@@ -87,6 +92,7 @@ def init(
 			python=python,
 			verbose=verbose,
 			dev=dev,
+			default_app=default_app,
 		)
 		log(f"Bench {path} initialized", level=1)
 	except SystemExit:

--- a/bench/config/procfile.py
+++ b/bench/config/procfile.py
@@ -8,14 +8,37 @@ from bench.bench import Bench
 from bench.utils import which
 
 
-def setup_procfile(bench_path, yes=False, skip_redis=False, skip_web=False, skip_watch=None, skip_socketio=False, skip_schedule=False, with_coverage=False):
+def setup_procfile(bench_path, yes=False, skip_redis=False, skip_web=False, skip_watch=None, skip_socketio=False, skip_schedule=False, with_coverage=False,use_mprocs=False, default_app=None):
 	if skip_watch is None:
 		# backwards compatibilty; may be eventually removed
 		skip_watch = os.environ.get("CI")
 	config = Bench(bench_path).conf
+	is_mac = platform.system() == "Darwin"
+
+	if use_mprocs:
+		mprocs_path = os.path.join(bench_path, "mprocs.yaml")
+		mprocs = (
+			bench.config.env()
+			.get_template("mprocs.yaml")
+			.render(
+				node=which("node") or which("nodejs"),
+				webserver_port=config.get("webserver_port"),
+				skip_redis=skip_redis,
+				skip_web=skip_web,
+				skip_watch=skip_watch,
+				skip_socketio=skip_socketio,
+				skip_schedule=skip_schedule,
+				with_coverage=with_coverage,
+				workers=config.get("workers", {}),
+				is_mac=is_mac,
+				default_app=default_app
+			)
+		)
+		with open(mprocs_path, "w") as f:
+			f.write(mprocs)
+			
 	procfile_path = os.path.join(bench_path, "Procfile")
 
-	is_mac = platform.system() == "Darwin"
 	if not yes and os.path.exists(procfile_path):
 		click.confirm(
 			"A Procfile already exists and this will overwrite it. Do you want to continue?",

--- a/bench/config/templates/mprocs.yaml
+++ b/bench/config/templates/mprocs.yaml
@@ -1,0 +1,24 @@
+procs:
+  backend:
+    shell: bench serve {% if with_coverage -%} --with-coverage  {%- endif %} {% if webserver_port -%} --port {{ webserver_port }} {%- endif %}
+  {% if default_app %}
+  frontend:
+    shell: cd apps/{{default_app}}/ && npm run dev
+  {% endif %}{% if not skip_redis %}
+  redis_cache:
+    shell: redis-server config/redis_cache.conf
+  redis_queue:
+    shell: redis-server config/redis_queue.conf
+  {% endif %}{% if not skip_socketio %}
+  socketio:
+    shell:  {{ node }} apps/frappe/socketio.js
+  {% endif %}{% if not skip_watch %}
+  watch:
+    shell: bench watch
+  {% endif %}{% if not skip_schedule %}
+  schedule:
+    shell: bench schedule
+  {% endif %}
+  worker:
+    shell: {{ 'OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES NO_PROXY=*' if is_mac else '' }} bench worker 1>> logs/worker.log 2>> logs/worker.error.log
+    

--- a/bench/utils/system.py
+++ b/bench/utils/system.py
@@ -25,6 +25,7 @@ def init(
 	path,
 	apps_path=None,
 	no_procfile=False,
+	use_mprocs=False,
 	no_backups=False,
 	frappe_path=None,
 	frappe_branch=None,
@@ -36,6 +37,7 @@ def init(
 	python="python3",
 	install_app=None,
 	dev=False,
+	default_app=None,
 ):
 	"""Initialize a new bench directory
 
@@ -70,7 +72,9 @@ def init(
 	bench.setup.config(
 		redis=not skip_redis_config_generation,
 		procfile=not no_procfile,
+		use_mprocs=use_mprocs,
 		additional_config=config,
+		default_app=default_app
 	)
 	bench.setup.patches()
 
@@ -147,13 +151,20 @@ def setup_sudoers(user):
 
 
 def start(no_dev=False, concurrency=None, procfile=None, no_prefix=False, procman=None):
+	os.environ["PYTHONUNBUFFERED"] = "true"
+	if not no_dev:
+		os.environ["DEV_SERVER"] = "true"
+
+	# Check if mprocs file exists
+	if os.path.exists('mprocs.yaml'):
+		program = which('mprocs')
+		if program:
+			os.execv(program, ['mprocs', *sys.argv[2:]])
+	
 	program = which(procman) if procman else get_process_manager()
 	if not program:
 		raise Exception("No process manager found")
 
-	os.environ["PYTHONUNBUFFERED"] = "true"
-	if not no_dev:
-		os.environ["DEV_SERVER"] = "true"
 
 	command = [program, "start"]
 	if concurrency:

--- a/bench/utils/system.py
+++ b/bench/utils/system.py
@@ -69,6 +69,12 @@ def init(
 	config = {}
 	if dev:
 		config["developer_mode"] = 1
+
+	if default_app:
+		# Assume mprocs if default_app is set
+		use_mprocs = True
+		install_app = default_app
+
 	bench.setup.config(
 		redis=not skip_redis_config_generation,
 		procfile=not no_procfile,


### PR DESCRIPTION
Adds two configuration options to `bench init`:
- `--use-mprocs`: allows people to use `mprocs` instead of of `honcho` - though both are still supported even with this option
- `--default-app TEXT`: allows developers to set a default app to run the frontend server for

`bench start` will now use `mprocs` if `mprocs.yaml` exists - otherwise it'll use honcho (current working).

Also, if `default-app` is specified, both `use_mprocs` and `install-app` are assumed so that this:
```
bench init --use-mprocs --install-app drive --default-app drive PATH
```
becomes:
```
bench init --default-app drive PATH
```