### PR TITLE
chore: use ecdsa certs and secp384r1

### DIFF
--- a/bench/config/templates/letsencrypt.cfg
+++ b/bench/config/templates/letsencrypt.cfg
@@ -2,8 +2,9 @@
 # All flags used by the client can be configured here. Run Certbot with
 # "--help" to learn more about the available options.
 
-# Use a 4096 bit RSA key instead of 2048
-rsa-key-size = 4096
+# Use ECC for the private key
+key-type = ecdsa
+elliptic-curve = secp384r1
 
 # Uncomment and update to register with the specified e-mail address
 #email = email@domain.com


### PR DESCRIPTION
this patch follows the default in let's encrypt and make use of the stronger secp384r1 curve