### PR TITLE
feat: allow custom ACME servers for certbot

### DIFF
--- a/bench/commands/setup.py
+++ b/bench/commands/setup.py
@@ -159,16 +159,27 @@ def set_ssh_port(port, force=False):
 @click.argument("site")
 @click.option("--custom-domain")
 @click.option(
+	"--custom-server",
+	default=None,
+	help="Custom ACME server URL",
+)
+@click.option(
 	"-n",
 	"--non-interactive",
 	default=False,
 	is_flag=True,
 	help="Run command non-interactively. This flag restarts nginx and runs certbot non interactively. Shouldn't be used on 1'st attempt",
 )
-def setup_letsencrypt(site, custom_domain, non_interactive):
+def setup_letsencrypt(site, custom_domain, custom_server, non_interactive):
 	from bench.config.lets_encrypt import setup_letsencrypt
 
-	setup_letsencrypt(site, custom_domain, bench_path=".", interactive=not non_interactive)
+	setup_letsencrypt(
+		site,
+		custom_domain,
+		bench_path=".",
+		interactive=not non_interactive,
+		custom_server=custom_server,
+	)
 
 
 @click.command(
@@ -177,16 +188,25 @@ def setup_letsencrypt(site, custom_domain, non_interactive):
 @click.argument("domain")
 @click.option("--email")
 @click.option(
+	"--custom-server",
+	default=None,
+	help="Custom ACME server URL",
+)
+@click.option(
 	"--exclude-base-domain",
 	default=False,
 	is_flag=True,
 	help="SSL Certificate not applicable for base domain",
 )
-def setup_wildcard_ssl(domain, email, exclude_base_domain):
+def setup_wildcard_ssl(domain, email, exclude_base_domain, custom_server):
 	from bench.config.lets_encrypt import setup_wildcard_ssl
 
 	setup_wildcard_ssl(
-		domain, email, bench_path=".", exclude_base_domain=exclude_base_domain
+		domain,
+		email,
+		bench_path=".",
+		exclude_base_domain=exclude_base_domain,
+		custom_server=custom_server,
 	)
 
 

--- a/bench/config/lets_encrypt.py
+++ b/bench/config/lets_encrypt.py
@@ -175,7 +175,7 @@ def setup_wildcard_ssl(domain, email, bench_path, exclude_base_domain, custom_se
 	try:
 		exec_cmd(
 			f"{get_certbot_path()} certonly --manual --preferred-challenges=dns {email_param} "
-			f"{server_param} "
+			f"{sp + ' ' if (sp := server_param) else ''}"
 			f"--agree-tos -d {' -d '.join(domain_list)}"
 		)
 

--- a/bench/config/lets_encrypt.py
+++ b/bench/config/lets_encrypt.py
@@ -15,7 +15,7 @@ from bench.utils.bench import update_common_site_config
 from bench.exceptions import CommandFailedError
 
 
-def setup_letsencrypt(site, custom_domain, bench_path, interactive):
+def setup_letsencrypt(site, custom_domain, bench_path, interactive, custom_server):
 
 	site_path = os.path.join(bench_path, "sites", site, "site_config.json")
 	if not os.path.exists(os.path.dirname(site_path)):
@@ -44,16 +44,16 @@ def setup_letsencrypt(site, custom_domain, bench_path, interactive):
 		print("You cannot setup SSL without DNS Multitenancy")
 		return
 
-	create_config(site, custom_domain)
+	create_config(site, custom_domain, custom_server)
 	run_certbot_and_setup_ssl(site, custom_domain, bench_path, interactive)
 	setup_crontab()
 
 
-def create_config(site, custom_domain):
+def create_config(site, custom_domain, custom_server):
 	config = (
 		bench.config.env()
 		.get_template("letsencrypt.cfg")
-		.render(domain=custom_domain or site)
+		.render(domain=custom_domain or site, server=custom_server)
 	)
 	config_path = f"/etc/letsencrypt/configs/{custom_domain or site}.cfg"
 	create_dir_if_missing(config_path)
@@ -142,7 +142,7 @@ def renew_certs():
 	service("nginx", "start")
 
 
-def setup_wildcard_ssl(domain, email, bench_path, exclude_base_domain):
+def setup_wildcard_ssl(domain, email, bench_path, exclude_base_domain, custom_server):
 	def _get_domains(domain):
 		domain_list = [domain]
 
@@ -168,11 +168,15 @@ def setup_wildcard_ssl(domain, email, bench_path, exclude_base_domain):
 	if email:
 		email_param = f"--email {email}"
 
+	server_param = ""
+	if custom_server:
+		server_param = f"--server {custom_server}"
+
 	try:
 		exec_cmd(
-			f"{get_certbot_path()} certonly --manual --preferred-challenges=dns {email_param} \
-			--server https://acme-v02.api.letsencrypt.org/directory \
-			--agree-tos -d {' -d '.join(domain_list)}"
+			f"{get_certbot_path()} certonly --manual --preferred-challenges=dns {email_param} "
+			f"{server_param} "
+			f"--agree-tos -d {' -d '.join(domain_list)}"
 		)
 
 	except CommandFailedError:
@@ -192,5 +196,5 @@ def setup_wildcard_ssl(domain, email, bench_path, exclude_base_domain):
 	setup_crontab()
 
 	make_nginx_conf(bench_path)
-	print("Restrting Nginx service")
+	print("Restarting Nginx service")
 	service("nginx", "restart")

--- a/bench/config/templates/letsencrypt.cfg
+++ b/bench/config/templates/letsencrypt.cfg
@@ -1,6 +1,10 @@
 # This is an example of the kind of things you can do in a configuration file.
 # All flags used by the client can be configured here. Run Certbot with
 # "--help" to learn more about the available options.
+{% if server %}
+
+server = {{ server }}
+{% endif %}
 
 # Use a 4096 bit RSA key instead of 2048
 rsa-key-size = 4096

--- a/bench/tests/test_letsencrypt.py
+++ b/bench/tests/test_letsencrypt.py
@@ -1,0 +1,151 @@
+import sys
+import os
+import unittest
+from unittest.mock import MagicMock, patch, mock_open
+
+git_mock = MagicMock()
+sys.modules["git"] = git_mock
+
+semver_mock = MagicMock()
+sys.modules["semantic_version"] = semver_mock
+sys.modules["semantic_version.Version"] = MagicMock()
+
+sys.modules["jinja2"] = MagicMock()
+sys.modules["requests"] = MagicMock()
+
+sys.path.insert(0, os.getcwd())
+
+from bench.config import lets_encrypt
+
+
+class TestLetsEncryptConfig(unittest.TestCase):
+	@patch("bench.config.lets_encrypt.create_dir_if_missing")
+	@patch("bench.config.env")
+	@patch("builtins.open", new_callable=mock_open)
+	def test_create_config_with_server(self, mock_file, mock_env, mock_create_dir):
+		mock_template = MagicMock()
+		mock_env.return_value.get_template.return_value = mock_template
+
+		def render_side_effect(domain, server=None):
+			content = f"domain = {domain}\n"
+			if server:
+				content += f"server = {server}\n"
+			return content
+
+		mock_template.render.side_effect = render_side_effect
+
+		lets_encrypt.create_config(
+			"site1.local",
+			None,
+			"https://acme-staging-v02.api.letsencrypt.org/directory",
+		)
+
+		mock_template.render.assert_called_with(
+			domain="site1.local",
+			server="https://acme-staging-v02.api.letsencrypt.org/directory",
+		)
+
+		handle = mock_file()
+		written = handle.write.call_args[0][0]
+		self.assertIn(
+			"server = https://acme-staging-v02.api.letsencrypt.org/directory",
+			written,
+		)
+
+	@patch("bench.config.lets_encrypt.create_dir_if_missing")
+	@patch("bench.config.env")
+	@patch("builtins.open", new_callable=mock_open)
+	def test_create_config_without_server(self, mock_file, mock_env, mock_create_dir):
+		mock_template = MagicMock()
+		mock_env.return_value.get_template.return_value = mock_template
+
+		def render_side_effect(domain, server=None):
+			content = f"domain = {domain}\n"
+			if server:
+				content += f"server = {server}\n"
+			return content
+
+		mock_template.render.side_effect = render_side_effect
+
+		lets_encrypt.create_config("site1.local", None, None)
+
+		mock_template.render.assert_called_with(
+			domain="site1.local",
+			server=None,
+		)
+
+		handle = mock_file()
+		written = handle.write.call_args[0][0]
+		self.assertNotIn("server =", written)
+
+	@patch("bench.config.lets_encrypt.service")
+	@patch("bench.config.lets_encrypt.make_nginx_conf")
+	@patch("bench.config.lets_encrypt.setup_crontab")
+	@patch("bench.config.lets_encrypt.update_common_site_config")
+	@patch("bench.config.lets_encrypt.get_certbot_path")
+	@patch("bench.config.lets_encrypt.exec_cmd")
+	@patch("bench.config.lets_encrypt.Bench")
+	def test_setup_wildcard_ssl_with_server(
+		self,
+		mock_bench,
+		mock_exec,
+		mock_get_certbot_path,
+		mock_update_common_site_config,
+		mock_setup_crontab,
+		mock_make_nginx_conf,
+		mock_service,
+	):
+		# Mock Bench config for dns_multitenant
+		mock_bench.return_value.conf.get.return_value = True
+		mock_get_certbot_path.return_value = "/usr/bin/certbot"
+
+		lets_encrypt.setup_wildcard_ssl(
+			"example.com",
+			"test@example.com",
+			".",
+			exclude_base_domain=False,
+			custom_server="https://acme-staging",
+		)
+
+		expected_cmd = (
+			"/usr/bin/certbot certonly --manual --preferred-challenges=dns "
+			"--email test@example.com --server https://acme-staging "
+			"--agree-tos -d example.com -d *.example.com"
+		)
+		mock_exec.assert_called_with(expected_cmd)
+
+	@patch("bench.config.lets_encrypt.service")
+	@patch("bench.config.lets_encrypt.make_nginx_conf")
+	@patch("bench.config.lets_encrypt.setup_crontab")
+	@patch("bench.config.lets_encrypt.update_common_site_config")
+	@patch("bench.config.lets_encrypt.get_certbot_path")
+	@patch("bench.config.lets_encrypt.exec_cmd")
+	@patch("bench.config.lets_encrypt.Bench")
+	def test_setup_wildcard_ssl_default(
+		self,
+		mock_bench,
+		mock_exec,
+		mock_get_certbot_path,
+		mock_update_common_site_config,
+		mock_setup_crontab,
+		mock_make_nginx_conf,
+		mock_service,
+	):
+		# Mock Bench config for dns_multitenant
+		mock_bench.return_value.conf.get.return_value = True
+		mock_get_certbot_path.return_value = "/usr/bin/certbot"
+
+		lets_encrypt.setup_wildcard_ssl(
+			"example.com", "test@example.com", ".", exclude_base_domain=False, custom_server=None
+		)
+
+		expected_cmd = (
+			"/usr/bin/certbot certonly --manual --preferred-challenges=dns "
+			"--email test@example.com  "
+			"--agree-tos -d example.com -d *.example.com"
+		)
+		mock_exec.assert_called_with(expected_cmd)
+
+
+if __name__ == "__main__":
+	unittest.main()


### PR DESCRIPTION
this new flag in bench setup lets-encrypt allow the user to specify their own custom ACME server such as zerossl or others, and their own internal ACME CA.