### PR TITLE
fix: cap setuptools below v82 to retain pkg_resources

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "python-crontab~=2.6.0",
     "requests~=2.32.5",
     "semantic-version~=2.10.0",
-    "setuptools>=71.0.0",
+    "setuptools>=71.0.0,<82.0.0",
     "tomli;python_version<'3.11'",
     "uv~=0.9.0 "
 ]


### PR DESCRIPTION
fixes: https://github.com/frappe/bench/issues/1698

setuptools v82.0.0 removed `pkg_resources`, which breaks Frappe v15 due to Dropbox depending on it.

Caps setuptools at `<82.0.0` so `pkg_resources` remains available.

Solves: https://github.com/frappe/bench/issues/1698

Note: IMHO the correct thing would be to refactor Frappe v15 to use a newer version of Dropbox.

"Important: Make sure you're using v12.0.2 or newer of this SDK by January 2026 for continued compatibility with the Dropbox API servers. Please refer to this blog post for more information: https://dropbox.tech/developers/api-server-certificate-changes" - https://github.com/dropbox/dropbox-sdk-python 