### PR TITLE
feat(completions): add filesystem path tab completion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
           sudo apt update -y;
           wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-2/wkhtmltox_0.12.6.1-2.jammy_amd64.deb;
           sudo apt install ./wkhtmltox_0.12.6.1-2.jammy_amd64.deb;
-          sudo apt install redis-server pkg-config
+          sudo apt install redis-server pkg-config zsh
 
           python -m pip install -U --no-cache-dir --force-reinstall urllib3 pyOpenSSL ndg-httpsclient pyasn1 wheel setuptools pip;
           python -m pip install -U -e ${GITHUB_WORKSPACE};

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
           python -m pip install -U --no-cache-dir --force-reinstall urllib3 pyOpenSSL ndg-httpsclient pyasn1 wheel setuptools pip;
           python -m pip install -U -e ${GITHUB_WORKSPACE};
 
-      - run: python -m unittest -v bench.tests.test_utils && python -m unittest -v bench.tests.test_init
+      - run: python -m unittest -v bench.tests.test_utils && python -m unittest -v bench.tests.test_init && python -m unittest -v bench.tests.test_completions
 
       - uses: mxschmitt/action-tmate@v3
         if: ${{ failure() && contains( github.event.pull_request.labels.*.name, 'debug-gha') }}

--- a/bench/commands/completion_utils.py
+++ b/bench/commands/completion_utils.py
@@ -1,0 +1,32 @@
+import click
+
+
+_PATH_NAME_HINTS = ("path", "file", "certificate", "sql", "clone_from")
+
+
+def normalize_param_name(name: str) -> str:
+	return name.lower().replace("-", "_")
+
+
+def looks_like_path_name(name: str) -> bool:
+	normalized = normalize_param_name(name)
+	return any(hint in normalized for hint in _PATH_NAME_HINTS)
+
+
+def looks_like_path_option(option: str) -> bool:
+	return looks_like_path_name(option.lstrip("-"))
+
+
+def param_expects_path(param) -> bool:
+	if isinstance(param.type, click.Path):
+		return True
+
+	names = []
+	if isinstance(param, click.Option):
+		if param.name:
+			names.append(param.name)
+		names.extend(option.lstrip("-") for option in param.opts)
+	elif isinstance(param, click.Argument) and param.name:
+		names.append(param.name)
+
+	return any(looks_like_path_name(name) for name in names)

--- a/bench/commands/completions.py
+++ b/bench/commands/completions.py
@@ -486,52 +486,56 @@ def _unique(values):
 
 
 def render_bash_completion(spec: dict) -> str:
-	return _render_completion_script(spec, shell="bash")
+	parts = [
+		"# shellcheck shell=bash",
+		*_render_spec_constants(spec),
+		"",
+		_render_case_function("_bench_subcommands_for", spec["subcommands"]),
+		"",
+		_render_case_function("_bench_options_for", spec["options"]),
+		"",
+		_render_case_function("_bench_value_options_for", spec["value_options"]),
+		"",
+		_render_case_function("_bench_path_options_for", spec["path_options"]),
+		"",
+		_render_case_function("_bench_path_positionals_for", spec["path_positionals"]),
+		"",
+		_render_bash_runtime(),
+		"",
+		"complete -o nosort -o nospace -F _bench_completion bench",
+	]
+	return "\n".join(parts) + "\n"
 
 
 def render_zsh_completion(spec: dict) -> str:
-	return _render_completion_script(spec, shell="zsh")
-
-
-def _render_completion_script(spec: dict, shell: str) -> str:
-	parts = []
-
-	if shell == "zsh":
-		parts.extend(
-			[
-				"#compdef bench",
-				"autoload -U bashcompinit",
-				"bashcompinit",
-				"",
-			]
-		)
-
-	parts.extend(
-		[
-			"# shellcheck shell=bash",
-			f"_BENCH_ROOT_KEY={shlex.quote(ROOT_KEY)}",
-			f"_BENCH_FRAPPE_KEY={shlex.quote(FRAPPE_KEY)}",
-			f"_BENCH_FRAPPE_COMMANDS={shlex.quote(' '.join(spec['frappe_commands']))}",
-			f"_BENCH_FORWARDED_FLAGS={shlex.quote(' '.join(FORWARDED_FLAGS))}",
-			f"_BENCH_FORWARDED_VALUE_OPTIONS={shlex.quote(' '.join(FORWARDED_VALUE_OPTIONS))}",
-			"",
-			_render_case_function("_bench_subcommands_for", spec["subcommands"]),
-			"",
-			_render_case_function("_bench_options_for", spec["options"]),
-			"",
-			_render_case_function("_bench_value_options_for", spec["value_options"]),
-			"",
-			_render_case_function("_bench_path_options_for", spec["path_options"]),
-			"",
-			_render_case_function("_bench_path_positionals_for", spec["path_positionals"]),
-			"",
-			_render_bash_runtime(shell),
-			"",
-			"complete -o nosort -o nospace -F _bench_completion bench",
-		]
-	)
-
+	parts = [
+		"#compdef bench",
+		"",
+		*_render_spec_constants(spec),
+		"",
+		_render_case_function("_bench_subcommands_for", spec["subcommands"]),
+		"",
+		_render_case_function("_bench_options_for", spec["options"]),
+		"",
+		_render_case_function("_bench_value_options_for", spec["value_options"]),
+		"",
+		_render_case_function("_bench_path_options_for", spec["path_options"]),
+		"",
+		_render_case_function("_bench_path_positionals_for", spec["path_positionals"]),
+		"",
+		_ZSH_RUNTIME,
+	]
 	return "\n".join(parts) + "\n"
+
+
+def _render_spec_constants(spec: dict) -> list[str]:
+	return [
+		f"_BENCH_ROOT_KEY={shlex.quote(ROOT_KEY)}",
+		f"_BENCH_FRAPPE_KEY={shlex.quote(FRAPPE_KEY)}",
+		f"_BENCH_FRAPPE_COMMANDS={shlex.quote(' '.join(spec['frappe_commands']))}",
+		f"_BENCH_FORWARDED_FLAGS={shlex.quote(' '.join(FORWARDED_FLAGS))}",
+		f"_BENCH_FORWARDED_VALUE_OPTIONS={shlex.quote(' '.join(FORWARDED_VALUE_OPTIONS))}",
+	]
 
 
 def _render_case_function(name: str, mapping: dict) -> str:
@@ -545,18 +549,8 @@ def _render_case_function(name: str, mapping: dict) -> str:
 	return "\n".join(lines)
 
 
-def _render_bash_runtime(shell: str) -> str:
-	complete_files = (
-		_BENCH_COMPLETE_FILES_ZSH if shell == "zsh" else _BENCH_COMPLETE_FILES_BASH
-	)
-	suffix = _BASH_RUNTIME_SUFFIX
-	if shell == "zsh":
-		suffix = suffix.replace(
-			"_bench_completion() {\n\tlocal cur=",
-			"_bench_completion() {\n\temulate -L sh\n\tlocal cur=",
-			1,
-		)
-	return _BASH_RUNTIME_PREFIX + complete_files + suffix
+def _render_bash_runtime() -> str:
+	return _BASH_RUNTIME_PREFIX + _BENCH_COMPLETE_FILES_BASH + _BASH_RUNTIME_SUFFIX
 
 
 _BASH_RUNTIME_PREFIX = r"""_bench_find_root() {
@@ -791,65 +785,181 @@ _bench_complete_files() {
 
 """
 
-_BENCH_COMPLETE_FILES_ZSH = r"""_bench_expand_tilde() {
-	local cur="$1"
+_ZSH_RUNTIME = r"""_bench_find_root() {
+	local dir=$PWD
 
-	if [[ "$cur" == "~" || "$cur" == "~/"* ]]; then
-		printf '%s' "${cur/#\~/$HOME}"
+	while [[ -n $dir && $dir != / ]]; do
+		if [[ -d $dir/apps && -d $dir/sites && -d $dir/config && -d $dir/logs ]]; then
+			print -r -- $dir
+			return 0
+		fi
+		dir=${dir:h}
+	done
+
+	return 1
+}
+
+_bench_list_sites() {
+	local root site_config site
+
+	root=$(_bench_find_root) || return 0
+
+	for site_config in $root/sites/*/site_config.json(N); do
+		site=${site_config:h:t}
+		print -r -- $site
+	done
+}
+
+_bench_list_apps() {
+	local root app line
+
+	root=$(_bench_find_root) || return 0
+
+	if [[ -f $root/sites/apps.txt ]]; then
+		while IFS= read -r line; do
+			[[ -n $line ]] || continue
+			print -r -- $line
+		done < $root/sites/apps.txt
 		return 0
 	fi
 
-	printf '%s' "$cur"
+	for app in $root/apps/*(N/); do
+		print -r -- ${app:t}
+	done
 }
 
-_bench_path_match_candidates() {
-	local expanded="$1"
-	local dir prefix
+_bench_has_word() {
+	(( $# )) || return 1
+	local needle=$1
+	shift
+	local word
 
-	if [[ -d "$expanded" ]]; then
-		find "$expanded" -mindepth 1 -maxdepth 1 -print 2>/dev/null
+	for word in "$@"; do
+		[[ $word == $needle ]] && return 0
+	done
+
+	return 1
+}
+
+_bench_join_path() {
+	if [[ $1 == $_BENCH_ROOT_KEY ]]; then
+		print -r -- $2
 		return 0
 	fi
 
-	if [[ "$expanded" == */* ]]; then
-		dir="${expanded%/*}"
-		prefix="${expanded##*/}"
-	else
-		dir="."
-		prefix="$expanded"
-	fi
-
-	find "$dir" -maxdepth 1 -name "${prefix}"'*' -print 2>/dev/null
+	print -r -- $1 $2
 }
 
