### PR TITLE
feat: add bench-ai CLI for natural language bench command help

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,28 @@ In case the setup fails, the log file is saved under `$HOME/easy-install.log`. Y
 	$ bench --help
 	```
 
+### bench-ai (optional)
+
+`bench-ai` suggests `bench` commands from natural language. It ships with the same package as `bench` and calls an
+[OpenAI-compatible](https://platform.openai.com/docs/api-reference/chat) **Chat Completions** HTTP API using your
+API key. Context is built from this machine’s `bench` CLI help and, when you run it **inside a Frappe bench**, the
+same framework command appendix as `bench --help`.
+
+Setup:
+
+```sh
+export OPENAI_API_KEY=...   # or BENCH_AI_API_KEY
+# optional: BENCH_AI_BASE_URL (default https://api.openai.com/v1), BENCH_AI_MODEL (default gpt-4o-mini)
+bench-ai "how do I back up all sites?"
+bench-ai "what does bench doctor do?" --dry-run
+```
+
+`--dry-run` prints model and context size without calling the API. `--run` asks for confirmation, then executes the
+parsed command without a shell—review every suggestion before using it, especially on production.
+
+For best results on framework commands (`doctor`, `migrate`, …), run `bench-ai` from your bench directory so local
+Frappe command names are included.
+
 
 For more in-depth information on commands and their usage, follow [Commands and Usage](https://github.com/frappe/bench/blob/develop/docs/commands_and_usage.md). As for a consolidated list of bench commands, check out [Bench Usage](https://github.com/frappe/bench/blob/develop/docs/bench_usage.md).
 

--- a/bench/commands/ai.py
+++ b/bench/commands/ai.py
@@ -17,6 +17,10 @@ MAX_BENCH_PATH_LIST_CHARS = 12000
 MAX_FRAPPE_HELP_CHARS = 20000
 MAX_FRAPPE_NAMES_CHARS = 12000
 
+# Prefix for a typical shell suggestion line (Sonar: single definition for the literal).
+BENCH_SHELL_PREFIX = "bench "
+BENCH_BINARY = "bench"
+
 # Fallback when we can't run bench_helper (e.g. not inside a bench). Tokens align with Frappe docs.
 COMMON_FRAPPE_COMMANDS_CRIB = """Common Frappe framework command names (short crib; same commands are listed in Frappe docs).
 They usually run as `bench <name>` (bench forwards to Frappe) or `bench --site <site> <name>` when a site is required:
@@ -141,55 +145,71 @@ def collect_bench_click_paths(
 	return paths
 
 
-def build_context() -> str:
-	from bench.commands import bench_command
-
-	sections: List[str] = [CHEATSHEET, COMMON_FRAPPE_COMMANDS_CRIB]
-
+def _context_append_native_paths(sections: List[str], bench_command: click.Group) -> None:
 	native = sorted(set(collect_bench_click_paths(bench_command)))
 	block = "Bench native subcommands (from Click; `bench <path>` without `--site`):\n" + "\n".join(native)
 	if len(block) > MAX_BENCH_PATH_LIST_CHARS:
 		block = block[: MAX_BENCH_PATH_LIST_CHARS - 3] + "...\n(list truncated)"
 	sections.append(block)
 
+
+def _context_append_click_help(sections: List[str], bench_command: click.Group) -> None:
 	ctx = click.Context(bench_command)
 	help_text = ctx.get_help()
 	if len(help_text) > MAX_HELP_CHARS:
 		help_text = help_text[: MAX_HELP_CHARS - 3] + "..."
 	sections.append("Bench CLI help (top of `bench --help`):\n" + help_text)
 
-	from bench.utils import get_env_frappe_commands, is_bench_directory
 
+def _context_append_frappe_help(sections: List[str]) -> None:
+	try:
+		from bench.cli import get_frappe_help
+
+		frappe_help = get_frappe_help()
+	except Exception:
+		return
+	if not frappe_help.strip():
+		return
+	text = frappe_help.strip()
+	if len(text) > MAX_FRAPPE_HELP_CHARS:
+		text = text[: MAX_FRAPPE_HELP_CHARS - 3] + "..."
+	sections.append("Framework commands (`bench --help` appendix on this bench):\n" + text)
+
+
+def _context_append_frappe_names(sections: List[str]) -> None:
+	from bench.utils import get_env_frappe_commands
+
+	try:
+		cmds = get_env_frappe_commands()
+	except Exception:
+		return
+	if not cmds:
+		return
+	names = sorted({str(c).strip() for c in cmds if str(c).strip()})
+	line = "Framework command names (`bench --site <site> <name>` …):\n" + ", ".join(names)
+	if len(line) > MAX_FRAPPE_NAMES_CHARS:
+		line = line[: MAX_FRAPPE_NAMES_CHARS - 3] + "... (truncated)"
+	sections.append(line)
+
+
+def _context_append_when_in_bench(sections: List[str]) -> None:
+	_context_append_frappe_help(sections)
+	_context_append_frappe_names(sections)
+
+
+def build_context() -> str:
+	from bench.commands import bench_command
+	from bench.utils import is_bench_directory
+
+	sections: List[str] = [CHEATSHEET, COMMON_FRAPPE_COMMANDS_CRIB]
+	_context_append_native_paths(sections, bench_command)
+	_context_append_click_help(sections, bench_command)
 	if is_bench_directory():
-		try:
-			from bench.cli import get_frappe_help
-
-			frappe_help = get_frappe_help()
-			if frappe_help.strip():
-				if len(frappe_help) > MAX_FRAPPE_HELP_CHARS:
-					frappe_help = frappe_help[: MAX_FRAPPE_HELP_CHARS - 3] + "..."
-				sections.append(
-					"Framework commands (`bench --help` appendix on this bench):\n" + frappe_help.strip()
-				)
-		except Exception:
-			pass
-		try:
-			cmds = get_env_frappe_commands()
-			if cmds:
-				names = sorted({str(c).strip() for c in cmds if str(c).strip()})
-				line = (
-					"Framework command names (`bench --site <site> <name>` …):\n" + ", ".join(names)
-				)
-				if len(line) > MAX_FRAPPE_NAMES_CHARS:
-					line = line[: MAX_FRAPPE_NAMES_CHARS - 3] + "... (truncated)"
-				sections.append(line)
-		except Exception:
-			pass
+		_context_append_when_in_bench(sections)
 	else:
 		sections.append(
 			"Note: not inside a bench — live framework names/help omitted. `cd` to your bench for the full list."
 		)
-
 	return "\n\n".join(sections)
 
 
@@ -254,7 +274,7 @@ def extract_bench_invocation(line: str) -> Optional[Tuple[str, List[str]]]:
 		tokens = shlex.split(line)
 	except ValueError:
 		return None
-	if not tokens or tokens[0] != "bench":
+	if not tokens or tokens[0] != BENCH_BINARY:
 		return None
 	i = _skip_global_bench_flags(tokens, 1)
 	if i < len(tokens) and tokens[i] == "--site":
@@ -336,7 +356,9 @@ def validate_suggested_command_line(
 	return ok, msg
 
 
-_LINE_BENCH = re.compile(r"^\s*(?:[-*]\s+)?(?P<cmd>bench\s+.+)$")
+_LINE_BENCH = re.compile(
+	rf"^\s*(?:[-*]\s+)?(?P<cmd>{re.escape(BENCH_SHELL_PREFIX)}\S.*)$"
+)
 
 
 def parse_suggested_command(text: str) -> str:
@@ -346,7 +368,7 @@ def parse_suggested_command(text: str) -> str:
 	):
 		for raw in block.strip().splitlines():
 			line = raw.strip()
-			if line.startswith("bench "):
+			if line.startswith(BENCH_SHELL_PREFIX):
 				found.append(line)
 	for line in text.splitlines():
 		m = _LINE_BENCH.match(line)
@@ -380,6 +402,154 @@ Structure your answer as:
 
 Keep ### What this command does factual for the commands you named. Be concise; don't paste Context back.
 """
+
+
+def _bench_ai_tip_outside_bench() -> None:
+	from bench.utils import is_bench_directory
+
+	if is_bench_directory():
+		return
+	click.secho(
+		"Tip: not in a Frappe bench — using static framework crib; `cd` to your bench for full `bench --help`.",
+		fg="yellow",
+		dim=True,
+	)
+	click.echo()
+
+
+def _bench_ai_dry_run(model_id: str, base_url: str, context: str, prompt: str) -> None:
+	click.secho("bench-ai — dry run", fg="cyan", bold=True)
+	click.echo()
+	stats = [
+		("Model", model_id),
+		("API base", normalize_base_url(base_url)),
+		("Context size", f"{len(context):,} chars"),
+		("Prompt", f"{len(prompt):,} chars"),
+	]
+	w = max(len(k) for k, _ in stats)
+	for k, v in stats:
+		click.echo(f"  {k.ljust(w)}  {v}")
+	click.echo()
+	click.secho("No API request sent.", dim=True)
+
+
+def _bench_ai_completion_messages(context: str, prompt: str) -> list:
+	return [
+		{"role": "system", "content": SYSTEM_PROMPT},
+		{
+			"role": "user",
+			"content": (
+				"Context is authoritative; only use ```bash for commands that match it.\n\n"
+				f"Context:\n{context}\n\nQuestion:\n{prompt}"
+			),
+		},
+	]
+
+
+def _bench_ai_print_reply(reply: str) -> None:
+	click.echo()
+	click.secho("Guidance", fg="bright_blue", bold=True)
+	click.secho(
+		"(From local bench help; suggested line is checked against this CLI.)",
+		fg="bright_black",
+		dim=True,
+	)
+	click.echo(click.style(_rule_char_line(), fg="bright_black"))
+	click.echo(reply)
+
+
+def _bench_ai_validation_footer(
+	suggested: str,
+	valid: bool,
+	err: str,
+	inv: Optional[Tuple[str, List[str]]],
+	frappe_names: Optional[set],
+) -> None:
+	if _line_has_placeholders(suggested):
+		click.secho("Line has <placeholders> — edit before running.", fg="yellow")
+		return
+	if not valid:
+		click.secho("Local validation failed", fg="red", bold=True)
+		click.secho(err, fg="red")
+		click.secho("Compare with `bench --help` before using this.", fg="yellow")
+		return
+	if inv and inv[0] == "frappe" and frappe_names is None:
+		click.secho(
+			"`--site` line not checked against live Frappe list (run bench-ai from a bench for that).",
+			fg="yellow",
+			dim=True,
+		)
+		return
+	if valid and frappe_names is not None:
+		click.secho("OK — matches this bench's CLI / Frappe commands.", fg="green", dim=True)
+		return
+	if valid:
+		click.secho(
+			"OK — native bench and/or crib (full framework list only on a real bench).",
+			fg="green",
+			dim=True,
+		)
+
+
+def _bench_ai_show_suggestion(
+	reply: str,
+	bench_command: click.Group,
+	frappe_names: Optional[set],
+) -> None:
+	suggested = parse_suggested_command(reply)
+	is_bench_line = suggested.startswith(BENCH_SHELL_PREFIX)
+	valid, err = (
+		validate_suggested_command_line(suggested, bench_command, frappe_names)
+		if is_bench_line
+		else (True, "")
+	)
+	if not is_bench_line:
+		click.echo()
+		click.secho(
+			"No `bench …` line in the reply (add a ```bash block). Running from a bench helps for framework commands.",
+			fg="yellow",
+		)
+		return
+	click.echo()
+	click.secho("Suggested command (for --run)", fg="cyan", bold=True)
+	click.echo(click.style(_rule_char_line(), fg="bright_black"))
+	click.echo(click.style(suggested, fg="green", bold=True))
+	click.echo()
+	_bench_ai_validation_footer(suggested, valid, err, extract_bench_invocation(suggested), frappe_names)
+
+
+def _bench_ai_run_if_requested(
+	run_cmd: bool,
+	reply: str,
+	bench_command: click.Group,
+	frappe_names: Optional[set],
+) -> None:
+	if not run_cmd:
+		return
+	final = parse_suggested_command(reply)
+	if not final.startswith(BENCH_SHELL_PREFIX):
+		raise click.ClickException("Refusing --run: no runnable `bench ...` in the reply.")
+	if _line_has_placeholders(final):
+		raise click.ClickException("Refusing --run: fix <placeholders> first.")
+	ok_run, run_err = validate_suggested_command_line(final, bench_command, frappe_names)
+	if not ok_run:
+		raise click.ClickException(
+			f"Refusing --run: {run_err} Verify with `bench --help` and run manually if needed."
+		)
+	click.echo()
+	if not click.confirm(click.style("Run this command?", fg="yellow") + f"\n  {final}", default=False):
+		click.secho("Cancelled.", dim=True)
+		return
+	try:
+		argv = shlex.split(final)
+	except ValueError as e:
+		raise click.ClickException(f"Could not parse command: {e}") from e
+	click.secho("Running…", fg="bright_black")
+	ret = subprocess.run(argv, check=False).returncode
+	if ret:
+		click.secho(f"Exit code: {ret}", fg="yellow")
+	else:
+		click.secho("Done.", fg="green")
 
 
 @click.command(
@@ -419,36 +589,16 @@ Keep ### What this command does factual for the commands you named. Be concise; 
 def bench_ai(prompt, model, temperature, dry_run, run_cmd):
 	from bench.cli import change_working_directory
 	from bench.commands import bench_command
-	from bench.utils import is_bench_directory
 
 	change_working_directory()
-
-	if not is_bench_directory():
-		click.secho(
-			"Tip: not in a Frappe bench — using static framework crib; `cd` to your bench for full `bench --help`.",
-			fg="yellow",
-			dim=True,
-		)
-		click.echo()
+	_bench_ai_tip_outside_bench()
 
 	context = build_context()
 	model_id = model or os.environ.get("BENCH_AI_MODEL") or DEFAULT_MODEL
 	base_url = os.environ.get("BENCH_AI_BASE_URL", DEFAULT_BASE_URL)
 
 	if dry_run:
-		click.secho("bench-ai — dry run", fg="cyan", bold=True)
-		click.echo()
-		stats = [
-			("Model", model_id),
-			("API base", normalize_base_url(base_url)),
-			("Context size", f"{len(context):,} chars"),
-			("Prompt", f"{len(prompt):,} chars"),
-		]
-		w = max(len(k) for k, _ in stats)
-		for k, v in stats:
-			click.echo(f"  {k.ljust(w)}  {v}")
-		click.echo()
-		click.secho("No API request sent.", dim=True)
+		_bench_ai_dry_run(model_id, base_url, context, prompt)
 		return
 
 	api_key = get_api_key()
@@ -457,100 +607,18 @@ def bench_ai(prompt, model, temperature, dry_run, run_cmd):
 			"Missing API key. Set BENCH_AI_API_KEY or OPENAI_API_KEY, or use --dry-run."
 		)
 
