### PR TITLE
fix(easy-install): pull tagged frappe_docker instead of main

### DIFF
--- a/easy-install.py
+++ b/easy-install.py
@@ -46,13 +46,13 @@ def cprint(*args, level: int = 1):
 def clone_frappe_docker_repo() -> None:
     try:
         urllib.request.urlretrieve(
-            "https://github.com/frappe/frappe_docker/archive/refs/heads/main.zip",
+            "https://github.com/frappe/frappe_docker/archive/refs/tags/v1.0.1.zip",
             "frappe_docker.zip",
         )
         logging.info("Downloaded frappe_docker zip file from GitHub")
         unpack_archive("frappe_docker.zip", ".")
         # Unzipping the frappe_docker.zip creates a folder "frappe_docker-main"
-        move("frappe_docker-main", "frappe_docker")
+        move("frappe_docker-1.0.1", "frappe_docker")
         logging.info("Unzipped and Renamed frappe_docker")
         os.remove("frappe_docker.zip")
         logging.info("Removed the downloaded zip file")


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. Update necessary Documentation
 4. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/bench/blob/master/docs/contribution_guidelines.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

What type of a PR is this?

- [ ] Changes to Existing Features
- [ ] New Feature Submissions
- [x] Bug Fix
- [ ] Breaking Change (include change in API behaviours, etc.)

---

> Please provide enough information so that others can review your pull request:

`frappe_docker` recently introduced breaking changes. This PR is a hotifx, it pulls the latest tag before the breaking change, instead of the main branch. This is not a final solution, as the easy-install script should be migrated correctly.

#1696 