-_bench_complete_files() {
-	local cur="$1"
-	local expanded use_tilde=0
-	local match
-	local i
+_bench_collect_completion_state() {
+	local ctx=$_BENCH_ROOT_KEY
+	local positional_index=0
+	local skip_next=0
+	local i token value_opts subcommands
 
-	if [[ "$cur" == "~" || "$cur" == "~/"* ]]; then
-		use_tilde=1
-	fi
+	for (( i = 2; i < CURRENT; i++ )); do
+		token=$words[i]
 
-	expanded="$(_bench_expand_tilde "$cur")"
-	COMPREPLY=()
-
-	while IFS= read -r match; do
-		[[ -n "$match" ]] || continue
-
-		if [[ -d "$match" && "$match" != */ ]]; then
-			match="${match}/"
+		if (( skip_next )); then
+			skip_next=0
+			continue
 		fi
 
-		if (( use_tilde )) && [[ "$match" == "$HOME"/* || "$match" == "$HOME" ]]; then
-			match="~${match#$HOME}"
+		if [[ $token == -- ]]; then
+			break
 		fi
 
-		COMPREPLY+=("$match")
-	done < <(_bench_path_match_candidates "$expanded")
+		value_opts=(${(z)"$(_bench_value_options_for "$ctx")"})
+		if [[ $ctx == $_BENCH_ROOT_KEY ]]; then
+			value_opts+=(${(z)_BENCH_FORWARDED_VALUE_OPTIONS})
+		fi
+
+		if _bench_has_word $token $value_opts; then
+			skip_next=1
+			continue
+		fi
+
+		if [[ $token == -* ]]; then
+			continue
+		fi
+
+		subcommands=(${(z)"$(_bench_subcommands_for "$ctx")"})
+		if _bench_has_word $token $subcommands; then
+			ctx=$(_bench_join_path "$ctx" "$token")
+			positional_index=0
+			continue
+		fi
+
+		if [[ $ctx == $_BENCH_ROOT_KEY ]] && _bench_has_word $token ${(z)_BENCH_FRAPPE_COMMANDS}; then
+			ctx=$(_bench_join_path "$_BENCH_FRAPPE_KEY" "$token")
+			positional_index=0
+			continue
+		fi
+
+		(( positional_index++ ))
+	done
+
+	print -r -- $ctx\|$positional_index
 }
 
+_bench() {
+	local curcontext=$curcontext state
+	local cur prev ctx positional_index
+	local -a state_parts options subcommands path_options path_positionals words_list lines
+
+	cur=$words[CURRENT]
+	(( CURRENT > 2 )) && prev=$words[CURRENT-1]
+
+	case $prev in
+		(--site|-s)
+			lines=(${(@f)"$(_bench_list_sites)"})
+			[[ ${#lines[@]} -gt 0 ]] && _describe -t sites site lines
+			return $?
+			;;
+		(--app)
+			lines=(${(@f)"$(_bench_list_apps)"})
+			[[ ${#lines[@]} -gt 0 ]] && _describe -t apps app lines
+			return $?
+			;;
+	esac
+
+	state_parts=("${(@s:|:)$(_bench_collect_completion_state)}")
+	ctx=$state_parts[1]
+	positional_index=$state_parts[2]
+
+	path_options=(${(z)"$(_bench_path_options_for "$ctx")"})
+	if _bench_has_word $prev $path_options; then
+		_files
+		return $?
+	fi
+
+	path_positionals=(${(z)"$(_bench_path_positionals_for "$ctx")"})
+	if [[ $cur != -* ]] && _bench_has_word $positional_index $path_positionals; then
+		_files
+		return $?
+	fi
+
+	options=(${(z)"$(_bench_options_for "$ctx")"})
+	subcommands=(${(z)"$(_bench_subcommands_for "$ctx")"})
+
+	if [[ $ctx == $_BENCH_ROOT_KEY ]]; then
+		subcommands+=(${(z)_BENCH_FRAPPE_COMMANDS})
+		options+=(${(z)_BENCH_FORWARDED_FLAGS})
+		options+=(${(z)_BENCH_FORWARDED_VALUE_OPTIONS})
+	elif [[ $ctx == $_BENCH_FRAPPE_KEY || $ctx == $_BENCH_FRAPPE_KEY\ * ]]; then
+		options+=(${(z)_BENCH_FORWARDED_FLAGS})
+		options+=(${(z)_BENCH_FORWARDED_VALUE_OPTIONS})
+	fi
+
+	if [[ $cur == -* ]]; then
+		[[ ${#options[@]} -gt 0 ]] && _describe -t options option options
+		return $?
+	fi
+
+	words_list=($subcommands $options)
+	[[ ${#words_list[@]} -gt 0 ]] && _describe -t commands command words_list
+}
+
+compdef _bench bench
 """
 
 _BASH_RUNTIME_SUFFIX = r"""_bench_completion() {

--- a/bench/commands/completions.py
+++ b/bench/commands/completions.py
@@ -14,6 +14,10 @@ MAX_FRAPPE_DEPTH = 4
 FORWARDED_FLAGS = ["--verbose", "-v", "--profile", "--force"]
 FORWARDED_VALUE_OPTIONS = ["--site", "-s"]
 
+# Substrings matched against normalized option/argument names when Click does not
+# declare an explicit click.Path type (common in older frappe command definitions).
+_PATH_NAME_HINTS = ("path", "file", "certificate", "sql", "clone_from")
+
 # Path to the collector script that runs inside the frappe virtualenv.
 # Kept as a separate file so it gets syntax highlighting, linting, and can be
 # run or inspected directly without extracting it from a string constant.
@@ -115,21 +119,34 @@ def build_completion_spec(root_command: click.Command, verbose: bool = True) -> 
 	subcommands = {}
 	options = {}
 	value_options = {}
+	path_options = {}
+	path_positionals = {}
 
-	_collect_command_tree(root_command, (), subcommands, options, value_options)
+	_collect_command_tree(
+		root_command, (), subcommands, options, value_options, path_options, path_positionals
+	)
 
 	bench_path = _find_current_bench_path()
 	frappe_commands = []
 	if bench_path:
 		frappe_commands = _unique(get_env_frappe_commands(bench_path))
 		_collect_frappe_tree(
-			bench_path, subcommands, options, value_options, frappe_commands, verbose=verbose
+			bench_path,
+			subcommands,
+			options,
+			value_options,
+			path_options,
+			path_positionals,
+			frappe_commands,
+			verbose=verbose,
 		)
 
 	return {
 		"subcommands": subcommands,
 		"options": options,
 		"value_options": value_options,
+		"path_options": path_options,
+		"path_positionals": path_positionals,
 		"frappe_commands": frappe_commands,
 	}
 
@@ -165,7 +182,14 @@ def _get_frappe_spec_batch(bench_path, verbose: bool = True) -> dict | None:
 
 
 def _collect_frappe_tree(
-	bench_path, subcommands, options, value_options, fallback_commands, verbose: bool = True
+	bench_path,
+	subcommands,
+	options,
+	value_options,
+	path_options,
+	path_positionals,
+	fallback_commands,
+	verbose: bool = True,
 ):
 	spec = _get_frappe_spec_batch(bench_path, verbose=verbose)
 
@@ -178,14 +202,32 @@ def _collect_frappe_tree(
 			subcommands[key] = entry["commands"]
 			options[key] = entry["options"]
 			value_options[key] = entry["value_options"]
+			path_options[key] = entry.get("path_options", [])
+			path_positionals[key] = entry.get("path_positionals", [])
 		return
 
 	# get_app_groups() isn't available on older frappe versions, so fall back to
 	# spawning one --help subprocess per command, parallelised across each BFS level.
-	_collect_frappe_tree_bfs(bench_path, subcommands, options, value_options, fallback_commands)
+	_collect_frappe_tree_bfs(
+		bench_path,
+		subcommands,
+		options,
+		value_options,
+		path_options,
+		path_positionals,
+		fallback_commands,
+	)
 
 
-def _collect_frappe_tree_bfs(bench_path, subcommands, options, value_options, fallback_commands):
+def _collect_frappe_tree_bfs(
+	bench_path,
+	subcommands,
+	options,
+	value_options,
+	path_options,
+	path_positionals,
+	fallback_commands,
+):
 	from concurrent.futures import ThreadPoolExecutor, as_completed
 
 	seen = set()
@@ -220,6 +262,14 @@ def _collect_frappe_tree_bfs(bench_path, subcommands, options, value_options, fa
 
 				options[key] = _unique(["--help", *parsed["options"]])
 				value_options[key] = _unique(parsed["value_options"])
+				path_options[key] = _unique(
+					[
+						option
+						for option in parsed["value_options"]
+						if _looks_like_path_option(option)
+					]
+				)
+				path_positionals[key] = _unique(parsed["path_positionals"])
 				subcommands[key] = _unique(children)
 
 				if len(path) < MAX_FRAPPE_DEPTH:
@@ -275,10 +325,23 @@ def _parse_click_help(help_text: str) -> dict:
 				if len(parts) > 1:
 					value_options.append(parts[0])
 
+	path_positionals = []
+	for raw_line in help_text.splitlines():
+		stripped = raw_line.strip()
+		if not stripped.startswith("Usage:"):
+			continue
+		path_positionals.extend(
+			str(index)
+			for index, token in enumerate(_usage_positional_tokens(stripped))
+			if _looks_like_path_name(token)
+		)
+		break
+
 	return {
 		"commands": _unique(commands),
 		"options": _unique(options),
 		"value_options": _unique(value_options),
+		"path_positionals": _unique(path_positionals),
 	}
 
 
@@ -318,24 +381,41 @@ def _ensure_line(path: Path, line: str) -> bool:
 
 
 def _collect_command_tree(
-	command: click.Command, path, subcommands, options, value_options
+	command: click.Command,
+	path,
+	subcommands,
+	options,
+	value_options,
+	path_options,
+	path_positionals,
 ):
 	key = _path_key(path)
 	command_options = ["--help"]
 	command_value_options = []
+	command_path_options = []
+	command_path_positionals = []
+	positional_index = 0
 
 	for param in command.params:
-		if not isinstance(param, click.Option):
+		if isinstance(param, click.Option):
+			flags = _unique([*param.opts, *param.secondary_opts])
+			command_options.extend(flags)
+
+			if _option_takes_value(param):
+				command_value_options.extend(flags)
+				if _param_expects_path(param):
+					command_path_options.extend(flags)
 			continue
 
-		flags = _unique([*param.opts, *param.secondary_opts])
-		command_options.extend(flags)
-
-		if _option_takes_value(param):
-			command_value_options.extend(flags)
+		if isinstance(param, click.Argument):
+			if _param_expects_path(param):
+				command_path_positionals.append(str(positional_index))
+			positional_index += 1
 
 	options[key] = _unique(command_options)
 	value_options[key] = _unique(command_value_options)
+	path_options[key] = _unique(command_path_options)
+	path_positionals[key] = _unique(command_path_positionals)
 
 	command_map = getattr(command, "commands", None)
 	if command_map is not None:
@@ -344,7 +424,13 @@ def _collect_command_tree(
 
 		for name, child in command_map.items():
 			_collect_command_tree(
-				child, (*path, name), subcommands, options, value_options
+				child,
+				(*path, name),
+				subcommands,
+				options,
+				value_options,
+				path_options,
+				path_positionals,
 			)
 	else:
 		subcommands[key] = []
@@ -352,6 +438,43 @@ def _collect_command_tree(
 
 def _option_takes_value(option: click.Option) -> bool:
 	return not option.is_flag and option.nargs != 0
+
+
+def _normalize_param_name(name: str) -> str:
+	return name.lower().replace("-", "_")
+
+
+def _looks_like_path_name(name: str) -> bool:
+	normalized = _normalize_param_name(name)
+	return any(hint in normalized for hint in _PATH_NAME_HINTS)
+
+
+def _looks_like_path_option(option: str) -> bool:
+	return _looks_like_path_name(option.lstrip("-"))
+
+
+def _param_expects_path(param) -> bool:
+	if isinstance(param.type, click.Path):
+		return True
+
+	names = []
+	if isinstance(param, click.Option):
+		if param.name:
+			names.append(param.name)
+		names.extend(option.lstrip("-") for option in param.opts)
+	elif isinstance(param, click.Argument) and param.name:
+		names.append(param.name)
+
+	return any(_looks_like_path_name(name) for name in names)
+
+
+def _usage_positional_tokens(usage_line: str) -> list[str]:
+	import re
+
+	usage = usage_line.split(":", 1)[-1].strip()
+	usage = re.sub(r"\[[^\]]*\]", "", usage)
+	tokens = re.findall(r"\b[A-Z][A-Z0-9_-]*\b", usage)
+	return [token for token in tokens if token not in {"OPTIONS", "ARGS", "COMMAND"}]
 
 
 def _path_key(path) -> str:
@@ -397,6 +520,10 @@ def _render_completion_script(spec: dict, shell: str) -> str:
 			_render_case_function("_bench_options_for", spec["options"]),
 			"",
 			_render_case_function("_bench_value_options_for", spec["value_options"]),
+			"",
+			_render_case_function("_bench_path_options_for", spec["path_options"]),
+			"",
+			_render_case_function("_bench_path_positionals_for", spec["path_positionals"]),
 			"",
 			_BASH_RUNTIME,
 			"",
@@ -541,6 +668,60 @@ _bench_collect_context() {
 	printf '%s' "$path"
 }
 
+_bench_collect_completion_state() {
+	local path="$_BENCH_ROOT_KEY"
+	local positional_index=0
+	local skip_next=0
+	local index
+	local token
+	local value_opts
+	local subcommands
+
+	for ((index = 1; index < COMP_CWORD; index++)); do
+		token="${COMP_WORDS[index]}"
+
+		if (( skip_next )); then
+			skip_next=0
+			continue
+		fi
+
+		if [[ "$token" == "--" ]]; then
+			break
+		fi
+
+		value_opts="$(_bench_value_options_for "$path")"
+		if [[ "$path" == "$_BENCH_ROOT_KEY" ]]; then
+			value_opts="$value_opts $_BENCH_FORWARDED_VALUE_OPTIONS"
+		fi
+
+		if _bench_has_word "$token" "$value_opts"; then
+			skip_next=1
+			continue
+		fi
+
+		if [[ "$token" == -* ]]; then
+			continue
+		fi
+
+		subcommands="$(_bench_subcommands_for "$path")"
+		if _bench_has_word "$token" "$subcommands"; then
+			path="$(_bench_join_path "$path" "$token")"
+			positional_index=0
+			continue
+		fi
+
+		if [[ "$path" == "$_BENCH_ROOT_KEY" ]] && _bench_has_word "$token" "$_BENCH_FRAPPE_COMMANDS"; then
+			path="$_BENCH_FRAPPE_KEY"
+			positional_index=0
+			continue
+		fi
+
+		((positional_index++))
+	done
+
+	printf '%s|%s' "$path" "$positional_index"
+}
+
 _bench_complete_words() {
 	local cur="$1"
 	local words="$2"
@@ -554,14 +735,24 @@ _bench_lines_to_words() {
 	printf '%s' "${lines//$'\n'/ }"
 }
 
+_bench_complete_files() {
+	local cur="$1"
+
+	COMPREPLY=( $(compgen -f -- "$cur") )
+}
+
 _bench_completion() {
 	local cur="${COMP_WORDS[COMP_CWORD]}"
 	local prev=""
 	local path
+	local positional_index=0
 	local words
 	local options
 	local subcommands
 	local dynamic_words
+	local path_options
+	local path_positionals
+	local state
 
 	COMPREPLY=()
 
@@ -584,7 +775,22 @@ _bench_completion() {
 			;;
 	esac
 
-	path="$(_bench_collect_context)"
+	state="$(_bench_collect_completion_state)"
+	path="${state%|*}"
+	positional_index="${state##*|}"
+
+	path_options="$(_bench_path_options_for "$path")"
+	if _bench_has_word "$prev" "$path_options"; then
+		_bench_complete_files "$cur"
+		return 0
+	fi
+
+	path_positionals="$(_bench_path_positionals_for "$path")"
+	if [[ "$cur" != -* ]] && _bench_has_word "$positional_index" "$path_positionals"; then
+		_bench_complete_files "$cur"
+		return 0
+	fi
+
 	options="$(_bench_options_for "$path")"
 	subcommands="$(_bench_subcommands_for "$path")"
 

--- a/bench/commands/completions.py
+++ b/bench/commands/completions.py
@@ -711,7 +711,10 @@ _bench_complete_files() {
 	expanded="$(_bench_expand_tilde "$cur")"
 
 	compopt -o filenames 2>/dev/null
-	COMPREPLY=( $(compgen -f -- "$expanded") )
+	COMPREPLY=()
+	while IFS= read -r path; do
+		COMPREPLY+=("$path")
+	done < <(compgen -f -- "$expanded")
 
 	for ((i = 0; i < ${#COMPREPLY[@]}; i++)); do
 		if [[ -d "${COMPREPLY[i]}" && "${COMPREPLY[i]}" != */ ]]; then

--- a/bench/commands/completions.py
+++ b/bench/commands/completions.py
@@ -676,6 +676,7 @@ _bench_complete_words() {
 	local cur="$1"
 	local words="$2"
 
+	compopt +o nospace 2>/dev/null
 	COMPREPLY=( $(compgen -W "$words" -- "$cur") )
 }
 

--- a/bench/commands/completions.py
+++ b/bench/commands/completions.py
@@ -4,6 +4,11 @@ from pathlib import Path
 
 import click
 
+from bench.commands.completion_utils import (
+	looks_like_path_name,
+	looks_like_path_option,
+	param_expects_path,
+)
 from bench.utils import find_parent_bench, get_cmd_output, get_env_frappe_commands
 from bench.utils.bench import get_env_cmd
 
@@ -13,10 +18,6 @@ FRAPPE_KEY = "__frappe__"
 MAX_FRAPPE_DEPTH = 4
 FORWARDED_FLAGS = ["--verbose", "-v", "--profile", "--force"]
 FORWARDED_VALUE_OPTIONS = ["--site", "-s"]
-
-# Substrings matched against normalized option/argument names when Click does not
-# declare an explicit click.Path type (common in older frappe command definitions).
-_PATH_NAME_HINTS = ("path", "file", "certificate", "sql", "clone_from")
 
 # Path to the collector script that runs inside the frappe virtualenv.
 # Kept as a separate file so it gets syntax highlighting, linting, and can be
@@ -261,7 +262,7 @@ def _collect_frappe_tree_bfs(
 					[
 						option
 						for option in parsed["value_options"]
-						if _looks_like_path_option(option)
+						if looks_like_path_option(option)
 					]
 				)
 				path_positionals[key] = _unique(parsed["path_positionals"])
@@ -328,7 +329,7 @@ def _parse_click_help(help_text: str) -> dict:
 		path_positionals.extend(
 			str(index)
 			for index, token in enumerate(_usage_positional_tokens(stripped))
-			if _looks_like_path_name(token)
+			if looks_like_path_name(token)
 		)
 		break
 
@@ -398,12 +399,12 @@ def _collect_command_tree(
 
 			if not param.is_flag and param.nargs != 0:
 				command_value_options.extend(flags)
-				if _param_expects_path(param):
+				if param_expects_path(param):
 					command_path_options.extend(flags)
 			continue
 
 		if isinstance(param, click.Argument):
-			if _param_expects_path(param):
+			if param_expects_path(param):
 				command_path_positionals.append(str(positional_index))
 			positional_index += 1
 
@@ -429,34 +430,6 @@ def _collect_command_tree(
 			)
 	else:
 		subcommands[key] = []
-
-def _normalize_param_name(name: str) -> str:
-	return name.lower().replace("-", "_")
-
-
-def _looks_like_path_name(name: str) -> bool:
-	normalized = _normalize_param_name(name)
-	return any(hint in normalized for hint in _PATH_NAME_HINTS)
-
-
-def _looks_like_path_option(option: str) -> bool:
-	return _looks_like_path_name(option.lstrip("-"))
-
-
-def _param_expects_path(param) -> bool:
-	if isinstance(param.type, click.Path):
-		return True
-
-	names = []
-	if isinstance(param, click.Option):
-		if param.name:
-			names.append(param.name)
-		names.extend(option.lstrip("-") for option in param.opts)
-	elif isinstance(param, click.Argument) and param.name:
-		names.append(param.name)
-
-	return any(_looks_like_path_name(name) for name in names)
-
 
 def _usage_positional_tokens(usage_line: str) -> list[str]:
 	import re

--- a/bench/commands/completions.py
+++ b/bench/commands/completions.py
@@ -386,50 +386,71 @@ def _collect_command_tree(
 	path_positionals,
 ):
 	key = _path_key(path)
+	(
+		options[key],
+		value_options[key],
+		path_options[key],
+		path_positionals[key],
+	) = _command_completion_metadata(command)
+
+	subcommands[key] = _command_child_names(command)
+	for name, child in _command_map(command).items():
+		_collect_command_tree(
+			child,
+			(*path, name),
+			subcommands,
+			options,
+			value_options,
+			path_options,
+			path_positionals,
+		)
+
+
+def _command_completion_metadata(command: click.Command):
 	command_options = ["--help"]
 	command_value_options = []
 	command_path_options = []
-	command_path_positionals = []
-	positional_index = 0
 
-	for param in command.params:
-		if isinstance(param, click.Option):
-			flags = _unique([*param.opts, *param.secondary_opts])
-			command_options.extend(flags)
+	for option in _command_options(command):
+		flags = _unique([*option.opts, *option.secondary_opts])
+		command_options.extend(flags)
+		command_value_options.extend(flags if _option_takes_value(option) else [])
+		command_path_options.extend(
+			flags if _option_takes_value(option) and param_expects_path(option) else []
+		)
 
-			if not param.is_flag and param.nargs != 0:
-				command_value_options.extend(flags)
-				if param_expects_path(param):
-					command_path_options.extend(flags)
-			continue
+	return (
+		_unique(command_options),
+		_unique(command_value_options),
+		_unique(command_path_options),
+		_path_positional_indexes(command),
+	)
 
-		if isinstance(param, click.Argument):
-			if param_expects_path(param):
-				command_path_positionals.append(str(positional_index))
-			positional_index += 1
 
-	options[key] = _unique(command_options)
-	value_options[key] = _unique(command_value_options)
-	path_options[key] = _unique(command_path_options)
-	path_positionals[key] = _unique(command_path_positionals)
+def _command_options(command: click.Command):
+	return (param for param in command.params if isinstance(param, click.Option))
 
-	command_map = getattr(command, "commands", None)
-	if command_map is not None:
-		children = _unique(list(command_map.keys()))
-		subcommands[key] = children
 
-		for name, child in command_map.items():
-			_collect_command_tree(
-				child,
-				(*path, name),
-				subcommands,
-				options,
-				value_options,
-				path_options,
-				path_positionals,
-			)
-	else:
-		subcommands[key] = []
+def _option_takes_value(option: click.Option) -> bool:
+	return not option.is_flag and option.nargs != 0
+
+
+def _path_positional_indexes(command: click.Command):
+	return [
+		str(index)
+		for index, param in enumerate(
+			param for param in command.params if isinstance(param, click.Argument)
+		)
+		if param_expects_path(param)
+	]
+
+def _command_child_names(command: click.Command):
+	return _unique(list(_command_map(command).keys()))
+
+
+def _command_map(command: click.Command):
+	return getattr(command, "commands", None) or {}
+
 
 def _usage_positional_tokens(usage_line: str) -> list[str]:
 	import re

--- a/bench/commands/completions.py
+++ b/bench/commands/completions.py
@@ -200,84 +200,118 @@ def _collect_frappe_tree(
 			spec[FRAPPE_KEY]["commands"] = _unique(
 				[*spec[FRAPPE_KEY]["commands"], *fallback_commands]
 			)
-		for key, entry in spec.items():
-			subcommands[key] = entry["commands"]
-			options[key] = entry["options"]
-			value_options[key] = entry["value_options"]
-			path_options[key] = entry.get("path_options", [])
-			path_positionals[key] = entry.get("path_positionals", [])
+		_apply_frappe_completion_spec(
+			spec, subcommands, options, value_options, path_options, path_positionals
+		)
 		return
 
 	# get_app_groups() isn't available on older frappe versions, so fall back to
 	# spawning one --help subprocess per command, parallelised across each BFS level.
-	_collect_frappe_tree_bfs(
-		bench_path,
+	spec = _build_frappe_tree_bfs_spec(bench_path, fallback_commands)
+	_apply_frappe_completion_spec(
+		spec,
 		subcommands,
 		options,
 		value_options,
 		path_options,
 		path_positionals,
-		fallback_commands,
 	)
 
 
-def _collect_frappe_tree_bfs(
-	bench_path,
-	subcommands,
-	options,
-	value_options,
-	path_options,
-	path_positionals,
-	fallback_commands,
+def _apply_frappe_completion_spec(
+	spec, subcommands, options, value_options, path_options, path_positionals
 ):
-	from concurrent.futures import ThreadPoolExecutor, as_completed
+	for key, entry in spec.items():
+		subcommands[key] = entry["commands"]
+		options[key] = entry["options"]
+		value_options[key] = entry["value_options"]
+		path_options[key] = entry.get("path_options", [])
+		path_positionals[key] = entry.get("path_positionals", [])
+
+
+def _build_frappe_tree_bfs_spec(bench_path, fallback_commands):
+	from concurrent.futures import ThreadPoolExecutor
 
 	seen = set()
 	pending = [()]
+	spec = {}
 
 	with ThreadPoolExecutor() as executor:
 		while pending:
-			to_fetch = []
-			for path in pending:
-				key = _path_key((FRAPPE_KEY, *path))
-				if key not in seen:
-					seen.add(key)
-					to_fetch.append(path)
+			pending = _collect_frappe_bfs_level(
+				executor, bench_path, pending, seen, spec, fallback_commands
+			)
 
-			if not to_fetch:
-				break
+	return spec
 
-			futures = {
-				executor.submit(_get_frappe_help_text, bench_path, path): path
-				for path in to_fetch
-			}
 
-			next_pending = []
-			for future in as_completed(futures):
-				path = futures[future]
-				key = _path_key((FRAPPE_KEY, *path))
-				parsed = _parse_click_help(future.result())
+def _collect_frappe_bfs_level(
+	executor, bench_path, pending, seen, spec, fallback_commands
+):
+	paths = _unseen_frappe_paths(pending, seen)
+	if not paths:
+		return []
 
-				children = parsed["commands"]
-				if not path and fallback_commands:
-					children = _unique([*children, *fallback_commands])
+	futures = {
+		executor.submit(_get_frappe_help_text, bench_path, path): path for path in paths
+	}
+	return _consume_frappe_help_futures(futures, spec, fallback_commands)
 
-				options[key] = _unique(["--help", *parsed["options"]])
-				value_options[key] = _unique(parsed["value_options"])
-				path_options[key] = _unique(
-					[
-						option
-						for option in parsed["value_options"]
-						if looks_like_path_option(option)
-					]
-				)
-				path_positionals[key] = _unique(parsed["path_positionals"])
-				subcommands[key] = _unique(children)
 
-				if len(path) < MAX_FRAPPE_DEPTH:
-					next_pending.extend((*path, child) for child in children)
+def _unseen_frappe_paths(pending, seen):
+	paths = []
+	for path in pending:
+		key = _path_key((FRAPPE_KEY, *path))
+		if key in seen:
+			continue
+		seen.add(key)
+		paths.append(path)
+	return paths
 
-			pending = next_pending
+
+def _consume_frappe_help_futures(futures, spec, fallback_commands):
+	from concurrent.futures import as_completed
+
+	next_pending = []
+	for future in as_completed(futures):
+		path = futures[future]
+		next_pending.extend(
+			_record_frappe_spec_entry(path, future.result(), spec, fallback_commands)
+		)
+	return next_pending
+
+
+def _record_frappe_spec_entry(path, help_text, spec, fallback_commands):
+	parsed = _parse_click_help(help_text)
+	children = _frappe_children(path, parsed["commands"], fallback_commands)
+	key = _path_key((FRAPPE_KEY, *path))
+	spec[key] = _frappe_spec_entry(parsed, children)
+	return _child_frappe_paths(path, children)
+
+
+def _frappe_children(path, commands, fallback_commands):
+	if path or not fallback_commands:
+		return commands
+	return _unique([*commands, *fallback_commands])
+
+
+def _frappe_spec_entry(parsed, children):
+	value_options = _unique(parsed["value_options"])
+	return {
+		"commands": _unique(children),
+		"options": _unique(["--help", *parsed["options"]]),
+		"value_options": value_options,
+		"path_options": _unique(
+			[option for option in value_options if looks_like_path_option(option)]
+		),
+		"path_positionals": _unique(parsed["path_positionals"]),
+	}
+
+
+def _child_frappe_paths(path, children):
+	if len(path) >= MAX_FRAPPE_DEPTH:
+		return []
+	return [(*path, child) for child in children]
 
 
 def _get_frappe_help_text(bench_path, path) -> str:

--- a/bench/commands/completions.py
+++ b/bench/commands/completions.py
@@ -126,7 +126,7 @@ def build_completion_spec(root_command: click.Command, verbose: bool = True) -> 
 		root_command, (), subcommands, options, value_options, path_options, path_positionals
 	)
 
-	bench_path = _find_current_bench_path()
+	bench_path = find_parent_bench(os.path.abspath("."))
 	frappe_commands = []
 	if bench_path:
 		frappe_commands = _unique(get_env_frappe_commands(bench_path))
@@ -149,11 +149,6 @@ def build_completion_spec(root_command: click.Command, verbose: bool = True) -> 
 		"path_positionals": path_positionals,
 		"frappe_commands": frappe_commands,
 	}
-
-
-def _find_current_bench_path() -> str | None:
-	current_dir = os.path.abspath(".")
-	return find_parent_bench(current_dir)
 
 
 def _get_frappe_spec_batch(bench_path, verbose: bool = True) -> dict | None:
@@ -401,7 +396,7 @@ def _collect_command_tree(
 			flags = _unique([*param.opts, *param.secondary_opts])
 			command_options.extend(flags)
 
-			if _option_takes_value(param):
+			if not param.is_flag and param.nargs != 0:
 				command_value_options.extend(flags)
 				if _param_expects_path(param):
 					command_path_options.extend(flags)
@@ -434,11 +429,6 @@ def _collect_command_tree(
 			)
 	else:
 		subcommands[key] = []
-
-
-def _option_takes_value(option: click.Option) -> bool:
-	return not option.is_flag and option.nargs != 0
-
 
 def _normalize_param_name(name: str) -> str:
 	return name.lower().replace("-", "_")
@@ -626,55 +616,6 @@ _bench_join_path() {
 	fi
 
 	printf '%s %s' "$1" "$2"
-}
-
-_bench_collect_context() {
-	local ctx="$_BENCH_ROOT_KEY"
-	local skip_next=0
-	local index
-	local token
-	local value_opts
-	local subcommands
-
-	for ((index = 1; index < COMP_CWORD; index++)); do
-		token="${COMP_WORDS[index]}"
-
-		if (( skip_next )); then
-			skip_next=0
-			continue
-		fi
-
-		if [[ "$token" == "--" ]]; then
-			break
-		fi
-
-		value_opts="$(_bench_value_options_for "$ctx")"
-		if [[ "$ctx" == "$_BENCH_ROOT_KEY" ]]; then
-			value_opts="$value_opts $_BENCH_FORWARDED_VALUE_OPTIONS"
-		fi
-
-		if _bench_has_word "$token" "$value_opts"; then
-			skip_next=1
-			continue
-		fi
-
-		if [[ "$token" == -* ]]; then
-			continue
-		fi
-
-		subcommands="$(_bench_subcommands_for "$ctx")"
-		if _bench_has_word "$token" "$subcommands"; then
-			ctx="$(_bench_join_path "$ctx" "$token")"
-			continue
-		fi
-
-		if [[ "$ctx" == "$_BENCH_ROOT_KEY" ]] && _bench_has_word "$token" "$_BENCH_FRAPPE_COMMANDS"; then
-			ctx="$(_bench_join_path "$_BENCH_FRAPPE_KEY" "$token")"
-			continue
-		fi
-	done
-
-	printf '%s' "$ctx"
 }
 
 _bench_collect_completion_state() {

--- a/bench/commands/completions.py
+++ b/bench/commands/completions.py
@@ -525,9 +525,9 @@ def _render_completion_script(spec: dict, shell: str) -> str:
 			"",
 			_render_case_function("_bench_path_positionals_for", spec["path_positionals"]),
 			"",
-			_BASH_RUNTIME,
+			_render_bash_runtime(shell),
 			"",
-			"complete -o nosort -F _bench_completion bench",
+			"complete -o nosort -o nospace -F _bench_completion bench",
 		]
 	)
 
@@ -545,7 +545,21 @@ def _render_case_function(name: str, mapping: dict) -> str:
 	return "\n".join(lines)
 
 
-_BASH_RUNTIME = r"""_bench_find_root() {
+def _render_bash_runtime(shell: str) -> str:
+	complete_files = (
+		_BENCH_COMPLETE_FILES_ZSH if shell == "zsh" else _BENCH_COMPLETE_FILES_BASH
+	)
+	suffix = _BASH_RUNTIME_SUFFIX
+	if shell == "zsh":
+		suffix = suffix.replace(
+			"_bench_completion() {\n\tlocal cur=",
+			"_bench_completion() {\n\temulate -L sh\n\tlocal cur=",
+			1,
+		)
+	return _BASH_RUNTIME_PREFIX + complete_files + suffix
+
+
+_BASH_RUNTIME_PREFIX = r"""_bench_find_root() {
 	local dir="$PWD"
 
 	while [[ -n "$dir" && "$dir" != "/" ]]; do
@@ -621,7 +635,7 @@ _bench_join_path() {
 }
 
 _bench_collect_context() {
-	local path="$_BENCH_ROOT_KEY"
+	local ctx="$_BENCH_ROOT_KEY"
 	local skip_next=0
 	local index
 	local token
@@ -640,8 +654,8 @@ _bench_collect_context() {
 			break
 		fi
 
-		value_opts="$(_bench_value_options_for "$path")"
-		if [[ "$path" == "$_BENCH_ROOT_KEY" ]]; then
+		value_opts="$(_bench_value_options_for "$ctx")"
+		if [[ "$ctx" == "$_BENCH_ROOT_KEY" ]]; then
 			value_opts="$value_opts $_BENCH_FORWARDED_VALUE_OPTIONS"
 		fi
 
@@ -654,22 +668,23 @@ _bench_collect_context() {
 			continue
 		fi
 
-		subcommands="$(_bench_subcommands_for "$path")"
+		subcommands="$(_bench_subcommands_for "$ctx")"
 		if _bench_has_word "$token" "$subcommands"; then
-			path="$(_bench_join_path "$path" "$token")"
+			ctx="$(_bench_join_path "$ctx" "$token")"
 			continue
 		fi
 
-		if [[ "$path" == "$_BENCH_ROOT_KEY" ]] && _bench_has_word "$token" "$_BENCH_FRAPPE_COMMANDS"; then
-			path="$_BENCH_FRAPPE_KEY"
+		if [[ "$ctx" == "$_BENCH_ROOT_KEY" ]] && _bench_has_word "$token" "$_BENCH_FRAPPE_COMMANDS"; then
+			ctx="$(_bench_join_path "$_BENCH_FRAPPE_KEY" "$token")"
+			continue
 		fi
 	done
 
-	printf '%s' "$path"
+	printf '%s' "$ctx"
 }
 
 _bench_collect_completion_state() {
-	local path="$_BENCH_ROOT_KEY"
+	local ctx="$_BENCH_ROOT_KEY"
 	local positional_index=0
 	local skip_next=0
 	local index
@@ -689,8 +704,8 @@ _bench_collect_completion_state() {
 			break
 		fi
 
-		value_opts="$(_bench_value_options_for "$path")"
-		if [[ "$path" == "$_BENCH_ROOT_KEY" ]]; then
+		value_opts="$(_bench_value_options_for "$ctx")"
+		if [[ "$ctx" == "$_BENCH_ROOT_KEY" ]]; then
 			value_opts="$value_opts $_BENCH_FORWARDED_VALUE_OPTIONS"
 		fi
 
@@ -703,15 +718,15 @@ _bench_collect_completion_state() {
 			continue
 		fi
 
-		subcommands="$(_bench_subcommands_for "$path")"
+		subcommands="$(_bench_subcommands_for "$ctx")"
 		if _bench_has_word "$token" "$subcommands"; then
-			path="$(_bench_join_path "$path" "$token")"
+			ctx="$(_bench_join_path "$ctx" "$token")"
 			positional_index=0
 			continue
 		fi
 
-		if [[ "$path" == "$_BENCH_ROOT_KEY" ]] && _bench_has_word "$token" "$_BENCH_FRAPPE_COMMANDS"; then
-			path="$_BENCH_FRAPPE_KEY"
+		if [[ "$ctx" == "$_BENCH_ROOT_KEY" ]] && _bench_has_word "$token" "$_BENCH_FRAPPE_COMMANDS"; then
+			ctx="$(_bench_join_path "$_BENCH_FRAPPE_KEY" "$token")"
 			positional_index=0
 			continue
 		fi
@@ -719,7 +734,7 @@ _bench_collect_completion_state() {
 		((positional_index++))
 	done
 
-	printf '%s|%s' "$path" "$positional_index"
+	printf '%s|%s' "$ctx" "$positional_index"
 }
 
 _bench_complete_words() {
@@ -735,16 +750,112 @@ _bench_lines_to_words() {
 	printf '%s' "${lines//$'\n'/ }"
 }
 
-_bench_complete_files() {
+"""
+
+_BENCH_COMPLETE_FILES_BASH = r"""_bench_expand_tilde() {
 	local cur="$1"
 
-	COMPREPLY=( $(compgen -f -- "$cur") )
+	if [[ "$cur" == "~" || "$cur" == "~/"* ]]; then
+		printf '%s' "${cur/#\~/$HOME}"
+		return 0
+	fi
+
+	printf '%s' "$cur"
 }
 
-_bench_completion() {
+_bench_complete_files() {
+	local cur="$1"
+	local expanded
+	local use_tilde=0
+	local i
+
+	if [[ "$cur" == "~" || "$cur" == "~/"* ]]; then
+		use_tilde=1
+	fi
+
+	expanded="$(_bench_expand_tilde "$cur")"
+
+	compopt -o filenames 2>/dev/null
+	COMPREPLY=( $(compgen -f -- "$expanded") )
+
+	for ((i = 0; i < ${#COMPREPLY[@]}; i++)); do
+		if [[ -d "${COMPREPLY[i]}" && "${COMPREPLY[i]}" != */ ]]; then
+			COMPREPLY[i]+=/
+		fi
+
+		if (( use_tilde )) && [[ "${COMPREPLY[i]}" == "$HOME"/* || "${COMPREPLY[i]}" == "$HOME" ]]; then
+			COMPREPLY[i]="~${COMPREPLY[i]#$HOME}"
+		fi
+	done
+}
+
+"""
+
+_BENCH_COMPLETE_FILES_ZSH = r"""_bench_expand_tilde() {
+	local cur="$1"
+
+	if [[ "$cur" == "~" || "$cur" == "~/"* ]]; then
+		printf '%s' "${cur/#\~/$HOME}"
+		return 0
+	fi
+
+	printf '%s' "$cur"
+}
+
+_bench_path_match_candidates() {
+	local expanded="$1"
+	local dir prefix
+
+	if [[ -d "$expanded" ]]; then
+		find "$expanded" -mindepth 1 -maxdepth 1 -print 2>/dev/null
+		return 0
+	fi
+
+	if [[ "$expanded" == */* ]]; then
+		dir="${expanded%/*}"
+		prefix="${expanded##*/}"
+	else
+		dir="."
+		prefix="$expanded"
+	fi
+
+	find "$dir" -maxdepth 1 -name "${prefix}"'*' -print 2>/dev/null
+}
+
+_bench_complete_files() {
+	local cur="$1"
+	local expanded use_tilde=0
+	local match
+	local i
+
+	if [[ "$cur" == "~" || "$cur" == "~/"* ]]; then
+		use_tilde=1
+	fi
+
+	expanded="$(_bench_expand_tilde "$cur")"
+	COMPREPLY=()
+
+	while IFS= read -r match; do
+		[[ -n "$match" ]] || continue
+
+		if [[ -d "$match" && "$match" != */ ]]; then
+			match="${match}/"
+		fi
+
+		if (( use_tilde )) && [[ "$match" == "$HOME"/* || "$match" == "$HOME" ]]; then
+			match="~${match#$HOME}"
+		fi
+
+		COMPREPLY+=("$match")
+	done < <(_bench_path_match_candidates "$expanded")
+}
+
+"""
+
+_BASH_RUNTIME_SUFFIX = r"""_bench_completion() {
 	local cur="${COMP_WORDS[COMP_CWORD]}"
 	local prev=""
-	local path
+	local ctx
 	local positional_index=0
 	local words
 	local options
@@ -776,29 +887,29 @@ _bench_completion() {
 	esac
 
 	state="$(_bench_collect_completion_state)"
-	path="${state%|*}"
+	ctx="${state%|*}"
 	positional_index="${state##*|}"
 
-	path_options="$(_bench_path_options_for "$path")"
+	path_options="$(_bench_path_options_for "$ctx")"
 	if _bench_has_word "$prev" "$path_options"; then
 		_bench_complete_files "$cur"
 		return 0
 	fi
 
-	path_positionals="$(_bench_path_positionals_for "$path")"
+	path_positionals="$(_bench_path_positionals_for "$ctx")"
 	if [[ "$cur" != -* ]] && _bench_has_word "$positional_index" "$path_positionals"; then
 		_bench_complete_files "$cur"
 		return 0
 	fi
 
-	options="$(_bench_options_for "$path")"
-	subcommands="$(_bench_subcommands_for "$path")"
+	options="$(_bench_options_for "$ctx")"
+	subcommands="$(_bench_subcommands_for "$ctx")"
 
-	if [[ "$path" == "$_BENCH_ROOT_KEY" ]]; then
+	if [[ "$ctx" == "$_BENCH_ROOT_KEY" ]]; then
 		subcommands="$subcommands $_BENCH_FRAPPE_COMMANDS"
 		options="$options $_BENCH_FORWARDED_FLAGS $_BENCH_FORWARDED_VALUE_OPTIONS"
-	elif [[ "$path" == "$_BENCH_FRAPPE_KEY" ]]; then
-		options="$_BENCH_FORWARDED_FLAGS $_BENCH_FORWARDED_VALUE_OPTIONS"
+	elif [[ "$ctx" == "$_BENCH_FRAPPE_KEY" || "$ctx" == "$_BENCH_FRAPPE_KEY "* ]]; then
+		options="$options $_BENCH_FORWARDED_FLAGS $_BENCH_FORWARDED_VALUE_OPTIONS"
 	fi
 
 	if [[ "$cur" == -* ]]; then

--- a/bench/commands/completions.py
+++ b/bench/commands/completions.py
@@ -124,7 +124,13 @@ def build_completion_spec(root_command: click.Command, verbose: bool = True) -> 
 	path_positionals = {}
 
 	_collect_command_tree(
-		root_command, (), subcommands, options, value_options, path_options, path_positionals
+		root_command,
+		(),
+		subcommands,
+		options,
+		value_options,
+		path_options,
+		path_positionals,
 	)
 
 	bench_path = find_parent_bench(os.path.abspath("."))
@@ -443,6 +449,7 @@ def _path_positional_indexes(command: click.Command):
 		)
 		if param_expects_path(param)
 	]
+
 
 def _command_child_names(command: click.Command):
 	return _unique(list(_command_map(command).keys()))

--- a/bench/commands/completions.py
+++ b/bench/commands/completions.py
@@ -640,7 +640,7 @@ _bench_collect_completion_state() {
 		fi
 
 		value_opts="$(_bench_value_options_for "$ctx")"
-		if [[ "$ctx" == "$_BENCH_ROOT_KEY" ]]; then
+		if [[ "$ctx" == "$_BENCH_ROOT_KEY" || "$ctx" == "$_BENCH_FRAPPE_KEY" || "$ctx" == "$_BENCH_FRAPPE_KEY "* ]]; then
 			value_opts="$value_opts $_BENCH_FORWARDED_VALUE_OPTIONS"
 		fi
 
@@ -814,7 +814,7 @@ _bench_collect_completion_state() {
 		fi
 
 		value_opts=(${(z)"$(_bench_value_options_for "$ctx")"})
-		if [[ $ctx == $_BENCH_ROOT_KEY ]]; then
+		if [[ $ctx == $_BENCH_ROOT_KEY || $ctx == $_BENCH_FRAPPE_KEY || $ctx == $_BENCH_FRAPPE_KEY\ * ]]; then
 			value_opts+=(${(z)_BENCH_FORWARDED_VALUE_OPTIONS})
 		fi
 

--- a/bench/commands/frappe_spec_collector.py
+++ b/bench/commands/frappe_spec_collector.py
@@ -24,39 +24,80 @@ FRAPPE_KEY = "__frappe__"
 MAX_DEPTH = 4
 
 
-def _walk(cmd, path, depth, result):
-	key = f"{FRAPPE_KEY} {' '.join(path)}" if path else FRAPPE_KEY
-	opts, vopts, path_opts, path_pos, kids = [], [], [], [], []
-	positional_index = 0
+def _dedupe(values):
+	return list(dict.fromkeys(values))
 
-	for param in cmd.params:
-		if isinstance(param, click.Option):
-			flags = list(dict.fromkeys([*param.opts, *(param.secondary_opts or [])]))
-			opts.extend(flags)
-			if not param.is_flag and param.nargs != 0:
-				vopts.extend(flags)
-				if param_expects_path(param):
-					path_opts.extend(flags)
+
+def _option_flags(param):
+	return _dedupe([*param.opts, *(param.secondary_opts or [])])
+
+
+def _scan_option(param):
+	flags = _option_flags(param)
+	if param.is_flag or param.nargs == 0:
+		return flags, [], []
+
+	path_flags = flags if param_expects_path(param) else []
+	return flags, flags, path_flags
+
+
+def _scan_options(params):
+	options = []
+	value_options = []
+	path_options = []
+
+	for param in params:
+		if not isinstance(param, click.Option):
 			continue
 
-		if isinstance(param, click.Argument):
-			if param_expects_path(param):
-				path_pos.append(str(positional_index))
-			positional_index += 1
+		flags, value_flags, path_flags = _scan_option(param)
+		options.extend(flags)
+		value_options.extend(value_flags)
+		path_options.extend(path_flags)
 
-	if hasattr(cmd, "commands") and depth < MAX_DEPTH:
-		for name, child in cmd.commands.items():
-			kids.append(name)
-			_walk(child, path + [name], depth + 1, result)
+	return options, value_options, path_options
 
-	result[key] = {
-		"options": list(dict.fromkeys(["--help", *opts])),
-		"value_options": list(dict.fromkeys(vopts)),
-		"path_options": list(dict.fromkeys(path_opts)),
-		"path_positionals": list(dict.fromkeys(path_pos)),
-		"commands": kids,
+
+def _path_positionals(params):
+	path_positionals = []
+	positional_index = 0
+
+	for param in params:
+		if not isinstance(param, click.Argument):
+			continue
+		if param_expects_path(param):
+			path_positionals.append(str(positional_index))
+		positional_index += 1
+
+	return path_positionals
+
+
+def _walk_children(cmd, path, depth, result):
+	commands = getattr(cmd, "commands", None)
+	if not commands or depth >= MAX_DEPTH:
+		return []
+
+	for name, child in commands.items():
+		_walk(child, path + [name], depth + 1, result)
+	return list(commands)
+
+
+def _completion_spec(cmd, path, depth, result):
+	options, value_options, path_options = _scan_options(cmd.params)
+	child_commands = _walk_children(cmd, path, depth, result)
+
+	return {
+		"options": _dedupe(["--help", *options]),
+		"value_options": _dedupe(value_options),
+		"path_options": _dedupe(path_options),
+		"path_positionals": _dedupe(_path_positionals(cmd.params)),
+		"commands": child_commands,
 	}
 
+
+def _walk(cmd, path, depth, result):
+	key = f"{FRAPPE_KEY} {' '.join(path)}" if path else FRAPPE_KEY
+	result[key] = _completion_spec(cmd, path, depth, result)
 	label = " ".join(["frappe", *path]) if path else "frappe"
 	print(f"  {label}", file=sys.stderr, flush=True)
 

--- a/bench/commands/frappe_spec_collector.py
+++ b/bench/commands/frappe_spec_collector.py
@@ -25,48 +25,48 @@ MAX_DEPTH = 4
 
 
 def _walk(cmd, path, depth, result):
-    key = f"{FRAPPE_KEY} {' '.join(path)}" if path else FRAPPE_KEY
-    opts, vopts, path_opts, path_pos, kids = [], [], [], [], []
-    positional_index = 0
+	key = f"{FRAPPE_KEY} {' '.join(path)}" if path else FRAPPE_KEY
+	opts, vopts, path_opts, path_pos, kids = [], [], [], [], []
+	positional_index = 0
 
-    for param in cmd.params:
-        if isinstance(param, click.Option):
-            flags = list(dict.fromkeys([*param.opts, *(param.secondary_opts or [])]))
-            opts.extend(flags)
-            if not param.is_flag and param.nargs != 0:
-                vopts.extend(flags)
-                if param_expects_path(param):
-                    path_opts.extend(flags)
-            continue
+	for param in cmd.params:
+		if isinstance(param, click.Option):
+			flags = list(dict.fromkeys([*param.opts, *(param.secondary_opts or [])]))
+			opts.extend(flags)
+			if not param.is_flag and param.nargs != 0:
+				vopts.extend(flags)
+				if param_expects_path(param):
+					path_opts.extend(flags)
+			continue
 
-        if isinstance(param, click.Argument):
-            if param_expects_path(param):
-                path_pos.append(str(positional_index))
-            positional_index += 1
+		if isinstance(param, click.Argument):
+			if param_expects_path(param):
+				path_pos.append(str(positional_index))
+			positional_index += 1
 
-    if hasattr(cmd, "commands") and depth < MAX_DEPTH:
-        for name, child in cmd.commands.items():
-            kids.append(name)
-            _walk(child, path + [name], depth + 1, result)
+	if hasattr(cmd, "commands") and depth < MAX_DEPTH:
+		for name, child in cmd.commands.items():
+			kids.append(name)
+			_walk(child, path + [name], depth + 1, result)
 
-    result[key] = {
-        "options": list(dict.fromkeys(["--help", *opts])),
-        "value_options": list(dict.fromkeys(vopts)),
-        "path_options": list(dict.fromkeys(path_opts)),
-        "path_positionals": list(dict.fromkeys(path_pos)),
-        "commands": kids,
-    }
+	result[key] = {
+		"options": list(dict.fromkeys(["--help", *opts])),
+		"value_options": list(dict.fromkeys(vopts)),
+		"path_options": list(dict.fromkeys(path_opts)),
+		"path_positionals": list(dict.fromkeys(path_pos)),
+		"commands": kids,
+	}
 
-    label = " ".join(["frappe", *path]) if path else "frappe"
-    print(f"  {label}", file=sys.stderr, flush=True)
+	label = " ".join(["frappe", *path]) if path else "frappe"
+	print(f"  {label}", file=sys.stderr, flush=True)
 
 
 app_groups = _bh.get_app_groups()
 frappe_group = app_groups.get("frappe")
 
 if frappe_group is None or not hasattr(frappe_group, "commands"):
-    print("error: frappe group not found in bench_helper", file=sys.stderr)
-    sys.exit(1)
+	print("error: frappe group not found in bench_helper", file=sys.stderr)
+	sys.exit(1)
 
 result = {}
 _walk(frappe_group, [], 0, result)

--- a/bench/commands/frappe_spec_collector.py
+++ b/bench/commands/frappe_spec_collector.py
@@ -23,12 +23,8 @@ MAX_DEPTH = 4
 _PATH_NAME_HINTS = ("path", "file", "certificate", "sql", "clone_from")
 
 
-def _normalize_param_name(name: str) -> str:
-    return name.lower().replace("-", "_")
-
-
 def _looks_like_path_name(name: str) -> bool:
-    normalized = _normalize_param_name(name)
+    normalized = name.lower().replace("-", "_")
     return any(hint in normalized for hint in _PATH_NAME_HINTS)
 
 

--- a/bench/commands/frappe_spec_collector.py
+++ b/bench/commands/frappe_spec_collector.py
@@ -6,7 +6,8 @@ Progress lines are written to stderr so they can be shown or suppressed
 independently of the JSON output.
 
 stdout: JSON object mapping completion-key strings to
-        {"options": [...], "value_options": [...], "commands": [...]}
+        {"options": [...], "value_options": [...], "path_options": [...],
+         "path_positionals": [...], "commands": [...]}
 stderr: one line per command as it is scanned
 exit 1: if the frappe click group cannot be located
 """
@@ -19,19 +20,52 @@ import frappe.utils.bench_helper as _bh
 
 FRAPPE_KEY = "__frappe__"
 MAX_DEPTH = 4
+_PATH_NAME_HINTS = ("path", "file", "certificate", "sql", "clone_from")
+
+
+def _normalize_param_name(name: str) -> str:
+    return name.lower().replace("-", "_")
+
+
+def _looks_like_path_name(name: str) -> bool:
+    normalized = _normalize_param_name(name)
+    return any(hint in normalized for hint in _PATH_NAME_HINTS)
+
+
+def _param_expects_path(param) -> bool:
+    if isinstance(param.type, click.Path):
+        return True
+
+    names = []
+    if isinstance(param, click.Option):
+        if param.name:
+            names.append(param.name)
+        names.extend(option.lstrip("-") for option in param.opts)
+    elif isinstance(param, click.Argument) and param.name:
+        names.append(param.name)
+
+    return any(_looks_like_path_name(name) for name in names)
 
 
 def _walk(cmd, path, depth, result):
     key = (FRAPPE_KEY + " " + " ".join(path)) if path else FRAPPE_KEY
-    opts, vopts, kids = [], [], []
+    opts, vopts, path_opts, path_pos, kids = [], [], [], [], []
+    positional_index = 0
 
     for param in cmd.params:
-        if not isinstance(param, click.Option):
+        if isinstance(param, click.Option):
+            flags = list(dict.fromkeys([*param.opts, *(param.secondary_opts or [])]))
+            opts.extend(flags)
+            if not param.is_flag and param.nargs != 0:
+                vopts.extend(flags)
+                if _param_expects_path(param):
+                    path_opts.extend(flags)
             continue
-        flags = list(dict.fromkeys([*param.opts, *(param.secondary_opts or [])]))
-        opts.extend(flags)
-        if not param.is_flag and param.nargs != 0:
-            vopts.extend(flags)
+
+        if isinstance(param, click.Argument):
+            if _param_expects_path(param):
+                path_pos.append(str(positional_index))
+            positional_index += 1
 
     if hasattr(cmd, "commands") and depth < MAX_DEPTH:
         for name, child in cmd.commands.items():
@@ -41,6 +75,8 @@ def _walk(cmd, path, depth, result):
     result[key] = {
         "options": list(dict.fromkeys(["--help", *opts])),
         "value_options": list(dict.fromkeys(vopts)),
+        "path_options": list(dict.fromkeys(path_opts)),
+        "path_positionals": list(dict.fromkeys(path_pos)),
         "commands": kids,
     }
 

--- a/bench/commands/frappe_spec_collector.py
+++ b/bench/commands/frappe_spec_collector.py
@@ -18,33 +18,14 @@ import sys
 import click
 import frappe.utils.bench_helper as _bh
 
+from completion_utils import param_expects_path
+
 FRAPPE_KEY = "__frappe__"
 MAX_DEPTH = 4
-_PATH_NAME_HINTS = ("path", "file", "certificate", "sql", "clone_from")
-
-
-def _looks_like_path_name(name: str) -> bool:
-    normalized = name.lower().replace("-", "_")
-    return any(hint in normalized for hint in _PATH_NAME_HINTS)
-
-
-def _param_expects_path(param) -> bool:
-    if isinstance(param.type, click.Path):
-        return True
-
-    names = []
-    if isinstance(param, click.Option):
-        if param.name:
-            names.append(param.name)
-        names.extend(option.lstrip("-") for option in param.opts)
-    elif isinstance(param, click.Argument) and param.name:
-        names.append(param.name)
-
-    return any(_looks_like_path_name(name) for name in names)
 
 
 def _walk(cmd, path, depth, result):
-    key = (FRAPPE_KEY + " " + " ".join(path)) if path else FRAPPE_KEY
+    key = f"{FRAPPE_KEY} {' '.join(path)}" if path else FRAPPE_KEY
     opts, vopts, path_opts, path_pos, kids = [], [], [], [], []
     positional_index = 0
 
@@ -54,12 +35,12 @@ def _walk(cmd, path, depth, result):
             opts.extend(flags)
             if not param.is_flag and param.nargs != 0:
                 vopts.extend(flags)
-                if _param_expects_path(param):
+                if param_expects_path(param):
                     path_opts.extend(flags)
             continue
 
         if isinstance(param, click.Argument):
-            if _param_expects_path(param):
+            if param_expects_path(param):
                 path_pos.append(str(positional_index))
             positional_index += 1
 

--- a/bench/tests/test_completions.py
+++ b/bench/tests/test_completions.py
@@ -12,8 +12,8 @@ from click.testing import CliRunner
 from bench.commands import bench_command
 from bench.commands.completions import (
 	_loader_line,
-	_looks_like_path_name,
-	_looks_like_path_option,
+	looks_like_path_name,
+	looks_like_path_option,
 	_parse_click_help,
 	generate_completion,
 )
@@ -249,15 +249,15 @@ class TestBenchCompletionGeneration(unittest.TestCase):
 			parsed["value_options"],
 			["--with-public-files", "--with-private-files"],
 		)
-		self.assertTrue(_looks_like_path_option("--with-public-files"))
-		self.assertTrue(_looks_like_path_option("--backup-path"))
-		self.assertFalse(_looks_like_path_option("--format"))
+		self.assertTrue(looks_like_path_option("--with-public-files"))
+		self.assertTrue(looks_like_path_option("--backup-path"))
+		self.assertFalse(looks_like_path_option("--format"))
 
 	def test_path_name_heuristics(self):
-		self.assertTrue(_looks_like_path_name("sql-file-path"))
-		self.assertTrue(_looks_like_path_name("ssl-certificate-key"))
-		self.assertTrue(_looks_like_path_name("clone-from"))
-		self.assertFalse(_looks_like_path_name("format"))
+		self.assertTrue(looks_like_path_name("sql-file-path"))
+		self.assertTrue(looks_like_path_name("ssl-certificate-key"))
+		self.assertTrue(looks_like_path_name("clone-from"))
+		self.assertFalse(looks_like_path_name("format"))
 
 	def test_frappe_restore_path_completion_via_help_fallback(self):
 		script = _generate_frappe_completion(

--- a/bench/tests/test_completions.py
+++ b/bench/tests/test_completions.py
@@ -3,6 +3,7 @@ import shlex
 import subprocess
 import tempfile
 import unittest
+from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import patch
 
@@ -38,54 +39,143 @@ def _run_zsh_completion(script_path: str, words: list[str], cwd: str | None = No
 	)
 
 
-class TestBenchCompletionGeneration(unittest.TestCase):
-	def test_bash_completion_is_shell_only(self):
-		script = generate_completion("bash", bench_command)
+def _frappe_root_help(commands: list[str]) -> str:
+	return (
+		"Usage: frappe [OPTIONS] COMMAND [ARGS]...\n\n"
+		"Options:\n"
+		"  --site TEXT\n"
+		"  --help      Show this message and exit.\n\n"
+		"Commands:\n"
+		+ "".join(f"  {command}\n" for command in commands)
+	)
 
-		self.assertIn("_bench_subcommands_for()", script)
-		self.assertIn("complete -o nosort -o nospace -F _bench_completion bench", script)
-		self.assertNotIn("_BENCH_COMPLETE", script)
 
-	def test_generation_embeds_current_frappe_commands(self):
-		def fake_help(cmd, cwd=".", _raise=True):
-			if "frappe migrate --help" in cmd:
-				return (
-					"Usage: frappe migrate [OPTIONS]\n\n"
-					"Options:\n"
-					"  --skip-failing TEXT\n"
-					"  --help              Show this message and exit.\n"
-				)
-			if "frappe list-apps --help" in cmd:
-				return (
-					"Usage: frappe list-apps [OPTIONS]\n\n"
-					"Options:\n"
-					"  --format TEXT\n"
-					"  --help         Show this message and exit.\n"
-				)
-			return (
-				"Usage: frappe [OPTIONS] COMMAND [ARGS]...\n\n"
-				"Options:\n"
-				"  --site TEXT\n"
-				"  --help      Show this message and exit.\n\n"
-				"Commands:\n"
-				"  migrate\n"
-				"  list-apps\n"
-			)
+def _frappe_command_help(command: str, usage: str = "[OPTIONS]", options=()) -> str:
+	return (
+		f"Usage: frappe {command} {usage}\n\n"
+		"Options:\n"
+		+ "".join(f"  {option}\n" for option in options)
+		+ "  --help              Show this message and exit.\n"
+	)
+
+
+def _fake_frappe_help(commands: list[str], help_by_command: dict[str, str] | None = None):
+	help_by_command = help_by_command or {}
+
+	def fake_help(cmd, cwd=".", _raise=True):
+		for command, help_text in help_by_command.items():
+			if f"frappe {command} --help" in cmd:
+				return help_text
+		return _frappe_root_help(commands)
+
+	return fake_help
+
+
+@contextmanager
+def _mock_frappe_completion(commands: list[str], help_by_command: dict[str, str] | None = None):
+	with tempfile.TemporaryDirectory() as bench_dir:
+		bench_path = Path(bench_dir)
+		(bench_path / "sites").mkdir()
 
 		with (
-			tempfile.TemporaryDirectory() as bench_dir,
 			patch(
 				"bench.commands.completions.get_env_frappe_commands",
-				return_value=["migrate", "list-apps", "migrate"],
+				return_value=commands,
 			),
 			patch(
 				"bench.commands.completions.find_parent_bench",
 				return_value=bench_dir,
 			),
 			patch("bench.commands.completions.get_env_cmd", return_value="python"),
-			patch("bench.commands.completions.get_cmd_output", side_effect=fake_help),
+			patch("bench.commands.completions._get_frappe_spec_batch", return_value=None),
+			patch(
+				"bench.commands.completions.get_cmd_output",
+				side_effect=_fake_frappe_help(commands, help_by_command),
+			),
 		):
-			script = generate_completion("bash", bench_command)
+			yield bench_path
+
+
+def _generate_frappe_completion(
+	shell: str,
+	commands: list[str],
+	help_by_command: dict[str, str] | None = None,
+) -> str:
+	with _mock_frappe_completion(commands, help_by_command):
+		return generate_completion(shell, bench_command)
+
+
+@contextmanager
+def _temporary_completion_script(script: str, suffix: str):
+	with tempfile.NamedTemporaryFile("w", suffix=suffix, delete=False) as handle:
+		handle.write(script)
+		script_path = handle.name
+
+	try:
+		yield script_path
+	finally:
+		Path(script_path).unlink(missing_ok=True)
+
+
+def _run_bash_completion_script(
+	script: str,
+	command: str,
+	cwd: str | Path | None = None,
+	env=None,
+):
+	with _temporary_completion_script(script, ".sh") as script_path:
+		return subprocess.run(
+			[
+				"bash",
+				"-c",
+				f"source {shlex.quote(script_path)} >/dev/null 2>&1 || true; {command}",
+			],
+			check=True,
+			capture_output=True,
+			text=True,
+			cwd=cwd,
+			env=env,
+		)
+
+
+class TestBenchCompletionGeneration(unittest.TestCase):
+	def assertContainsAll(self, script: str, snippets):
+		for snippet in snippets:
+			with self.subTest(snippet=snippet):
+				self.assertIn(snippet, script)
+
+	def assertContainsNone(self, script: str, snippets):
+		for snippet in snippets:
+			with self.subTest(snippet=snippet):
+				self.assertNotIn(snippet, script)
+
+	def test_bash_completion_is_shell_only(self):
+		script = generate_completion("bash", bench_command)
+
+		self.assertContainsAll(
+			script,
+			[
+				"_bench_subcommands_for()",
+				"complete -o nosort -o nospace -F _bench_completion bench",
+			],
+		)
+		self.assertContainsNone(script, ["_BENCH_COMPLETE"])
+
+	def test_generation_embeds_current_frappe_commands(self):
+		script = _generate_frappe_completion(
+			"bash",
+			["migrate", "list-apps", "migrate"],
+			{
+				"migrate": _frappe_command_help(
+					"migrate",
+					options=["--skip-failing TEXT"],
+				),
+				"list-apps": _frappe_command_help(
+					"list-apps",
+					options=["--format TEXT"],
+				),
+			},
+		)
 
 		self.assertIn("_BENCH_FRAPPE_COMMANDS='migrate list-apps'", script)
 		self.assertIn("__frappe__) printf '%s' 'migrate list-apps'", script)
@@ -97,42 +187,53 @@ class TestBenchCompletionGeneration(unittest.TestCase):
 	def test_zsh_completion_uses_native_compdef(self):
 		script = generate_completion("zsh", bench_command)
 
-		self.assertIn("#compdef bench", script)
-		self.assertIn("compdef _bench bench", script)
-		self.assertIn("_bench() {", script)
-		self.assertIn("_files", script)
-		self.assertNotIn("bashcompinit", script)
-		self.assertNotIn("emulate -L sh", script)
-		self.assertNotIn("_bench_completion()", script)
-		self.assertNotIn("complete -o nosort", script)
-		self.assertNotIn("_bench_path_match_candidates()", script)
+		self.assertContainsAll(
+			script,
+			["#compdef bench", "compdef _bench bench", "_bench() {", "_files"],
+		)
+		self.assertContainsNone(
+			script,
+			[
+				"bashcompinit",
+				"emulate -L sh",
+				"_bench_completion()",
+				"complete -o nosort",
+				"_bench_path_match_candidates()",
+			],
+		)
 
 	def test_runtime_avoids_external_coreutils(self):
 		script = generate_completion("bash", bench_command)
 
-		self.assertNotIn("tr '\\n' ' '", script)
-		self.assertNotIn("dirname", script)
-		self.assertNotIn("basename", script)
+		self.assertContainsNone(script, ["tr '\\n' ' '", "dirname", "basename"])
 
 	def test_bash_completion_includes_file_path_helpers(self):
 		script = generate_completion("bash", bench_command)
 
-		self.assertIn("_bench_path_options_for()", script)
-		self.assertIn("_bench_path_positionals_for()", script)
-		self.assertIn("_bench_complete_files()", script)
-		self.assertIn("compgen -f", script)
-		self.assertNotIn('matches=("$dir"/${base}*(N))', script)
-		self.assertNotIn("_bench_path_match_candidates()", script)
-		self.assertIn("complete -o nosort -o nospace -F _bench_completion bench", script)
-		self.assertIn("_bench_expand_tilde()", script)
-		self.assertIn('COMPREPLY[i]="~${COMPREPLY[i]#$HOME}"', script)
+		self.assertContainsAll(
+			script,
+			[
+				"_bench_path_options_for()",
+				"_bench_path_positionals_for()",
+				"_bench_complete_files()",
+				"compgen -f",
+				"complete -o nosort -o nospace -F _bench_completion bench",
+				"_bench_expand_tilde()",
+				'COMPREPLY[i]="~${COMPREPLY[i]#$HOME}"',
+			],
+		)
+		self.assertContainsNone(
+			script,
+			['matches=("$dir"/${base}*(N))', "_bench_path_match_candidates()"],
+		)
 
 	def test_bench_init_registers_path_completion(self):
 		script = generate_completion("bash", bench_command)
 
-		self.assertIn("init) printf '%s' 0", script)
-		self.assertIn("--frappe-path", script)
-		self.assertIn("--clone-from", script)
+		self.assertContainsAll(
+			script,
+			["init) printf '%s' 0", "--frappe-path", "--clone-from"],
+		)
 
 	def test_help_fallback_detects_path_options_and_positionals(self):
 		parsed = _parse_click_help(
@@ -159,47 +260,21 @@ class TestBenchCompletionGeneration(unittest.TestCase):
 		self.assertFalse(_looks_like_path_name("format"))
 
 	def test_frappe_restore_path_completion_via_help_fallback(self):
-		def fake_help(cmd, cwd=".", _raise=True):
-			if "frappe restore --help" in cmd:
-				return (
-					"Usage: frappe restore [OPTIONS] SQL-FILE-PATH\n\n"
-					"Options:\n"
-					"  --with-public-files PATH\n"
-					"  --with-private-files PATH\n"
-					"  --help              Show this message and exit.\n"
-				)
-			if "frappe backup --help" in cmd:
-				return (
-					"Usage: frappe backup [OPTIONS]\n\n"
-					"Options:\n"
-					"  --backup-path PATH\n"
-					"  --help           Show this message and exit.\n"
-				)
-			return (
-				"Usage: frappe [OPTIONS] COMMAND [ARGS]...\n\n"
-				"Options:\n"
-				"  --site TEXT\n"
-				"  --help      Show this message and exit.\n\n"
-				"Commands:\n"
-				"  restore\n"
-				"  backup\n"
-			)
-
-		with (
-			tempfile.TemporaryDirectory() as bench_dir,
-			patch(
-				"bench.commands.completions.get_env_frappe_commands",
-				return_value=["restore", "backup"],
-			),
-			patch(
-				"bench.commands.completions.find_parent_bench",
-				return_value=bench_dir,
-			),
-			patch("bench.commands.completions.get_env_cmd", return_value="python"),
-			patch("bench.commands.completions._get_frappe_spec_batch", return_value=None),
-			patch("bench.commands.completions.get_cmd_output", side_effect=fake_help),
-		):
-			script = generate_completion("bash", bench_command)
+		script = _generate_frappe_completion(
+			"bash",
+			["restore", "backup"],
+			{
+				"restore": _frappe_command_help(
+					"restore",
+					"[OPTIONS] SQL-FILE-PATH",
+					["--with-public-files PATH", "--with-private-files PATH"],
+				),
+				"backup": _frappe_command_help(
+					"backup",
+					options=["--backup-path PATH"],
+				),
+			},
+		)
 
 		self.assertIn("'__frappe__ restore') printf '%s' 0", script)
 		self.assertIn("--with-public-files", script)
@@ -207,348 +282,131 @@ class TestBenchCompletionGeneration(unittest.TestCase):
 		self.assertIn("--backup-path", script)
 
 	def test_runtime_resolves_frappe_subcommand_context(self):
-		def fake_help(cmd, cwd=".", _raise=True):
-			return (
-				"Usage: frappe [OPTIONS] COMMAND [ARGS]...\n\n"
-				"Commands:\n"
-				"  restore\n"
-			)
-
-		with tempfile.TemporaryDirectory() as bench_dir:
-			Path(bench_dir, "sites").mkdir()
-
-			with (
-				patch(
-					"bench.commands.completions.get_env_frappe_commands",
-					return_value=["restore"],
-				),
-				patch(
-					"bench.commands.completions.find_parent_bench",
-					return_value=bench_dir,
-				),
-				patch("bench.commands.completions.get_env_cmd", return_value="python"),
-				patch("bench.commands.completions._get_frappe_spec_batch", return_value=None),
-				patch("bench.commands.completions.get_cmd_output", side_effect=fake_help),
-			):
-				script = generate_completion("bash", bench_command)
+		with _mock_frappe_completion(["restore"]):
+			script = generate_completion("bash", bench_command)
 
 			self.assertIn(
 				'ctx="$(_bench_join_path "$_BENCH_FRAPPE_KEY" "$token")"',
 				script,
 			)
 
-			with tempfile.NamedTemporaryFile("w", suffix=".sh", delete=False) as handle:
-				handle.write(script)
-				script_path = handle.name
-
-			try:
-				result = subprocess.run(
-					[
-						"bash",
-						"-c",
-						f"source {script_path} >/dev/null 2>&1 || true; "
-						"COMP_WORDS=(bench restore ''); COMP_CWORD=2; "
-						"_bench_collect_completion_state",
-					],
-					check=True,
-					capture_output=True,
-					text=True,
-				)
-			finally:
-				Path(script_path).unlink(missing_ok=True)
+			result = _run_bash_completion_script(
+				script,
+				"COMP_WORDS=(bench restore ''); COMP_CWORD=2; "
+				"_bench_collect_completion_state",
+			)
 
 		self.assertEqual(result.stdout.strip(), "__frappe__ restore|0")
 
 	def test_runtime_completes_files_for_restore(self):
-		def fake_help(cmd, cwd=".", _raise=True):
-			if "frappe restore --help" in cmd:
-				return (
-					"Usage: frappe restore [OPTIONS] SQL-FILE-PATH\n\n"
-					"Options:\n"
-					"  --with-public-files PATH\n"
-					"  --help              Show this message and exit.\n"
-				)
-			return (
-				"Usage: frappe [OPTIONS] COMMAND [ARGS]...\n\n"
-				"Options:\n"
-				"  --site TEXT\n"
-				"  --help      Show this message and exit.\n\n"
-				"Commands:\n"
-				"  restore\n"
+		with _mock_frappe_completion(
+			["restore"],
+			{
+				"restore": _frappe_command_help(
+					"restore",
+					"[OPTIONS] SQL-FILE-PATH",
+					["--with-public-files PATH"],
+				),
+			},
+		) as bench_dir:
+			script = generate_completion("bash", bench_command)
+
+			result = _run_bash_completion_script(
+				script,
+				"touch marker-restore-test; "
+				"COMP_WORDS=(bench restore ''); COMP_CWORD=2; "
+				"_bench_completion; "
+				'printf "%s\\n" "${COMPREPLY[@]}"',
+				cwd=bench_dir,
 			)
-
-		with tempfile.TemporaryDirectory() as bench_dir:
-			Path(bench_dir, "sites").mkdir()
-
-			with (
-				patch(
-					"bench.commands.completions.get_env_frappe_commands",
-					return_value=["restore"],
-				),
-				patch(
-					"bench.commands.completions.find_parent_bench",
-					return_value=bench_dir,
-				),
-				patch("bench.commands.completions.get_env_cmd", return_value="python"),
-				patch("bench.commands.completions._get_frappe_spec_batch", return_value=None),
-				patch("bench.commands.completions.get_cmd_output", side_effect=fake_help),
-			):
-				script = generate_completion("bash", bench_command)
-
-			with tempfile.NamedTemporaryFile("w", suffix=".sh", delete=False) as handle:
-				handle.write(script)
-				script_path = handle.name
-
-			try:
-				result = subprocess.run(
-					[
-						"bash",
-						"-c",
-						f"source {script_path} >/dev/null 2>&1 || true; "
-						"touch marker-restore-test; "
-						"COMP_WORDS=(bench restore ''); COMP_CWORD=2; "
-						"_bench_completion; "
-						'printf "%s\\n" "${COMPREPLY[@]}"',
-					],
-					check=True,
-					capture_output=True,
-					text=True,
-					cwd=bench_dir,
-				)
-			finally:
-				Path(script_path).unlink(missing_ok=True)
 
 		self.assertIn("marker-restore-test", result.stdout.splitlines())
 
 	def test_runtime_appends_slash_to_completed_directories(self):
-		def fake_help(cmd, cwd=".", _raise=True):
-			if "frappe restore --help" in cmd:
-				return (
-					"Usage: frappe restore [OPTIONS] SQL-FILE-PATH\n\n"
-					"Options:\n"
-					"  --help              Show this message and exit.\n"
-				)
-			return (
-				"Usage: frappe [OPTIONS] COMMAND [ARGS]...\n\n"
-				"Commands:\n"
-				"  restore\n"
+		with _mock_frappe_completion(
+			["restore"],
+			{"restore": _frappe_command_help("restore", "[OPTIONS] SQL-FILE-PATH")},
+		) as bench_dir:
+			(bench_dir / "nested-dir").mkdir()
+			script = generate_completion("bash", bench_command)
+
+			result = _run_bash_completion_script(
+				script,
+				"COMP_WORDS=(bench restore nested); COMP_CWORD=2; "
+				"COMP_WORDS+=( '' ); COMP_CWORD=2; "
+				"_bench_completion; "
+				'printf "%s\\n" "${COMPREPLY[@]}"',
+				cwd=bench_dir,
 			)
-
-		with tempfile.TemporaryDirectory() as bench_dir:
-			Path(bench_dir, "sites").mkdir()
-			Path(bench_dir, "nested-dir").mkdir()
-
-			with (
-				patch(
-					"bench.commands.completions.get_env_frappe_commands",
-					return_value=["restore"],
-				),
-				patch(
-					"bench.commands.completions.find_parent_bench",
-					return_value=bench_dir,
-				),
-				patch("bench.commands.completions.get_env_cmd", return_value="python"),
-				patch("bench.commands.completions._get_frappe_spec_batch", return_value=None),
-				patch("bench.commands.completions.get_cmd_output", side_effect=fake_help),
-			):
-				script = generate_completion("bash", bench_command)
-
-			with tempfile.NamedTemporaryFile("w", suffix=".sh", delete=False) as handle:
-				handle.write(script)
-				script_path = handle.name
-
-			try:
-				result = subprocess.run(
-					[
-						"bash",
-						"-c",
-						f"source {script_path} >/dev/null 2>&1 || true; "
-						"COMP_WORDS=(bench restore nested); COMP_CWORD=2; "
-						"COMP_WORDS+=( '' ); COMP_CWORD=2; "
-						"_bench_completion; "
-						'printf "%s\\n" "${COMPREPLY[@]}"',
-					],
-					check=True,
-					capture_output=True,
-					text=True,
-					cwd=bench_dir,
-				)
-			finally:
-				Path(script_path).unlink(missing_ok=True)
 
 		self.assertIn("nested-dir/", result.stdout.splitlines())
 
 	def test_runtime_completes_tilde_paths_after_forwarded_site(self):
-		def fake_help(cmd, cwd=".", _raise=True):
-			if "frappe restore --help" in cmd:
-				return (
-					"Usage: frappe restore [OPTIONS] SQL-FILE-PATH\n\n"
-					"Options:\n"
-					"  --help              Show this message and exit.\n"
-				)
-			return (
-				"Usage: frappe [OPTIONS] COMMAND [ARGS]...\n\n"
-				"Commands:\n"
-				"  restore\n"
-			)
-
-		with tempfile.TemporaryDirectory() as bench_dir:
-			Path(bench_dir, "sites").mkdir()
-			downloads = Path(bench_dir) / "downloads"
+		with _mock_frappe_completion(
+			["restore"],
+			{"restore": _frappe_command_help("restore", "[OPTIONS] SQL-FILE-PATH")},
+		) as bench_dir:
+			downloads = bench_dir / "downloads"
 			downloads.mkdir()
 			(downloads / "backup.sql.gz").write_text("x", encoding="utf-8")
+			script = generate_completion("bash", bench_command)
 
-			with (
-				patch(
-					"bench.commands.completions.get_env_frappe_commands",
-					return_value=["restore"],
-				),
-				patch(
-					"bench.commands.completions.find_parent_bench",
-					return_value=bench_dir,
-				),
-				patch("bench.commands.completions.get_env_cmd", return_value="python"),
-				patch("bench.commands.completions._get_frappe_spec_batch", return_value=None),
-				patch("bench.commands.completions.get_cmd_output", side_effect=fake_help),
-			):
-				script = generate_completion("bash", bench_command)
-
-			with tempfile.NamedTemporaryFile("w", suffix=".sh", delete=False) as handle:
-				handle.write(script)
-				script_path = handle.name
-
-			try:
-				result = subprocess.run(
-					[
-						"bash",
-						"-c",
-						f"source {script_path} >/dev/null 2>&1 || true; "
-						"COMP_WORDS=(bench restore --site mysite '~/downloads/b'); COMP_CWORD=4; "
-						"_bench_completion; "
-						'printf "%s\\n" "${COMPREPLY[@]}"',
-					],
-					check=True,
-					capture_output=True,
-					text=True,
-					cwd=bench_dir,
-					env={**os.environ, "HOME": bench_dir},
-				)
-			finally:
-				Path(script_path).unlink(missing_ok=True)
+			result = _run_bash_completion_script(
+				script,
+				"COMP_WORDS=(bench restore --site mysite '~/downloads/b'); COMP_CWORD=4; "
+				"_bench_completion; "
+				'printf "%s\\n" "${COMPREPLY[@]}"',
+				cwd=bench_dir,
+				env={**os.environ, "HOME": str(bench_dir)},
+			)
 
 		self.assertIn("~/downloads/backup.sql.gz", result.stdout.splitlines())
 
 	def test_zsh_runtime_resolves_frappe_subcommand_context(self):
-		def fake_help(cmd, cwd=".", _raise=True):
-			return (
-				"Usage: frappe [OPTIONS] COMMAND [ARGS]...\n\n"
-				"Commands:\n"
-				"  restore\n"
+		script = _generate_frappe_completion("zsh", ["restore"])
+
+		with _temporary_completion_script(script, ".zsh") as script_path:
+			result = subprocess.run(
+				[
+					"zsh",
+					"-c",
+					f"source {shlex.quote(script_path)}; "
+					"words=(bench restore); CURRENT=3; "
+					"_bench_collect_completion_state",
+				],
+				check=True,
+				capture_output=True,
+				text=True,
 			)
-
-		with tempfile.TemporaryDirectory() as bench_dir:
-			Path(bench_dir, "sites").mkdir()
-
-			with (
-				patch(
-					"bench.commands.completions.get_env_frappe_commands",
-					return_value=["restore"],
-				),
-				patch(
-					"bench.commands.completions.find_parent_bench",
-					return_value=bench_dir,
-				),
-				patch("bench.commands.completions.get_env_cmd", return_value="python"),
-				patch("bench.commands.completions._get_frappe_spec_batch", return_value=None),
-				patch("bench.commands.completions.get_cmd_output", side_effect=fake_help),
-			):
-				script = generate_completion("zsh", bench_command)
-
-			with tempfile.NamedTemporaryFile("w", suffix=".zsh", delete=False) as handle:
-				handle.write(script)
-				script_path = handle.name
-
-			try:
-				result = subprocess.run(
-					[
-						"zsh",
-						"-c",
-						f"source {shlex.quote(script_path)}; "
-						"words=(bench restore); CURRENT=3; "
-						"_bench_collect_completion_state",
-					],
-					check=True,
-					capture_output=True,
-					text=True,
-				)
-			finally:
-				Path(script_path).unlink(missing_ok=True)
 
 		self.assertEqual(result.stdout.strip(), "__frappe__ restore|0")
 
 	def test_zsh_completion_handles_partial_command_without_error(self):
 		script = generate_completion("zsh", bench_command)
 
-		with tempfile.NamedTemporaryFile("w", suffix=".zsh", delete=False) as handle:
-			handle.write(script)
-			script_path = handle.name
-
-		try:
+		with _temporary_completion_script(script, ".zsh") as script_path:
 			result = _run_zsh_completion(script_path, ["bench", "rest"])
-		finally:
-			Path(script_path).unlink(missing_ok=True)
 
 		self.assertNotIn("_bench_has_word", result.stderr)
 		self.assertEqual(result.returncode, 0)
 
 	def test_zsh_completion_uses_tilde_paths_after_forwarded_site(self):
-		def fake_help(cmd, cwd=".", _raise=True):
-			if "frappe restore --help" in cmd:
-				return (
-					"Usage: frappe restore [OPTIONS] SQL-FILE-PATH\n\n"
-					"Options:\n"
-					"  --help              Show this message and exit.\n"
-				)
-			return (
-				"Usage: frappe [OPTIONS] COMMAND [ARGS]...\n\n"
-				"Commands:\n"
-				"  restore\n"
-			)
-
-		with tempfile.TemporaryDirectory() as bench_dir:
-			Path(bench_dir, "sites").mkdir()
-			downloads = Path(bench_dir) / "downloads"
+		with _mock_frappe_completion(
+			["restore"],
+			{"restore": _frappe_command_help("restore", "[OPTIONS] SQL-FILE-PATH")},
+		) as bench_dir:
+			downloads = bench_dir / "downloads"
 			downloads.mkdir()
 			(downloads / "backup.sql.gz").write_text("x", encoding="utf-8")
+			script = generate_completion("zsh", bench_command)
 
-			with (
-				patch(
-					"bench.commands.completions.get_env_frappe_commands",
-					return_value=["restore"],
-				),
-				patch(
-					"bench.commands.completions.find_parent_bench",
-					return_value=bench_dir,
-				),
-				patch("bench.commands.completions.get_env_cmd", return_value="python"),
-				patch("bench.commands.completions._get_frappe_spec_batch", return_value=None),
-				patch("bench.commands.completions.get_cmd_output", side_effect=fake_help),
-			):
-				script = generate_completion("zsh", bench_command)
-
-			with tempfile.NamedTemporaryFile("w", suffix=".zsh", delete=False) as handle:
-				handle.write(script)
-				script_path = handle.name
-
-			try:
+			with _temporary_completion_script(script, ".zsh") as script_path:
 				result = _run_zsh_completion(
 					script_path,
 					["bench", "restore", "--site", "mysite", "~/downloads/b"],
 					cwd=bench_dir,
-					env={**os.environ, "HOME": bench_dir},
+					env={**os.environ, "HOME": str(bench_dir)},
 				)
-			finally:
-				Path(script_path).unlink(missing_ok=True)
 
 		self.assertTrue(
 			any("backup.sql.gz" in line for line in result.stdout.splitlines()),

--- a/bench/tests/test_completions.py
+++ b/bench/tests/test_completions.py
@@ -6,7 +6,13 @@ from unittest.mock import patch
 from click.testing import CliRunner
 
 from bench.commands import bench_command
-from bench.commands.completions import _loader_line, generate_completion
+from bench.commands.completions import (
+	_loader_line,
+	_looks_like_path_name,
+	_looks_like_path_option,
+	_parse_click_help,
+	generate_completion,
+)
 
 
 class TestBenchCompletionGeneration(unittest.TestCase):
@@ -78,6 +84,93 @@ class TestBenchCompletionGeneration(unittest.TestCase):
 		self.assertNotIn("tr '\\n' ' '", script)
 		self.assertNotIn("dirname", script)
 		self.assertNotIn("basename", script)
+
+	def test_bash_completion_includes_file_path_helpers(self):
+		script = generate_completion("bash", bench_command)
+
+		self.assertIn("_bench_path_options_for()", script)
+		self.assertIn("_bench_path_positionals_for()", script)
+		self.assertIn("_bench_complete_files()", script)
+		self.assertIn("compgen -f", script)
+
+	def test_bench_init_registers_path_completion(self):
+		script = generate_completion("bash", bench_command)
+
+		self.assertIn("init) printf '%s' 0", script)
+		self.assertIn("--frappe-path", script)
+		self.assertIn("--clone-from", script)
+
+	def test_help_fallback_detects_path_options_and_positionals(self):
+		parsed = _parse_click_help(
+			"Usage: bench restore [OPTIONS] SQL-FILE-PATH\n\n"
+			"Options:\n"
+			"  --with-public-files PATH\n"
+			"  --with-private-files PATH\n"
+			"  --help              Show this message and exit.\n"
+		)
+
+		self.assertEqual(parsed["path_positionals"], ["0"])
+		self.assertEqual(
+			parsed["value_options"],
+			["--with-public-files", "--with-private-files"],
+		)
+		self.assertTrue(_looks_like_path_option("--with-public-files"))
+		self.assertTrue(_looks_like_path_option("--backup-path"))
+		self.assertFalse(_looks_like_path_option("--format"))
+
+	def test_path_name_heuristics(self):
+		self.assertTrue(_looks_like_path_name("sql-file-path"))
+		self.assertTrue(_looks_like_path_name("ssl-certificate-key"))
+		self.assertTrue(_looks_like_path_name("clone-from"))
+		self.assertFalse(_looks_like_path_name("format"))
+
+	def test_frappe_restore_path_completion_via_help_fallback(self):
+		def fake_help(cmd, cwd=".", _raise=True):
+			if "frappe restore --help" in cmd:
+				return (
+					"Usage: frappe restore [OPTIONS] SQL-FILE-PATH\n\n"
+					"Options:\n"
+					"  --with-public-files PATH\n"
+					"  --with-private-files PATH\n"
+					"  --help              Show this message and exit.\n"
+				)
+			if "frappe backup --help" in cmd:
+				return (
+					"Usage: frappe backup [OPTIONS]\n\n"
+					"Options:\n"
+					"  --backup-path PATH\n"
+					"  --help           Show this message and exit.\n"
+				)
+			return (
+				"Usage: frappe [OPTIONS] COMMAND [ARGS]...\n\n"
+				"Options:\n"
+				"  --site TEXT\n"
+				"  --help      Show this message and exit.\n\n"
+				"Commands:\n"
+				"  restore\n"
+				"  backup\n"
+			)
+
+		with (
+			tempfile.TemporaryDirectory() as bench_dir,
+			patch(
+				"bench.commands.completions.get_env_frappe_commands",
+				return_value=["restore", "backup"],
+			),
+			patch(
+				"bench.commands.completions.find_parent_bench",
+				return_value=bench_dir,
+			),
+			patch("bench.commands.completions.get_env_cmd", return_value="python"),
+			patch("bench.commands.completions._get_frappe_spec_batch", return_value=None),
+			patch("bench.commands.completions.get_cmd_output", side_effect=fake_help),
+		):
+			script = generate_completion("bash", bench_command)
+
+		self.assertIn("'__frappe__ restore') printf '%s' 0", script)
+		self.assertIn("--with-public-files", script)
+		self.assertIn("--with-private-files", script)
+		self.assertIn("--backup-path", script)
 
 	def test_non_interactive_writes_script_and_rc_loader(self):
 		runner = CliRunner()

--- a/bench/tests/test_completions.py
+++ b/bench/tests/test_completions.py
@@ -378,7 +378,7 @@ class TestBenchCompletionGeneration(unittest.TestCase):
 
 		self.assertIn("nested-dir/", result.stdout.splitlines())
 
-	def test_runtime_completes_tilde_paths(self):
+	def test_runtime_completes_tilde_paths_after_forwarded_site(self):
 		def fake_help(cmd, cwd=".", _raise=True):
 			if "frappe restore --help" in cmd:
 				return (
@@ -423,8 +423,7 @@ class TestBenchCompletionGeneration(unittest.TestCase):
 						"bash",
 						"-c",
 						f"source {script_path} >/dev/null 2>&1 || true; "
-						"COMP_WORDS=(bench restore '~/downloads/b'); COMP_CWORD=2; "
-						"COMP_WORDS+=( '' ); COMP_CWORD=2; "
+						"COMP_WORDS=(bench restore --site mysite '~/downloads/b'); COMP_CWORD=4; "
 						"_bench_completion; "
 						'printf "%s\\n" "${COMPREPLY[@]}"',
 					],
@@ -502,7 +501,7 @@ class TestBenchCompletionGeneration(unittest.TestCase):
 		self.assertNotIn("_bench_has_word", result.stderr)
 		self.assertEqual(result.returncode, 0)
 
-	def test_zsh_completion_uses_tilde_paths_end_to_end(self):
+	def test_zsh_completion_uses_tilde_paths_after_forwarded_site(self):
 		def fake_help(cmd, cwd=".", _raise=True):
 			if "frappe restore --help" in cmd:
 				return (
@@ -544,7 +543,7 @@ class TestBenchCompletionGeneration(unittest.TestCase):
 			try:
 				result = _run_zsh_completion(
 					script_path,
-					["bench", "restore", "~/downloads/b"],
+					["bench", "restore", "--site", "mysite", "~/downloads/b"],
 					cwd=bench_dir,
 					env={**os.environ, "HOME": bench_dir},
 				)

--- a/bench/tests/test_completions.py
+++ b/bench/tests/test_completions.py
@@ -1,3 +1,5 @@
+import os
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
@@ -20,7 +22,7 @@ class TestBenchCompletionGeneration(unittest.TestCase):
 		script = generate_completion("bash", bench_command)
 
 		self.assertIn("_bench_subcommands_for()", script)
-		self.assertIn("complete -o nosort -F _bench_completion bench", script)
+		self.assertIn("complete -o nosort -o nospace -F _bench_completion bench", script)
 		self.assertNotIn("_BENCH_COMPLETE", script)
 
 	def test_generation_embeds_current_frappe_commands(self):
@@ -76,7 +78,12 @@ class TestBenchCompletionGeneration(unittest.TestCase):
 
 		self.assertIn("#compdef bench", script)
 		self.assertIn("autoload -U bashcompinit", script)
-		self.assertIn("complete -o nosort -F _bench_completion bench", script)
+		self.assertIn("_bench_completion() {\n\temulate -L sh", script)
+		header, _ = script.split("_bench_completion()", 1)
+		self.assertNotIn("emulate -L sh", header)
+		self.assertIn("_bench_path_match_candidates()", script)
+		self.assertIn("find \"$dir\" -maxdepth 1", script)
+		self.assertIn("complete -o nosort -o nospace -F _bench_completion bench", script)
 
 	def test_runtime_avoids_external_coreutils(self):
 		script = generate_completion("bash", bench_command)
@@ -92,6 +99,11 @@ class TestBenchCompletionGeneration(unittest.TestCase):
 		self.assertIn("_bench_path_positionals_for()", script)
 		self.assertIn("_bench_complete_files()", script)
 		self.assertIn("compgen -f", script)
+		self.assertNotIn('matches=("$dir"/${base}*(N))', script)
+		self.assertNotIn("_bench_path_match_candidates()", script)
+		self.assertIn("complete -o nosort -o nospace -F _bench_completion bench", script)
+		self.assertIn("_bench_expand_tilde()", script)
+		self.assertIn('COMPREPLY[i]="~${COMPREPLY[i]#$HOME}"', script)
 
 	def test_bench_init_registers_path_completion(self):
 		script = generate_completion("bash", bench_command)
@@ -171,6 +183,359 @@ class TestBenchCompletionGeneration(unittest.TestCase):
 		self.assertIn("--with-public-files", script)
 		self.assertIn("--with-private-files", script)
 		self.assertIn("--backup-path", script)
+
+	def test_runtime_resolves_frappe_subcommand_context(self):
+		def fake_help(cmd, cwd=".", _raise=True):
+			return (
+				"Usage: frappe [OPTIONS] COMMAND [ARGS]...\n\n"
+				"Commands:\n"
+				"  restore\n"
+			)
+
+		with tempfile.TemporaryDirectory() as bench_dir:
+			Path(bench_dir, "sites").mkdir()
+
+			with (
+				patch(
+					"bench.commands.completions.get_env_frappe_commands",
+					return_value=["restore"],
+				),
+				patch(
+					"bench.commands.completions.find_parent_bench",
+					return_value=bench_dir,
+				),
+				patch("bench.commands.completions.get_env_cmd", return_value="python"),
+				patch("bench.commands.completions._get_frappe_spec_batch", return_value=None),
+				patch("bench.commands.completions.get_cmd_output", side_effect=fake_help),
+			):
+				script = generate_completion("bash", bench_command)
+
+			self.assertIn(
+				'ctx="$(_bench_join_path "$_BENCH_FRAPPE_KEY" "$token")"',
+				script,
+			)
+
+			with tempfile.NamedTemporaryFile("w", suffix=".sh", delete=False) as handle:
+				handle.write(script)
+				script_path = handle.name
+
+			try:
+				result = subprocess.run(
+					[
+						"bash",
+						"-c",
+						f"source {script_path} >/dev/null 2>&1 || true; "
+						"COMP_WORDS=(bench restore ''); COMP_CWORD=2; "
+						"_bench_collect_completion_state",
+					],
+					check=True,
+					capture_output=True,
+					text=True,
+				)
+			finally:
+				Path(script_path).unlink(missing_ok=True)
+
+		self.assertEqual(result.stdout.strip(), "__frappe__ restore|0")
+
+	def test_runtime_completes_files_for_restore(self):
+		def fake_help(cmd, cwd=".", _raise=True):
+			if "frappe restore --help" in cmd:
+				return (
+					"Usage: frappe restore [OPTIONS] SQL-FILE-PATH\n\n"
+					"Options:\n"
+					"  --with-public-files PATH\n"
+					"  --help              Show this message and exit.\n"
+				)
+			return (
+				"Usage: frappe [OPTIONS] COMMAND [ARGS]...\n\n"
+				"Options:\n"
+				"  --site TEXT\n"
+				"  --help      Show this message and exit.\n\n"
+				"Commands:\n"
+				"  restore\n"
+			)
+
+		with tempfile.TemporaryDirectory() as bench_dir:
+			Path(bench_dir, "sites").mkdir()
+
+			with (
+				patch(
+					"bench.commands.completions.get_env_frappe_commands",
+					return_value=["restore"],
+				),
+				patch(
+					"bench.commands.completions.find_parent_bench",
+					return_value=bench_dir,
+				),
+				patch("bench.commands.completions.get_env_cmd", return_value="python"),
+				patch("bench.commands.completions._get_frappe_spec_batch", return_value=None),
+				patch("bench.commands.completions.get_cmd_output", side_effect=fake_help),
+			):
+				script = generate_completion("bash", bench_command)
+
+			with tempfile.NamedTemporaryFile("w", suffix=".sh", delete=False) as handle:
+				handle.write(script)
+				script_path = handle.name
+
+			try:
+				result = subprocess.run(
+					[
+						"bash",
+						"-c",
+						f"source {script_path} >/dev/null 2>&1 || true; "
+						"touch marker-restore-test; "
+						"COMP_WORDS=(bench restore ''); COMP_CWORD=2; "
+						"_bench_completion; "
+						'printf "%s\\n" "${COMPREPLY[@]}"',
+					],
+					check=True,
+					capture_output=True,
+					text=True,
+					cwd=bench_dir,
+				)
+			finally:
+				Path(script_path).unlink(missing_ok=True)
+
+		self.assertIn("marker-restore-test", result.stdout.splitlines())
+
+	def test_runtime_appends_slash_to_completed_directories(self):
+		def fake_help(cmd, cwd=".", _raise=True):
+			if "frappe restore --help" in cmd:
+				return (
+					"Usage: frappe restore [OPTIONS] SQL-FILE-PATH\n\n"
+					"Options:\n"
+					"  --help              Show this message and exit.\n"
+				)
+			return (
+				"Usage: frappe [OPTIONS] COMMAND [ARGS]...\n\n"
+				"Commands:\n"
+				"  restore\n"
+			)
+
+		with tempfile.TemporaryDirectory() as bench_dir:
+			Path(bench_dir, "sites").mkdir()
+			Path(bench_dir, "nested-dir").mkdir()
+
+			with (
+				patch(
+					"bench.commands.completions.get_env_frappe_commands",
+					return_value=["restore"],
+				),
+				patch(
+					"bench.commands.completions.find_parent_bench",
+					return_value=bench_dir,
+				),
+				patch("bench.commands.completions.get_env_cmd", return_value="python"),
+				patch("bench.commands.completions._get_frappe_spec_batch", return_value=None),
+				patch("bench.commands.completions.get_cmd_output", side_effect=fake_help),
+			):
+				script = generate_completion("bash", bench_command)
+
+			with tempfile.NamedTemporaryFile("w", suffix=".sh", delete=False) as handle:
+				handle.write(script)
+				script_path = handle.name
+
+			try:
+				result = subprocess.run(
+					[
+						"bash",
+						"-c",
+						f"source {script_path} >/dev/null 2>&1 || true; "
+						"COMP_WORDS=(bench restore nested); COMP_CWORD=2; "
+						"COMP_WORDS+=( '' ); COMP_CWORD=2; "
+						"_bench_completion; "
+						'printf "%s\\n" "${COMPREPLY[@]}"',
+					],
+					check=True,
+					capture_output=True,
+					text=True,
+					cwd=bench_dir,
+				)
+			finally:
+				Path(script_path).unlink(missing_ok=True)
+
+		self.assertIn("nested-dir/", result.stdout.splitlines())
+
+	def test_runtime_completes_tilde_paths(self):
+		def fake_help(cmd, cwd=".", _raise=True):
+			if "frappe restore --help" in cmd:
+				return (
+					"Usage: frappe restore [OPTIONS] SQL-FILE-PATH\n\n"
+					"Options:\n"
+					"  --help              Show this message and exit.\n"
+				)
+			return (
+				"Usage: frappe [OPTIONS] COMMAND [ARGS]...\n\n"
+				"Commands:\n"
+				"  restore\n"
+			)
+
+		with tempfile.TemporaryDirectory() as bench_dir:
+			Path(bench_dir, "sites").mkdir()
+			downloads = Path(bench_dir) / "downloads"
+			downloads.mkdir()
+			(downloads / "backup.sql.gz").write_text("x", encoding="utf-8")
+
+			with (
+				patch(
+					"bench.commands.completions.get_env_frappe_commands",
+					return_value=["restore"],
+				),
+				patch(
+					"bench.commands.completions.find_parent_bench",
+					return_value=bench_dir,
+				),
+				patch("bench.commands.completions.get_env_cmd", return_value="python"),
+				patch("bench.commands.completions._get_frappe_spec_batch", return_value=None),
+				patch("bench.commands.completions.get_cmd_output", side_effect=fake_help),
+			):
+				script = generate_completion("bash", bench_command)
+
+			with tempfile.NamedTemporaryFile("w", suffix=".sh", delete=False) as handle:
+				handle.write(script)
+				script_path = handle.name
+
+			try:
+				result = subprocess.run(
+					[
+						"bash",
+						"-c",
+						f"source {script_path} >/dev/null 2>&1 || true; "
+						"COMP_WORDS=(bench restore '~/downloads/b'); COMP_CWORD=2; "
+						"COMP_WORDS+=( '' ); COMP_CWORD=2; "
+						"_bench_completion; "
+						'printf "%s\\n" "${COMPREPLY[@]}"',
+					],
+					check=True,
+					capture_output=True,
+					text=True,
+					cwd=bench_dir,
+					env={**os.environ, "HOME": bench_dir},
+				)
+			finally:
+				Path(script_path).unlink(missing_ok=True)
+
+		self.assertIn("~/downloads/backup.sql.gz", result.stdout.splitlines())
+
+	def test_zsh_runtime_completes_tilde_paths(self):
+		def fake_help(cmd, cwd=".", _raise=True):
+			if "frappe restore --help" in cmd:
+				return (
+					"Usage: frappe restore [OPTIONS] SQL-FILE-PATH\n\n"
+					"Options:\n"
+					"  --help              Show this message and exit.\n"
+				)
+			return (
+				"Usage: frappe [OPTIONS] COMMAND [ARGS]...\n\n"
+				"Commands:\n"
+				"  restore\n"
+			)
+
+		with tempfile.TemporaryDirectory() as bench_dir:
+			Path(bench_dir, "sites").mkdir()
+			downloads = Path(bench_dir) / "downloads"
+			downloads.mkdir()
+			(downloads / "backup.sql.gz").write_text("x", encoding="utf-8")
+
+			with (
+				patch(
+					"bench.commands.completions.get_env_frappe_commands",
+					return_value=["restore"],
+				),
+				patch(
+					"bench.commands.completions.find_parent_bench",
+					return_value=bench_dir,
+				),
+				patch("bench.commands.completions.get_env_cmd", return_value="python"),
+				patch("bench.commands.completions._get_frappe_spec_batch", return_value=None),
+				patch("bench.commands.completions.get_cmd_output", side_effect=fake_help),
+			):
+				script = generate_completion("zsh", bench_command)
+
+			with tempfile.NamedTemporaryFile("w", suffix=".zsh", delete=False) as handle:
+				handle.write(script)
+				script_path = handle.name
+
+			try:
+				result = subprocess.run(
+					[
+						"zsh",
+						"-c",
+						f"source {script_path} >/dev/null 2>&1 || true; "
+						"COMP_WORDS=(bench restore '~/downloads/b'); COMP_CWORD=2; "
+						"_bench_complete_files '~/downloads/b'; "
+						'printf "%s\\n" "${COMPREPLY[@]}"',
+					],
+					check=True,
+					capture_output=True,
+					text=True,
+					cwd=bench_dir,
+					env={**os.environ, "HOME": bench_dir},
+				)
+			finally:
+				Path(script_path).unlink(missing_ok=True)
+
+		self.assertIn("~/downloads/backup.sql.gz", result.stdout.splitlines())
+
+	def test_zsh_completion_uses_tilde_paths_end_to_end(self):
+		def fake_help(cmd, cwd=".", _raise=True):
+			if "frappe restore --help" in cmd:
+				return (
+					"Usage: frappe restore [OPTIONS] SQL-FILE-PATH\n\n"
+					"Options:\n"
+					"  --help              Show this message and exit.\n"
+				)
+			return (
+				"Usage: frappe [OPTIONS] COMMAND [ARGS]...\n\n"
+				"Commands:\n"
+				"  restore\n"
+			)
+
+		with tempfile.TemporaryDirectory() as bench_dir:
+			Path(bench_dir, "sites").mkdir()
+			downloads = Path(bench_dir) / "downloads"
+			downloads.mkdir()
+			(downloads / "backup.sql.gz").write_text("x", encoding="utf-8")
+
+			with (
+				patch(
+					"bench.commands.completions.get_env_frappe_commands",
+					return_value=["restore"],
+				),
+				patch(
+					"bench.commands.completions.find_parent_bench",
+					return_value=bench_dir,
+				),
+				patch("bench.commands.completions.get_env_cmd", return_value="python"),
+				patch("bench.commands.completions._get_frappe_spec_batch", return_value=None),
+				patch("bench.commands.completions.get_cmd_output", side_effect=fake_help),
+			):
+				script = generate_completion("zsh", bench_command)
+
+			with tempfile.NamedTemporaryFile("w", suffix=".zsh", delete=False) as handle:
+				handle.write(script)
+				script_path = handle.name
+
+			try:
+				result = subprocess.run(
+					[
+						"zsh",
+						"-c",
+						f"source {script_path} >/dev/null 2>&1 || true; "
+						"COMP_WORDS=(bench restore '~/downloads/b'); COMP_CWORD=2; "
+						"_bench_completion; "
+						'printf "%s\\n" "${COMPREPLY[@]}"',
+					],
+					check=True,
+					capture_output=True,
+					text=True,
+					cwd=bench_dir,
+					env={**os.environ, "HOME": bench_dir},
+				)
+			finally:
+				Path(script_path).unlink(missing_ok=True)
+
+		self.assertIn("~/downloads/backup.sql.gz", result.stdout.splitlines())
 
 	def test_non_interactive_writes_script_and_rc_loader(self):
 		runner = CliRunner()

--- a/bench/tests/test_completions.py
+++ b/bench/tests/test_completions.py
@@ -19,13 +19,15 @@ from bench.commands.completions import (
 )
 
 
-def _run_zsh_completion(script_path: str, words: list[str], cwd: str | None = None, env=None):
+def _run_zsh_completion(
+	script_path: str, words: list[str], cwd: str | None = None, env=None
+):
 	quoted_words = " ".join(shlex.quote(word) for word in words)
 	command = (
 		f"autoload -Uz compinit; compinit -C; "
 		f"source {shlex.quote(script_path)}; "
-		"_files() { compadd \"$HOME/downloads/backup.sql.gz\"; }; "
-		"compadd() { reply=(\"$@\"); }; "
+		'_files() { compadd "$HOME/downloads/backup.sql.gz"; }; '
+		'compadd() { reply=("$@"); }; '
 		f"words=({quoted_words}); CURRENT={len(words)}; curcontext=:bench:; "
 		"_bench; printf '%s\\n' \"${reply[@]}\""
 	)
@@ -45,8 +47,7 @@ def _frappe_root_help(commands: list[str]) -> str:
 		"Options:\n"
 		"  --site TEXT\n"
 		"  --help      Show this message and exit.\n\n"
-		"Commands:\n"
-		+ "".join(f"  {command}\n" for command in commands)
+		"Commands:\n" + "".join(f"  {command}\n" for command in commands)
 	)
 
 
@@ -59,7 +60,9 @@ def _frappe_command_help(command: str, usage: str = "[OPTIONS]", options=()) -> 
 	)
 
 
-def _fake_frappe_help(commands: list[str], help_by_command: dict[str, str] | None = None):
+def _fake_frappe_help(
+	commands: list[str], help_by_command: dict[str, str] | None = None
+):
 	help_by_command = help_by_command or {}
 
 	def fake_help(cmd, cwd=".", _raise=True):
@@ -72,7 +75,9 @@ def _fake_frappe_help(commands: list[str], help_by_command: dict[str, str] | Non
 
 
 @contextmanager
-def _mock_frappe_completion(commands: list[str], help_by_command: dict[str, str] | None = None):
+def _mock_frappe_completion(
+	commands: list[str], help_by_command: dict[str, str] | None = None
+):
 	with tempfile.TemporaryDirectory() as bench_dir:
 		bench_path = Path(bench_dir)
 		(bench_path / "sites").mkdir()
@@ -87,7 +92,9 @@ def _mock_frappe_completion(commands: list[str], help_by_command: dict[str, str]
 				return_value=bench_dir,
 			),
 			patch("bench.commands.completions.get_env_cmd", return_value="python"),
-			patch("bench.commands.completions._get_frappe_spec_batch", return_value=None),
+			patch(
+				"bench.commands.completions._get_frappe_spec_batch", return_value=None
+			),
 			patch(
 				"bench.commands.completions.get_cmd_output",
 				side_effect=_fake_frappe_help(commands, help_by_command),

--- a/bench/tests/test_completions.py
+++ b/bench/tests/test_completions.py
@@ -1,4 +1,5 @@
 import os
+import shlex
 import subprocess
 import tempfile
 import unittest
@@ -15,6 +16,26 @@ from bench.commands.completions import (
 	_parse_click_help,
 	generate_completion,
 )
+
+
+def _run_zsh_completion(script_path: str, words: list[str], cwd: str | None = None, env=None):
+	quoted_words = " ".join(shlex.quote(word) for word in words)
+	command = (
+		f"autoload -Uz compinit; compinit -C; "
+		f"source {shlex.quote(script_path)}; "
+		"_files() { compadd \"$HOME/downloads/backup.sql.gz\"; }; "
+		"compadd() { reply=(\"$@\"); }; "
+		f"words=({quoted_words}); CURRENT={len(words)}; curcontext=:bench:; "
+		"_bench; printf '%s\\n' \"${reply[@]}\""
+	)
+	return subprocess.run(
+		["zsh", "-c", command],
+		check=True,
+		capture_output=True,
+		text=True,
+		cwd=cwd,
+		env=env,
+	)
 
 
 class TestBenchCompletionGeneration(unittest.TestCase):
@@ -73,17 +94,18 @@ class TestBenchCompletionGeneration(unittest.TestCase):
 			"'__frappe__ migrate') printf '%s' '--help --skip-failing'", script
 		)
 
-	def test_zsh_completion_bootstraps_bash_compat(self):
+	def test_zsh_completion_uses_native_compdef(self):
 		script = generate_completion("zsh", bench_command)
 
 		self.assertIn("#compdef bench", script)
-		self.assertIn("autoload -U bashcompinit", script)
-		self.assertIn("_bench_completion() {\n\temulate -L sh", script)
-		header, _ = script.split("_bench_completion()", 1)
-		self.assertNotIn("emulate -L sh", header)
-		self.assertIn("_bench_path_match_candidates()", script)
-		self.assertIn("find \"$dir\" -maxdepth 1", script)
-		self.assertIn("complete -o nosort -o nospace -F _bench_completion bench", script)
+		self.assertIn("compdef _bench bench", script)
+		self.assertIn("_bench() {", script)
+		self.assertIn("_files", script)
+		self.assertNotIn("bashcompinit", script)
+		self.assertNotIn("emulate -L sh", script)
+		self.assertNotIn("_bench_completion()", script)
+		self.assertNotIn("complete -o nosort", script)
+		self.assertNotIn("_bench_path_match_candidates()", script)
 
 	def test_runtime_avoids_external_coreutils(self):
 		script = generate_completion("bash", bench_command)
@@ -417,14 +439,8 @@ class TestBenchCompletionGeneration(unittest.TestCase):
 
 		self.assertIn("~/downloads/backup.sql.gz", result.stdout.splitlines())
 
-	def test_zsh_runtime_completes_tilde_paths(self):
+	def test_zsh_runtime_resolves_frappe_subcommand_context(self):
 		def fake_help(cmd, cwd=".", _raise=True):
-			if "frappe restore --help" in cmd:
-				return (
-					"Usage: frappe restore [OPTIONS] SQL-FILE-PATH\n\n"
-					"Options:\n"
-					"  --help              Show this message and exit.\n"
-				)
 			return (
 				"Usage: frappe [OPTIONS] COMMAND [ARGS]...\n\n"
 				"Commands:\n"
@@ -433,9 +449,6 @@ class TestBenchCompletionGeneration(unittest.TestCase):
 
 		with tempfile.TemporaryDirectory() as bench_dir:
 			Path(bench_dir, "sites").mkdir()
-			downloads = Path(bench_dir) / "downloads"
-			downloads.mkdir()
-			(downloads / "backup.sql.gz").write_text("x", encoding="utf-8")
 
 			with (
 				patch(
@@ -461,21 +474,33 @@ class TestBenchCompletionGeneration(unittest.TestCase):
 					[
 						"zsh",
 						"-c",
-						f"source {script_path} >/dev/null 2>&1 || true; "
-						"COMP_WORDS=(bench restore '~/downloads/b'); COMP_CWORD=2; "
-						"_bench_complete_files '~/downloads/b'; "
-						'printf "%s\\n" "${COMPREPLY[@]}"',
+						f"source {shlex.quote(script_path)}; "
+						"words=(bench restore); CURRENT=3; "
+						"_bench_collect_completion_state",
 					],
 					check=True,
 					capture_output=True,
 					text=True,
-					cwd=bench_dir,
-					env={**os.environ, "HOME": bench_dir},
 				)
 			finally:
 				Path(script_path).unlink(missing_ok=True)
 
-		self.assertIn("~/downloads/backup.sql.gz", result.stdout.splitlines())
+		self.assertEqual(result.stdout.strip(), "__frappe__ restore|0")
+
+	def test_zsh_completion_handles_partial_command_without_error(self):
+		script = generate_completion("zsh", bench_command)
+
+		with tempfile.NamedTemporaryFile("w", suffix=".zsh", delete=False) as handle:
+			handle.write(script)
+			script_path = handle.name
+
+		try:
+			result = _run_zsh_completion(script_path, ["bench", "rest"])
+		finally:
+			Path(script_path).unlink(missing_ok=True)
+
+		self.assertNotIn("_bench_has_word", result.stderr)
+		self.assertEqual(result.returncode, 0)
 
 	def test_zsh_completion_uses_tilde_paths_end_to_end(self):
 		def fake_help(cmd, cwd=".", _raise=True):
@@ -517,25 +542,19 @@ class TestBenchCompletionGeneration(unittest.TestCase):
 				script_path = handle.name
 
 			try:
-				result = subprocess.run(
-					[
-						"zsh",
-						"-c",
-						f"source {script_path} >/dev/null 2>&1 || true; "
-						"COMP_WORDS=(bench restore '~/downloads/b'); COMP_CWORD=2; "
-						"_bench_completion; "
-						'printf "%s\\n" "${COMPREPLY[@]}"',
-					],
-					check=True,
-					capture_output=True,
-					text=True,
+				result = _run_zsh_completion(
+					script_path,
+					["bench", "restore", "~/downloads/b"],
 					cwd=bench_dir,
 					env={**os.environ, "HOME": bench_dir},
 				)
 			finally:
 				Path(script_path).unlink(missing_ok=True)
 
-		self.assertIn("~/downloads/backup.sql.gz", result.stdout.splitlines())
+		self.assertTrue(
+			any("backup.sql.gz" in line for line in result.stdout.splitlines()),
+			result.stdout,
+		)
 
 	def test_non_interactive_writes_script_and_rc_loader(self):
 		runner = CliRunner()


### PR DESCRIPTION
Goal: `bench restore [TAB]` and similar commands should offer file path completions. 

Collects path-taking options and positional arguments from Click metadata and completes them with `compgen -f`, covering commands like `restore`, `backup`, and `data-import` without breaking existing site/app completion.

Changes CI to actually run completion tests and install zsh to make them pass.

Contains some noise from formatting python files (`style:` commit) and refactoring complex functions to satisfy Sonarqube's complexitiy score (`refactor: ... Cognitive Complexity`).