### PR TITLE
security(nginx): remove OCSP stapling configuration

### DIFF
--- a/bench/config/templates/nginx.conf
+++ b/bench/config/templates/nginx.conf
@@ -42,8 +42,6 @@ server {
 	ssl_session_timeout  5m;
 	ssl_session_cache shared:SSL:10m;
 	ssl_session_tickets off;
-	ssl_stapling on;
-	ssl_stapling_verify on;
 	ssl_protocols TLSv1.2 TLSv1.3;
 	ssl_ciphers EECDH+AESGCM:EDH+AESGCM;
 	ssl_ecdh_curve secp384r1;


### PR DESCRIPTION
Let’s Encrypt has ended support for OCSP responses and OCSP stapling. As a result, ssl_stapling and ssl_stapling_verify no longer provide any security benefit and may cause warnings or misleading configuration state in modern Nginx deployments.

This change removes OCSP stapling directives from the nginx template to align with current TLS practices and browser revocation mechanisms (Certificate Transparency / CRLite).

Impact:
- No reduction in TLS security
- Avoids dead or misleading configuration
- Prevents potential startup or reload warnings
- Aligns with Let’s Encrypt post-OCSP revocation model

Reference:
https://letsencrypt.org/2024/12/05/ending-ocsp


 ---

<img width="928" height="332" alt="image" src="https://github.com/user-attachments/assets/81ad91b4-44fe-4971-b3d2-8dec03aca0a7" />