-	messages = [
-		{"role": "system", "content": SYSTEM_PROMPT},
-		{
-			"role": "user",
-			"content": (
-				"Context is authoritative; only use ```bash for commands that match it.\n\n"
-				f"Context:\n{context}\n\nQuestion:\n{prompt}"
-			),
-		},
-	]
 	click.secho("Requesting suggestion…", fg="bright_black")
-	reply = chat_completion(base_url, api_key, model_id, temperature, messages)
-
-	click.echo()
-	click.secho("Guidance", fg="bright_blue", bold=True)
-	click.secho(
-		"(From local bench help; suggested line is checked against this CLI.)",
-		fg="bright_black",
-		dim=True,
+	reply = chat_completion(
+		base_url,
+		api_key,
+		model_id,
+		temperature,
+		_bench_ai_completion_messages(context, prompt),
 	)
-	click.echo(click.style(_rule_char_line(), fg="bright_black"))
-	click.echo(reply)
-
+	_bench_ai_print_reply(reply)
 	frappe_names = load_frappe_command_names()
-	suggested = parse_suggested_command(reply)
-	is_bench_line = suggested.startswith("bench ")
-	valid, err = (
-		validate_suggested_command_line(suggested, bench_command, frappe_names)
-		if is_bench_line
-		else (True, "")
-	)
-
-	if is_bench_line:
-		click.echo()
-		click.secho("Suggested command (for --run)", fg="cyan", bold=True)
-		click.echo(click.style(_rule_char_line(), fg="bright_black"))
-		click.echo(click.style(suggested, fg="green", bold=True))
-		click.echo()
-		inv = extract_bench_invocation(suggested)
-		if _line_has_placeholders(suggested):
-			click.secho(
-				"Line has <placeholders> — edit before running.",
-				fg="yellow",
-			)
-		elif not valid:
-			click.secho("Local validation failed", fg="red", bold=True)
-			click.secho(err, fg="red")
-			click.secho("Compare with `bench --help` before using this.", fg="yellow")
-		elif inv and inv[0] == "frappe" and frappe_names is None:
-			click.secho(
-				"`--site` line not checked against live Frappe list (run bench-ai from a bench for that).",
-				fg="yellow",
-				dim=True,
-			)
-		elif valid and frappe_names is not None:
-			click.secho("OK — matches this bench's CLI / Frappe commands.", fg="green", dim=True)
-		elif valid:
-			click.secho(
-				"OK — native bench and/or crib (full framework list only on a real bench).",
-				fg="green",
-				dim=True,
-			)
-	else:
-		click.echo()
-		click.secho(
-			"No `bench …` line in the reply (add a ```bash block). Running from a bench helps for framework commands.",
-			fg="yellow",
-		)
-
-	if run_cmd:
-		final = parse_suggested_command(reply)
-		if not final.startswith("bench "):
-			raise click.ClickException("Refusing --run: no runnable `bench ...` in the reply.")
-		if _line_has_placeholders(final):
-			raise click.ClickException("Refusing --run: fix <placeholders> first.")
-		ok_run, run_err = validate_suggested_command_line(final, bench_command, frappe_names)
-		if not ok_run:
-			raise click.ClickException(
-				f"Refusing --run: {run_err} Verify with `bench --help` and run manually if needed."
-			)
-		click.echo()
-		if not click.confirm(click.style("Run this command?", fg="yellow") + f"\n  {final}", default=False):
-			click.secho("Cancelled.", dim=True)
-			return
-		try:
-			argv = shlex.split(final)
-		except ValueError as e:
-			raise click.ClickException(f"Could not parse command: {e}") from e
-		click.secho("Running…", fg="bright_black")
-		ret = subprocess.run(argv, check=False).returncode
-		if ret:
-			click.secho(f"Exit code: {ret}", fg="yellow")
-		else:
-			click.secho("Done.", fg="green")
+	_bench_ai_show_suggestion(reply, bench_command, frappe_names)
+	_bench_ai_run_if_requested(run_cmd, reply, bench_command, frappe_names)
 
 
 def main():

--- a/bench/commands/ai.py
+++ b/bench/commands/ai.py
@@ -1,0 +1,561 @@
+# imports - standard imports
+import os
+import re
+import shlex
+import shutil
+import subprocess
+from typing import List, Optional, Tuple
+
+# imports - third party imports
+import click
+import requests
+
+DEFAULT_MODEL = "gpt-4o-mini"
+DEFAULT_BASE_URL = "https://api.openai.com/v1"
+MAX_HELP_CHARS = 12000
+MAX_BENCH_PATH_LIST_CHARS = 12000
+MAX_FRAPPE_HELP_CHARS = 20000
+MAX_FRAPPE_NAMES_CHARS = 12000
+
+# Fallback when we can't run bench_helper (e.g. not inside a bench). Tokens align with Frappe docs.
+COMMON_FRAPPE_COMMANDS_CRIB = """Common Frappe framework command names (short crib; same commands are listed in Frappe docs).
+They usually run as `bench <name>` (bench forwards to Frappe) or `bench --site <site> <name>` when a site is required:
+doctor, migrate, console, backup, restore, install-app, uninstall-app, reinstall-app, list-apps, show-config,
+clear-cache, clear-website-cache, build, version, scheduler, worker, mariadb, execute, data-import, export-csv,
+serve, reload-doc, reload-doctype, disable-scheduler, enable-scheduler, set-admin-password, set-config, use,
+browse, drop-site, partial-restore, transform-database, trim-database, trim-tables, rebuild-global-search
+
+Your machine’s complete set appears in Context only when bench-ai runs inside a Frappe bench with a working env."""
+
+COMMON_FRAPPE_FIRST_TOKENS = frozenset(
+	{
+		"doctor",
+		"migrate",
+		"console",
+		"backup",
+		"restore",
+		"install-app",
+		"uninstall-app",
+		"reinstall-app",
+		"list-apps",
+		"show-config",
+		"clear-cache",
+		"clear-website-cache",
+		"build",
+		"version",
+		"scheduler",
+		"worker",
+		"mariadb",
+		"execute",
+		"data-import",
+		"export-csv",
+		"serve",
+		"reload-doc",
+		"reload-doctype",
+		"disable-scheduler",
+		"enable-scheduler",
+		"set-admin-password",
+		"set-config",
+		"use",
+		"browse",
+		"drop-site",
+		"partial-restore",
+		"transform-database",
+		"trim-database",
+		"trim-tables",
+		"rebuild-global-search",
+	}
+)
+
+CHEATSHEET = """Typical frappe-bench flows:
+- New bench: clones Frappe into apps/, env, sites/, config — `bench init <path>`
+- New site: `bench new-site <site>`
+- Get app from Git (into apps/): `bench get-app <app> [git-url]` — not the same as installing on a site
+- Install app on a site: `bench --site <site> install-app <app>`
+- ERPNext example: `bench get-app erpnext`, then `bench --site <site> install-app erpnext`, often `migrate` / `bench build`
+- Framework commands (`doctor`, `migrate`, `console`, …): `bench --site <site> <cmd>` or `bench <cmd>` when bench delegates to Frappe; full list only when bench-ai runs inside a working bench
+- Dev: `bench start` · Update: `bench update` · Migrate site: `bench --site <site> migrate`
+- Backup: `bench --site <site> backup [--with-files]` · All sites: `bench backup-all-sites`
+"""
+
+BENCH_AI_LONG_DOC = """Suggest bench commands from plain English via an OpenAI-compatible Chat Completions API.
+
+Examples:
+  bench-ai "back up all sites"
+  bench-ai "install erpnext on site erp.local" --temperature 0
+  bench-ai "what command migrates my database?" --dry-run
+
+What it does: finds your bench root if possible, builds context from local `bench --help` (and Frappe appendix
+when inside a bench), sends that plus your question to the API, prints the reply and a parsed `bench …` line.
+
+Environment:
+  BENCH_AI_API_KEY or OPENAI_API_KEY (required unless --dry-run)
+  BENCH_AI_BASE_URL — default https://api.openai.com/v1
+  BENCH_AI_MODEL — default gpt-4o-mini
+
+By default nothing is executed. --run asks for confirmation, then runs the parsed argv without a shell."""
+
+
+def _print_help(ctx: click.Context, param, value: bool):
+	if not value or ctx.resilient_parsing:
+		return
+	click.echo(click.style("bench-ai", fg="cyan", bold=True) + " — natural language to bench command")
+	click.echo()
+	click.echo("Usage: bench-ai [OPTIONS] PROMPT")
+	click.echo()
+	click.echo(BENCH_AI_LONG_DOC.rstrip())
+	click.echo()
+	fmt = ctx.make_formatter()
+	ctx.command.format_options(ctx, fmt)
+	click.echo(fmt.getvalue().rstrip())
+	ctx.exit()
+
+
+def _rule_char_line():
+	cols = shutil.get_terminal_size(fallback=(88, 24)).columns
+	return "─" * min(max(cols - 4, 40), 72)
+
+
+def normalize_base_url(url: str) -> str:
+	url = (url or DEFAULT_BASE_URL).strip().rstrip("/")
+	if not url.endswith("/v1"):
+		url = url + "/v1"
+	return url
+
+
+def get_api_key() -> Optional[str]:
+	return os.environ.get("BENCH_AI_API_KEY") or os.environ.get("OPENAI_API_KEY")
+
+
+def collect_bench_click_paths(
+	group: click.Group, prefix: Tuple[str, ...] = ()
+) -> List[str]:
+	paths: List[str] = []
+	for name, cmd in group.commands.items():
+		aliases: Tuple[str, ...] = (name,) if isinstance(name, str) else tuple(name)
+		for part in aliases:
+			path = prefix + (part,)
+			paths.append(" ".join(path))
+			if isinstance(cmd, click.Group):
+				paths.extend(collect_bench_click_paths(cmd, path))
+	return paths
+
+
+def build_context() -> str:
+	from bench.commands import bench_command
+
+	sections: List[str] = [CHEATSHEET, COMMON_FRAPPE_COMMANDS_CRIB]
+
+	native = sorted(set(collect_bench_click_paths(bench_command)))
+	block = "Bench native subcommands (from Click; `bench <path>` without `--site`):\n" + "\n".join(native)
+	if len(block) > MAX_BENCH_PATH_LIST_CHARS:
+		block = block[: MAX_BENCH_PATH_LIST_CHARS - 3] + "...\n(list truncated)"
+	sections.append(block)
+
+	ctx = click.Context(bench_command)
+	help_text = ctx.get_help()
+	if len(help_text) > MAX_HELP_CHARS:
+		help_text = help_text[: MAX_HELP_CHARS - 3] + "..."
+	sections.append("Bench CLI help (top of `bench --help`):\n" + help_text)
+
+	from bench.utils import get_env_frappe_commands, is_bench_directory
+
+	if is_bench_directory():
+		try:
+			from bench.cli import get_frappe_help
+
+			frappe_help = get_frappe_help()
+			if frappe_help.strip():
+				if len(frappe_help) > MAX_FRAPPE_HELP_CHARS:
+					frappe_help = frappe_help[: MAX_FRAPPE_HELP_CHARS - 3] + "..."
+				sections.append(
+					"Framework commands (`bench --help` appendix on this bench):\n" + frappe_help.strip()
+				)
+		except Exception:
+			pass
+		try:
+			cmds = get_env_frappe_commands()
+			if cmds:
+				names = sorted({str(c).strip() for c in cmds if str(c).strip()})
+				line = (
+					"Framework command names (`bench --site <site> <name>` …):\n" + ", ".join(names)
+				)
+				if len(line) > MAX_FRAPPE_NAMES_CHARS:
+					line = line[: MAX_FRAPPE_NAMES_CHARS - 3] + "... (truncated)"
+				sections.append(line)
+		except Exception:
+			pass
+	else:
+		sections.append(
+			"Note: not inside a bench — live framework names/help omitted. `cd` to your bench for the full list."
+		)
+
+	return "\n\n".join(sections)
+
+
+def chat_completion(
+	base_url: str, api_key: str, model: str, temperature: float, messages: list
+) -> str:
+	endpoint = normalize_base_url(base_url) + "/chat/completions"
+	resp = requests.post(
+		endpoint,
+		headers={
+			"Authorization": f"Bearer {api_key}",
+			"Content-Type": "application/json",
+		},
+		json={"model": model, "messages": messages, "temperature": temperature},
+		timeout=120,
+	)
+	if resp.status_code == 401:
+		raise click.ClickException(
+			"API authentication failed (401). Check BENCH_AI_API_KEY or OPENAI_API_KEY."
+		)
+	if resp.status_code == 429:
+		raise click.ClickException("Rate limited (429). Retry later.")
+	try:
+		resp.raise_for_status()
+	except requests.HTTPError as e:
+		raise click.ClickException(f"API request failed: {e}") from e
+	data = resp.json()
+	choices = data.get("choices") or []
+	if not choices:
+		raise click.ClickException("Empty response from API.")
+	content = choices[0].get("message", {}).get("content")
+	if not content:
+		raise click.ClickException("No message content in API response.")
+	return content.strip()
+
+
+def _line_has_placeholders(line: str) -> bool:
+	return "<" in line and ">" in line
+
+
+def _skip_global_bench_flags(tokens: List[str], i: int) -> int:
+	while i < len(tokens):
+		t = tokens[i]
+		if t in ("-v", "--verbose"):
+			i += 1
+			continue
+		if t == "--version":
+			i += 1
+			continue
+		if t == "--use-feature":
+			if i + 1 < len(tokens) and not tokens[i + 1].startswith("-"):
+				i += 2
+			else:
+				i += 1
+			continue
+		break
+	return i
+
+
+def extract_bench_invocation(line: str) -> Optional[Tuple[str, List[str]]]:
+	try:
+		tokens = shlex.split(line)
+	except ValueError:
+		return None
+	if not tokens or tokens[0] != "bench":
+		return None
+	i = _skip_global_bench_flags(tokens, 1)
+	if i < len(tokens) and tokens[i] == "--site":
+		if i + 1 >= len(tokens):
+			return None
+		i += 2
+		i = _skip_global_bench_flags(tokens, i)
+		return ("frappe", list(tokens[i:]))
+	return ("bench", list(tokens[i:]))
+
+
+def validate_bench_native_path(group: click.Group, parts: List[str]) -> Tuple[bool, str]:
+	if not parts:
+		return False, "Incomplete `bench` command (missing subcommand)."
+	i = 0
+	while i < len(parts):
+		name = parts[i]
+		if name not in group.commands:
+			return False, f"Unknown bench CLI command `{name}` — not in your installed bench."
+		cmd = group.commands[name]
+		i += 1
+		if isinstance(cmd, click.Group):
+			if i >= len(parts):
+				return True, ""
+			group = cmd
+			continue
+		return True, ""
+	return True, ""
+
+
+def validate_frappe_subcommand(parts: List[str], frappe_names: set) -> Tuple[bool, str]:
+	if not parts:
+		return False, "Missing framework subcommand after `--site <site>`."
+	head = parts[0]
+	if head not in frappe_names:
+		return False, f"Unknown framework command `{head}` — not in this bench's Frappe list."
+	return True, ""
+
+
+def load_frappe_command_names() -> Optional[set]:
+	from bench.utils import get_env_frappe_commands, is_bench_directory
+
+	if not is_bench_directory():
+		return None
+	try:
+		raw = get_env_frappe_commands()
+	except Exception:
+		return None
+	if not raw:
+		return None
+	names = {str(x).strip() for x in raw if str(x).strip()}
+	return names or None
+
+
+def validate_suggested_command_line(
+	line: str,
+	bench_root: click.Group,
+	frappe_names: Optional[set],
+) -> Tuple[bool, str]:
+	if _line_has_placeholders(line):
+		return True, ""
+	parsed = extract_bench_invocation(line)
+	if parsed is None:
+		return False, "Could not parse a `bench ...` command from this line."
+	kind, parts = parsed
+	if kind == "frappe":
+		if frappe_names is None:
+			return True, ""
+		return validate_frappe_subcommand(parts, frappe_names)
+	ok, msg = validate_bench_native_path(bench_root, parts)
+	if ok:
+		return True, ""
+	if frappe_names is not None:
+		if parts and parts[0] in frappe_names:
+			return validate_frappe_subcommand(parts, frappe_names)
+		return ok, msg
+	if parts and parts[0] in COMMON_FRAPPE_FIRST_TOKENS:
+		return True, ""
+	return ok, msg
+
+
+_LINE_BENCH = re.compile(r"^\s*(?:[-*]\s+)?(?P<cmd>bench\s+.+)$")
+
+
+def parse_suggested_command(text: str) -> str:
+	found: List[str] = []
+	for block in re.findall(
+		r"```(?:bash|sh)?\s*\n(.*?)```", text, re.DOTALL | re.IGNORECASE
+	):
+		for raw in block.strip().splitlines():
+			line = raw.strip()
+			if line.startswith("bench "):
+				found.append(line)
+	for line in text.splitlines():
+		m = _LINE_BENCH.match(line)
+		if m:
+			found.append(m.group("cmd").strip())
+	for line in found:
+		if not _line_has_placeholders(line):
+			return line
+	if found:
+		return found[0]
+	return ""
+
+
+SYSTEM_PROMPT = """You help with frappe-bench CLI questions. Stick to the Context block: native subcommands from
+this install, `bench --help`, optional live Frappe names/help inside a bench, plus a short static framework crib
+when the live list is missing.
+
+Rules:
+- Native `bench` subcommands must appear in the "Bench native subcommands" list or Bench CLI help.
+- Framework commands: first token must be in the live framework list or in "Common Frappe framework command names".
+  If it isn't, do not put it in a ```bash fence.
+- No invented flags or subcommands. If Context is insufficient, explain in prose and point to official Bench docs;
+  leave ### Command to run without a bash fence.
+
+Structure your answer as:
+
+### Summary
+### Command to run
+### What this command does
+### Recommended next steps
+
+Keep ### What this command does factual for the commands you named. Be concise; don't paste Context back.
+"""
+
+
+@click.command(
+	name="bench-ai",
+	context_settings={"help_option_names": []},
+	add_help_option=False,
+)
+@click.option(
+	"-h",
+	"--help",
+	is_flag=True,
+	is_eager=True,
+	expose_value=False,
+	callback=_print_help,
+	help="Show usage and options.",
+)
+@click.argument("prompt", type=str, required=True, metavar="PROMPT")
+@click.option("--model", "model", default=None, help="Overrides BENCH_AI_MODEL.")
+@click.option(
+	"--temperature",
+	type=float,
+	default=0.1,
+	show_default=True,
+	help="Sampling temperature.",
+)
+@click.option(
+	"--dry-run",
+	is_flag=True,
+	help="Print model and context size only; no API call.",
+)
+@click.option(
+	"--run",
+	"run_cmd",
+	is_flag=True,
+	help="Confirm and run the suggested command (no shell).",
+)
+def bench_ai(prompt, model, temperature, dry_run, run_cmd):
+	from bench.cli import change_working_directory
+	from bench.commands import bench_command
+	from bench.utils import is_bench_directory
+
+	change_working_directory()
+
+	if not is_bench_directory():
+		click.secho(
+			"Tip: not in a Frappe bench — using static framework crib; `cd` to your bench for full `bench --help`.",
+			fg="yellow",
+			dim=True,
+		)
+		click.echo()
+
+	context = build_context()
+	model_id = model or os.environ.get("BENCH_AI_MODEL") or DEFAULT_MODEL
+	base_url = os.environ.get("BENCH_AI_BASE_URL", DEFAULT_BASE_URL)
+
+	if dry_run:
+		click.secho("bench-ai — dry run", fg="cyan", bold=True)
+		click.echo()
+		stats = [
+			("Model", model_id),
+			("API base", normalize_base_url(base_url)),
+			("Context size", f"{len(context):,} chars"),
+			("Prompt", f"{len(prompt):,} chars"),
+		]
+		w = max(len(k) for k, _ in stats)
+		for k, v in stats:
+			click.echo(f"  {k.ljust(w)}  {v}")
+		click.echo()
+		click.secho("No API request sent.", dim=True)
+		return
+
+	api_key = get_api_key()
+	if not api_key:
+		raise click.ClickException(
+			"Missing API key. Set BENCH_AI_API_KEY or OPENAI_API_KEY, or use --dry-run."
+		)
+
+	messages = [
+		{"role": "system", "content": SYSTEM_PROMPT},
+		{
+			"role": "user",
+			"content": (
+				"Context is authoritative; only use ```bash for commands that match it.\n\n"
+				f"Context:\n{context}\n\nQuestion:\n{prompt}"
+			),
+		},
+	]
+	click.secho("Requesting suggestion…", fg="bright_black")
+	reply = chat_completion(base_url, api_key, model_id, temperature, messages)
+
+	click.echo()
+	click.secho("Guidance", fg="bright_blue", bold=True)
+	click.secho(
+		"(From local bench help; suggested line is checked against this CLI.)",
+		fg="bright_black",
+		dim=True,
+	)
+	click.echo(click.style(_rule_char_line(), fg="bright_black"))
+	click.echo(reply)
+
+	frappe_names = load_frappe_command_names()
+	suggested = parse_suggested_command(reply)
+	is_bench_line = suggested.startswith("bench ")
+	valid, err = (
+		validate_suggested_command_line(suggested, bench_command, frappe_names)
+		if is_bench_line
+		else (True, "")
+	)
+
+	if is_bench_line:
+		click.echo()
+		click.secho("Suggested command (for --run)", fg="cyan", bold=True)
+		click.echo(click.style(_rule_char_line(), fg="bright_black"))
+		click.echo(click.style(suggested, fg="green", bold=True))
+		click.echo()
+		inv = extract_bench_invocation(suggested)
+		if _line_has_placeholders(suggested):
+			click.secho(
+				"Line has <placeholders> — edit before running.",
+				fg="yellow",
+			)
+		elif not valid:
+			click.secho("Local validation failed", fg="red", bold=True)
+			click.secho(err, fg="red")
+			click.secho("Compare with `bench --help` before using this.", fg="yellow")
+		elif inv and inv[0] == "frappe" and frappe_names is None:
+			click.secho(
+				"`--site` line not checked against live Frappe list (run bench-ai from a bench for that).",
+				fg="yellow",
+				dim=True,
+			)
+		elif valid and frappe_names is not None:
+			click.secho("OK — matches this bench's CLI / Frappe commands.", fg="green", dim=True)
+		elif valid:
+			click.secho(
+				"OK — native bench and/or crib (full framework list only on a real bench).",
+				fg="green",
+				dim=True,
+			)
+	else:
+		click.echo()
+		click.secho(
+			"No `bench …` line in the reply (add a ```bash block). Running from a bench helps for framework commands.",
+			fg="yellow",
+		)
+
+	if run_cmd:
+		final = parse_suggested_command(reply)
+		if not final.startswith("bench "):
+			raise click.ClickException("Refusing --run: no runnable `bench ...` in the reply.")
+		if _line_has_placeholders(final):
+			raise click.ClickException("Refusing --run: fix <placeholders> first.")
+		ok_run, run_err = validate_suggested_command_line(final, bench_command, frappe_names)
+		if not ok_run:
+			raise click.ClickException(
+				f"Refusing --run: {run_err} Verify with `bench --help` and run manually if needed."
+			)
+		click.echo()
+		if not click.confirm(click.style("Run this command?", fg="yellow") + f"\n  {final}", default=False):
+			click.secho("Cancelled.", dim=True)
+			return
+		try:
+			argv = shlex.split(final)
+		except ValueError as e:
+			raise click.ClickException(f"Could not parse command: {e}") from e
+		click.secho("Running…", fg="bright_black")
+		ret = subprocess.run(argv, check=False).returncode
+		if ret:
+			click.secho(f"Exit code: {ret}", fg="yellow")
+		else:
+			click.secho("Done.", fg="green")
+
+
+def main():
+	bench_ai()
+
+
+if __name__ == "__main__":
+	main()

--- a/bench/commands/ai.py
+++ b/bench/commands/ai.py
@@ -16,6 +16,8 @@ MAX_HELP_CHARS = 12000
 MAX_BENCH_PATH_LIST_CHARS = 12000
 MAX_FRAPPE_HELP_CHARS = 20000
 MAX_FRAPPE_NAMES_CHARS = 12000
+# Cap model reply size before fence parsing (avoids pathological input; no ReDoS from backtracking).
+MAX_AI_REPLY_PARSE_CHARS = 200_000
 
 # Prefix for a typical shell suggestion line (Sonar: single definition for the literal).
 BENCH_SHELL_PREFIX = "bench "
@@ -361,12 +363,28 @@ _LINE_BENCH = re.compile(
 )
 
 
+def _strip_opening_fence_language(block: str) -> str:
+	lines = block.lstrip("\n").splitlines()
+	if not lines:
+		return ""
+	first = lines[0].strip().lower()
+	if first in ("bash", "sh"):
+		return "\n".join(lines[1:])
+	return "\n".join(lines)
+
+
+def _iter_fenced_code_bodies(text: str):
+	chunks = text.split("```")
+	for i in range(1, len(chunks), 2):
+		yield _strip_opening_fence_language(chunks[i])
+
+
 def parse_suggested_command(text: str) -> str:
+	if len(text) > MAX_AI_REPLY_PARSE_CHARS:
+		text = text[:MAX_AI_REPLY_PARSE_CHARS]
 	found: List[str] = []
-	for block in re.findall(
-		r"```(?:bash|sh)?\s*\n(.*?)```", text, re.DOTALL | re.IGNORECASE
-	):
-		for raw in block.strip().splitlines():
+	for body in _iter_fenced_code_bodies(text):
+		for raw in body.strip().splitlines():
 			line = raw.strip()
 			if line.startswith(BENCH_SHELL_PREFIX):
 				found.append(line)

--- a/bench/tests/test_ai_command.py
+++ b/bench/tests/test_ai_command.py
@@ -1,0 +1,170 @@
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from bench.commands.ai import bench_ai
+
+
+class TestBenchAiCommand(unittest.TestCase):
+	def test_dry_run_skips_api(self):
+		with patch("bench.commands.ai.requests.post") as post:
+			runner = CliRunner()
+			result = runner.invoke(bench_ai, ["backup all sites", "--dry-run"])
+			self.assertEqual(result.exit_code, 0, msg=result.output)
+			post.assert_not_called()
+			self.assertIn("Context size", result.output)
+			self.assertIn("Model", result.output)
+			self.assertIn("dry run", result.output.lower())
+
+	def test_missing_api_key(self):
+		env = os.environ.copy()
+		env.pop("BENCH_AI_API_KEY", None)
+		env.pop("OPENAI_API_KEY", None)
+		runner = CliRunner()
+		result = runner.invoke(bench_ai, ["hello"], env=env)
+		self.assertNotEqual(result.exit_code, 0)
+		self.assertIn("Missing API key", result.output)
+
+	def test_suggestion_with_mocked_completion(self):
+		def fake_post(url, headers=None, json=None, timeout=None):
+			r = MagicMock()
+			r.status_code = 200
+			r.json.return_value = {
+				"choices": [
+					{
+						"message": {
+							"content": "Back up every site.\n```bash\nbench backup-all-sites\n```"
+						}
+					}
+				]
+			}
+			r.raise_for_status = MagicMock()
+			return r
+
+		with patch("bench.commands.ai.requests.post", side_effect=fake_post):
+			runner = CliRunner()
+			result = runner.invoke(
+				bench_ai,
+				["backup everything"],
+				env={"BENCH_AI_API_KEY": "test-secret"},
+			)
+		self.assertEqual(result.exit_code, 0, msg=result.output)
+		self.assertIn("bench backup-all-sites", result.output)
+		self.assertIn("Guidance", result.output)
+		self.assertIn("Suggested command", result.output)
+		self.assertIn("OK —", result.output)
+
+	def test_validate_bench_native_known_command(self):
+		from bench.commands import bench_command
+		from bench.commands.ai import validate_suggested_command_line
+
+		ok, _ = validate_suggested_command_line(
+			"bench get-app erpnext https://github.com/frappe/erpnext",
+			bench_command,
+			None,
+		)
+		self.assertTrue(ok)
+
+	def test_validate_bench_native_unknown_command(self):
+		from bench.commands import bench_command
+		from bench.commands.ai import validate_suggested_command_line
+
+		ok, msg = validate_suggested_command_line(
+			"bench this-is-not-a-real-subcommand-xyz",
+			bench_command,
+			None,
+		)
+		self.assertFalse(ok)
+		self.assertIn("Unknown", msg)
+
+	def test_validate_frappe_when_list_provided(self):
+		from bench.commands import bench_command
+		from bench.commands.ai import validate_suggested_command_line
+
+		ok, _ = validate_suggested_command_line(
+			"bench --site foo.local migrate",
+			bench_command,
+			{"migrate", "backup"},
+		)
+		self.assertTrue(ok)
+		ok2, _ = validate_suggested_command_line(
+			"bench doctor",
+			bench_command,
+			{"doctor", "migrate"},
+		)
+		self.assertTrue(ok2)
+		bad, msg = validate_suggested_command_line(
+			"bench --site foo.local totally-fake-frappe-cmd",
+			bench_command,
+			{"migrate", "backup"},
+		)
+		self.assertFalse(bad)
+		self.assertIn("Unknown framework", msg)
+
+	def test_parse_suggested_command_prefers_runnable_line(self):
+		from bench.commands.ai import parse_suggested_command
+
+		text = """### Command
+```bash
+bench get-app <app> <repo-url>
+```
+```bash
+bench get-app erpnext https://github.com/frappe/erpnext
+```
+"""
+		self.assertEqual(
+			parse_suggested_command(text),
+			"bench get-app erpnext https://github.com/frappe/erpnext",
+		)
+
+	def test_parse_suggested_command_ignores_prose(self):
+		from bench.commands.ai import parse_suggested_command
+
+		text = (
+			"### Summary\nThe command `bench doctor` is not listed.\n"
+			"Visit https://example.com for more.\n"
+		)
+		self.assertEqual(parse_suggested_command(text), "")
+
+	def test_parse_suggested_command_markdown_list_line(self):
+		from bench.commands.ai import parse_suggested_command
+
+		text = "### Command\n- bench doctor\n"
+		self.assertEqual(parse_suggested_command(text), "bench doctor")
+
+	def test_crib_allows_doctor_without_frappe_env(self):
+		from bench.commands import bench_command
+		from bench.commands.ai import validate_suggested_command_line
+
+		ok, _ = validate_suggested_command_line("bench doctor", bench_command, None)
+		self.assertTrue(ok)
+
+	def test_collect_bench_click_paths_includes_nested(self):
+		from bench.commands import bench_command
+		from bench.commands.ai import collect_bench_click_paths
+
+		paths = set(collect_bench_click_paths(bench_command))
+		self.assertIn("get-app", paths)
+		self.assertTrue(any(p.startswith("setup ") for p in paths))
+
+	def test_normalize_base_url(self):
+		from bench.commands.ai import normalize_base_url
+
+		self.assertEqual(
+			normalize_base_url("https://example.com"),
+			"https://example.com/v1",
+		)
+		self.assertEqual(
+			normalize_base_url("https://example.com/v1"),
+			"https://example.com/v1",
+		)
+		self.assertEqual(
+			normalize_base_url("https://example.com/v1/"),
+			"https://example.com/v1",
+		)
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/bench/tests/test_ai_command.py
+++ b/bench/tests/test_ai_command.py
@@ -1,4 +1,3 @@
-import os
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -19,11 +18,10 @@ class TestBenchAiCommand(unittest.TestCase):
 			self.assertIn("dry run", result.output.lower())
 
 	def test_missing_api_key(self):
-		env = os.environ.copy()
-		env.pop("BENCH_AI_API_KEY", None)
-		env.pop("OPENAI_API_KEY", None)
-		runner = CliRunner()
-		result = runner.invoke(bench_ai, ["hello"], env=env)
+		# CliRunner may merge with the parent process env; patch ensures no key is seen.
+		with patch("bench.commands.ai.get_api_key", return_value=None):
+			runner = CliRunner()
+			result = runner.invoke(bench_ai, ["hello"])
 		self.assertNotEqual(result.exit_code, 0)
 		self.assertIn("Missing API key", result.output)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dynamic = [
 
 [project.scripts]
 bench = "bench.cli:cli"
+bench-ai = "bench.commands.ai:main"
 
 [project.urls]
 Changelog = "https://github.com/frappe/bench/releases"


### PR DESCRIPTION
## Title 

**feat: add `bench-ai` CLI for natural-language bench command help**

---

## Description

### Summary

Adds an optional **`bench-ai`** console entry point that turns plain-English questions into structured guidance and a suggested `bench commands`. It uses the existing **`requests`** dependency to call an **OpenAI-compatible Chat Completions** HTTP API. No new runtime dependencies.

Context is built from this machine’s **`bench` Click CLI** (full native subcommand paths + `bench --help` text) and, when run **inside a Frappe bench**, the same **framework command appendix** as `bench --help` (via `get_frappe_help` / `get_env_frappe_commands`). When not in a bench, a short **static framework crib** plus validation fallback still allows common commands (e.g. `doctor`) to be suggested conservatively.

Suggested lines are **checked** against the local CLI where possible; **`--run`** refuses invalid or placeholder commands. Default behavior is **print-only**.

### What changed

- New module: `bench/commands/ai.py` the  CLI, context builder, API client, parsing, validation.
- New console script in `pyproject.toml`: `bench-ai = "bench.commands.ai:main"`.
- Tests: `bench/tests/test_ai_command.py` (mocked HTTP, parsing, validation, Click path collection).
- Docs: README section **“bench-ai (optional)”** under Basic Usage.

### Configuration

Env varaibles

1.  `OPENAI_API_KEY` or `BENCH_AI_API_KEY`: OPEN API key
2. `BENCH_AI_BASE_URL`:  Default `https://api.openai.com/v1` 
3. `BENCH_AI_MODEL`:  Default `gpt-4o-mini`

### How to test

```bash
pip install -e .
python -m unittest bench.tests.test_ai_command -v
export OPENAI_API_KEY=...   # optional for live test
bench-ai "back up all sites" --dry-run
bench-ai "what does bench doctor do?"
```

### Dependencies

**None added**,  uses existing `requests` (~2.32.x per `pyproject.toml`).

### Documentation

README updated with install/setup, flags, and security note (review before `--run`).

### Notes for reviewers

- Guidelines mention keeping PRs very small; this feature is intentionally **one cohesive tool**. I’m happy to **split** (e.g. core CLI + README in one PR, follow-up for crib/validation refinements) if you prefer [cascading PRs](https://github.com/frappe/erpnext/wiki/Cascading-Pull-Requests).
- Facing strings are English CLI output; I did not wrap them in `_()` since `bench` CLI generally doesn’t i18n user messages the same way as Frappe apps—happy to adjust if project policy requires it.

### Checklist

- [x] Tests added / updated  
- [x] README updated  
- [x] CI considerations: `unittest` module (no pytest required)  