### PR TITLE
fix(easy-install): various issues

### DIFF
--- a/easy-install.py
+++ b/easy-install.py
@@ -86,6 +86,7 @@ def write_to_env(
     custom_tag: str = None,
 ) -> None:
     quoted_sites = ",".join([f"`{site}`" for site in sites]).strip(",")
+    sites_rule = " || ".join([f"Host(`{site}`)" for site in sites])
     example_env = get_from_env(frappe_docker_dir, "example.env")
     erpnext_version = erpnext_version or example_env["ERPNEXT_VERSION"]
     env_file_lines = [
@@ -100,6 +101,7 @@ def write_to_env(
         f"LETSENCRYPT_EMAIL={email}\n",
         f"SITE_ADMIN_PASS={admin_pass}\n",
         f"SITES={quoted_sites}\n",
+        f"SITES_RULE={sites_rule}\n",
         "PULL_POLICY=missing\n",
         f'BACKUP_CRONSTRING="{cronstring}"\n',
     ]

--- a/easy-install.py
+++ b/easy-install.py
@@ -694,7 +694,9 @@ def build_image(
         tags = ["custom-apps:latest"]
 
     apps_json_base64 = None
+    apps_json_path_abs = None
     try:
+        apps_json_path_abs = os.path.abspath(apps_json_path)
         with open(apps_json_path, "rb") as file_text:
             file_read = file_text.read()
             apps_json_base64 = (
@@ -720,8 +722,15 @@ def build_image(
         f"--build-arg=PYTHON_VERSION={python_version}",
         f"--build-arg=NODE_VERSION={node_version}",
         f"--build-arg=APPS_JSON_BASE64={apps_json_base64}",
-        ".",
     ]
+
+    if apps_json_path_abs:
+        command += [
+            "--secret",
+            f"id=apps_json,src={apps_json_path_abs}",
+        ]
+
+    command.append(".")
 
     try:
         subprocess.run(

--- a/easy-install.py
+++ b/easy-install.py
@@ -693,10 +693,7 @@ def build_image(
     if not tags:
         tags = ["custom-apps:latest"]
 
-    apps_json_base64 = None
-    apps_json_path_abs = None
     try:
-        apps_json_path_abs = os.path.abspath(apps_json_path)
         with open(apps_json_path, "rb") as file_text:
             file_read = file_text.read()
             apps_json_base64 = (
@@ -705,6 +702,9 @@ def build_image(
     except Exception as e:
         logging.error("Unable to base64 encode apps.json", exc_info=True)
         cprint("\nUnable to base64 encode apps.json\n\n", "[ERROR]: ", e, level=1)
+        sys.exit(1)
+
+    apps_json_path_abs = os.path.abspath(apps_json_path)
 
     command = [
         which("docker"),
@@ -724,11 +724,10 @@ def build_image(
         f"--build-arg=APPS_JSON_BASE64={apps_json_base64}",
     ]
 
-    if apps_json_path_abs:
-        command += [
-            "--secret",
-            f"id=apps_json,src={apps_json_path_abs}",
-        ]
+    command += [
+        "--secret",
+        f"id=apps_json,src={apps_json_path_abs}",
+    ]
 
     command.append(".")
 

--- a/easy-install.py
+++ b/easy-install.py
@@ -605,8 +605,8 @@ def add_build_parser(subparsers: argparse.ArgumentParser):
     parser.add_argument(
         "-b",
         "--frappe-branch",
-        help="Frappe branch to use, default: version-15",
-        default="version-15",
+        help="Frappe branch to use, default: version-16",
+        default="version-16",
     )
     parser.add_argument(
         "-j",
@@ -741,6 +741,7 @@ def build_image(
     except Exception as e:
         logging.error("Image build failed", exc_info=True)
         cprint("\nImage build failed\n\n", "[ERROR]: ", e, level=1)
+        sys.exit(1)
 
     if push:
         try:
@@ -752,6 +753,7 @@ def build_image(
         except Exception as e:
             logging.error("Image push failed", exc_info=True)
             cprint("\nImage push failed\n\n", "[ERROR]: ", e, level=1)
+            sys.exit(1)
 
 
 def get_args_parser():

--- a/easy-install.py
+++ b/easy-install.py
@@ -693,17 +693,6 @@ def build_image(
     if not tags:
         tags = ["custom-apps:latest"]
 
-    try:
-        with open(apps_json_path, "rb") as file_text:
-            file_read = file_text.read()
-            apps_json_base64 = (
-                base64.encodebytes(file_read).decode("utf-8").replace("\n", "")
-            )
-    except Exception as e:
-        logging.error("Unable to base64 encode apps.json", exc_info=True)
-        cprint("\nUnable to base64 encode apps.json\n\n", "[ERROR]: ", e, level=1)
-        sys.exit(1)
-
     apps_json_path_abs = os.path.abspath(apps_json_path)
 
     command = [
@@ -721,15 +710,10 @@ def build_image(
         f"--build-arg=FRAPPE_BRANCH={frappe_branch}",
         f"--build-arg=PYTHON_VERSION={python_version}",
         f"--build-arg=NODE_VERSION={node_version}",
-        f"--build-arg=APPS_JSON_BASE64={apps_json_base64}",
-    ]
-
-    command += [
         "--secret",
         f"id=apps_json,src={apps_json_path_abs}",
+        "."
     ]
-
-    command.append(".")
 
     try:
         subprocess.run(

--- a/easy-install.py
+++ b/easy-install.py
@@ -630,14 +630,14 @@ def add_build_parser(subparsers: argparse.ArgumentParser):
     parser.add_argument(
         "-y",
         "--python-version",
-        help="Python Version, default: 3.11.6",
-        default="3.11.6",
+        help="Python Version, default: 3.14",
+        default="3.14",
     )
     parser.add_argument(
         "-d",
         "--node-version",
-        help="NodeJS Version, default: 18.18.2",
-        default="18.18.2",
+        help="NodeJS Version, default: 24.14.0",
+        default="24.14.0",
     )
     parser.add_argument(
         "-x",


### PR DESCRIPTION
## first issue

Resolved through https://github.com/frappe/bench/pull/1701

## second issue

Upstream `frappe_docker` changed the custom image `Containerfile` to read `apps.json` via a BuildKit secret. Our script still only passed the old `APPS_JSON_BASE64` build arg, so the image was built with Frappe only, and `--install-app erpnext` failed with `No module named 'erpnext'`.

I updated the Docker build command to pass:

```sh
--secret id=apps_json,src=/absolute/path/to/apps.json
```

## third issue

`easy-install.py` defaulted `--frappe-branch` to `version-15`, while upstream `frappe_docker` now builds ERPNext from `version-16`. That produced the Frappe/ERPNext dependency mismatch. The later `pull access denied for custom-apps` happened because the script swallowed the Docker build failure and continued into deploy.

Changes made:

- Default `--frappe-branch` is now `version-16`.
- Bumped default python version from 3.11 to 3.14
- Bumped default node version from 18 to 24
- Docker image build/push failures now `sys.exit(1)` instead of continuing.