### PR TITLE
feat(acme): enable ECC key type and specify elliptic curve

### DIFF
--- a/bench/config/templates/letsencrypt.cfg
+++ b/bench/config/templates/letsencrypt.cfg
@@ -2,6 +2,10 @@
 # All flags used by the client can be configured here. Run Certbot with
 # "--help" to learn more about the available options.
 
+# Use ECC for the private key
+key-type = ecdsa
+elliptic-curve = secp384r1
+
 # Use a 4096 bit RSA key instead of 2048
 rsa-key-size = 4096
 


### PR DESCRIPTION
enables configuration to handle the smaller, more efficient ECC key format instead of relying solely on RSA. since certbot and the Let’s Encrypt ACME server now issue ECC certificates by default, the setup should accommodate them as well.