### PR TITLE
fix: handle detached HEAD state in bench update & add --app-name override for get-app

### DIFF
--- a/bench/app.py
+++ b/bench/app.py
@@ -1033,6 +1033,13 @@ Here are your choices:
 					bench.run(f"git fetch {remote} --unshallow", cwd=app_dir)
 
 			branch = get_current_branch(app, bench_path=bench_path)
+
+			# --- FIX: Skip update if detached HEAD ---
+			if not branch:
+				print(f"App {app} is pinned to a specific version. Skipping update.")
+				continue
+			# -----------------------------------------
+
 			logger.log(f"pulling {app}")
 			if reset:
 				reset_cmd = f"git reset --hard {remote}/{branch}"

--- a/bench/app.py
+++ b/bench/app.py
@@ -668,6 +668,7 @@ def get_app(
 	resolve_deps=False,
 	cache_key=None,
 	compress_artifacts=False,
+	app_name=None,
 ):
 	"""bench get-app clones a Frappe App from remote (GitHub or any other git server),
 	and installs it on the current bench. This also resolves dependencies based on the
@@ -778,6 +779,14 @@ def get_app(
 
 	if to_clone:
 		app.get()
+		# rename folder if app_name override provided
+		if app_name and app_name != app.repo:
+			os.rename(
+				os.path.join(bench_path, "apps", app.repo),
+				os.path.join(bench_path, "apps", app_name),
+			)
+			app.app_name = app_name
+			app.repo = app_name
 
 	if (
 		to_clone

--- a/bench/commands/make.py
+++ b/bench/commands/make.py
@@ -163,6 +163,7 @@ def drop(path):
 	default=False,
 	help="Whether to gzip get-app artifacts that are to be cached",
 )
+@click.option("--app-name", default=None, help="Override folder name on disk")
 def get_app(
 	git_url,
 	branch,
@@ -174,6 +175,7 @@ def get_app(
 	resolve_deps=False,
 	cache_key=None,
 	compress_artifacts=False,
+	app_name=None,
 ):
 	"clone an app from the internet and set it up in your bench"
 	from bench.app import get_app
@@ -188,9 +190,8 @@ def get_app(
 		resolve_deps=resolve_deps,
 		cache_key=cache_key,
 		compress_artifacts=compress_artifacts,
+		app_name=app_name,
 	)
-
-
 @click.command("new-app", help="Create a new Frappe application under apps folder")
 @click.option(
 	"--no-git",

--- a/bench/utils/app.py
+++ b/bench/utils/app.py
@@ -177,7 +177,11 @@ def get_current_branch(app, bench_path="."):
 	from bench.utils import get_cmd_output
 
 	repo_dir = get_repo_dir(app, bench_path=bench_path)
-	return get_cmd_output("git symbolic-ref -q --short HEAD", cwd=repo_dir)
+	try:
+		return get_cmd_output("git symbolic-ref -q --short HEAD", cwd=repo_dir)
+	except Exception:
+		# If we are in Detached HEAD state (e.g. pinned tag), this returns None
+		return None
 
 
 @lru_cache(maxsize=5)
@@ -273,8 +277,8 @@ def get_app_name(bench_path: str, folder_name: str) -> str:
 
 	if not app_name:
 		raise AppInstallationError(
-            "Could not determine the package name. Checked pyproject.toml, setup.cfg, and setup.py."
-        )
+			"Could not determine the package name. Checked pyproject.toml, setup.cfg, and setup.py."
+		)
 
 
 	if app_name and folder_name != app_name:


### PR DESCRIPTION
## What type of a PR is this?
- [x] Changes to Existing Features
- [x] New Feature Submissions
- [x] Bug Fix

---

## Please provide enough information so that others can review your pull request:

This PR combines two changes:

**1. Bug Fix — Detached HEAD crash in `bench update`**

When an app is pinned to a tag or commit, `git symbolic-ref -q --short HEAD` fails with exit code 1, crashing `bench update` entirely.

- `bench/utils/app.py` — `get_current_branch` wraps the git command in a `try/except`; returns `None` if in Detached HEAD state (e.g. pinned tag)
- `bench/app.py` — `pull_apps` checks `if not branch`; prints a skip message and calls `continue`, allowing the rest of the update to proceed

**2. Enhancement — `--app-name` override for `bench get-app`**

Allows renaming the cloned app folder on disk at install time (e.g. cloning `rpaas` as `paas`).

- `bench/commands/make.py` — adds `--app-name` click option with `default=None`
- `bench/app.py` — after cloning, if `app_name` is provided and differs from `app.repo`, renames the folder using `os.rename` and updates both `app.app_name` and `app.repo`

---

## Screenshots/GIFs
- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [x] Have you lint your code locally prior to submission?
- [x] Have you successfully run tests with your changes locally?
- [x] Does your commit message have an explanation for your changes and why you'd like us to include them?
- [ ] Docs have been added / updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Did you modify the existing test cases? If yes, why?

---

> Screenshots/GIFs

*N/A - CLI fix.*